### PR TITLE
Add TradingView WebGL playground sample

### DIFF
--- a/samples/JavaScriptPlayground/MainWindow.axaml.cs
+++ b/samples/JavaScriptPlayground/MainWindow.axaml.cs
@@ -2244,6 +2244,41 @@ frameHandle = window.requestAnimationFrame(render);
 """
             ),
             new Preset(
+                "TradingView + Native WebGL",
+                """
+<Border xmlns="https://github.com/avaloniaui" xmlns:js="clr-namespace:JavaScript.Avalonia;assembly=JavaScript.Avalonia" Padding="16" Background="#0b1120" BorderBrush="#1f2937" BorderThickness="1" CornerRadius="8">
+  <StackPanel Spacing="12">
+    <TextBlock Text="TradingView Lightweight Charts + native WebGL" FontWeight="SemiBold" Foreground="#f8fafc" />
+    <TextBlock Text="TradingView renders the candlestick chart while JavaScript.Avalonia renders a synchronized WebGL volume panel on an OpenGL-backed canvas." TextWrapping="Wrap" Foreground="#cbd5e1" />
+    <Border Background="#101827" BorderBrush="#334155" BorderThickness="1" CornerRadius="6" ClipToBounds="True">
+      <Canvas Name="tradingViewChartHost" Width="720" Height="360" Background="#101827" ClipToBounds="True" />
+    </Border>
+    <Border Background="#050816" BorderBrush="#334155" BorderThickness="1" CornerRadius="6" ClipToBounds="True">
+      <js:CanvasOpenGlDrawingSurface Name="tradingViewWebGlSurface" Width="720" Height="180" />
+    </Border>
+    <StackPanel Orientation="Horizontal" Spacing="8">
+      <Button Name="tradingViewStream" Content="Stream tick" />
+      <Button Name="tradingViewShuffle" Content="Shuffle data" />
+      <Button Name="tradingViewReset" Content="Reset" />
+    </StackPanel>
+    <TextBlock Name="tradingViewStatus" Foreground="#d1d5db" TextWrapping="Wrap" />
+    <TextBlock Name="tradingViewWebGlStatus" Foreground="#93c5fd" TextWrapping="Wrap" />
+  </StackPanel>
+</Border>
+""",
+                """
+try {
+  require('./Scripts/tradingview-webgl-demo.js');
+} catch (error) {
+  const status = document.getElementById('tradingViewStatus');
+  if (status) {
+    status.textContent = `Failed to load TradingView WebGL demo: ${error}`;
+  }
+  throw error;
+}
+"""
+            ),
+            new Preset(
                 "Canvas 2D + Fabric.js",
                 """
 <Border xmlns="https://github.com/avaloniaui" Padding="16" Background="#ffffff" BorderBrush="#d1d5db" BorderThickness="1" CornerRadius="8">

--- a/samples/JavaScriptPlayground/Scripts/tradingview-webgl-demo.js
+++ b/samples/JavaScriptPlayground/Scripts/tradingview-webgl-demo.js
@@ -1,0 +1,769 @@
+(function () {
+  const LIGHTWEIGHT_CHARTS_URL = 'https://cdn.jsdelivr.net/npm/lightweight-charts@4.2.3/dist/lightweight-charts.standalone.production.js';
+  const root = typeof globalThis !== 'undefined' ? globalThis : window;
+  const win = typeof window !== 'undefined' ? window : root;
+
+  function defineGlobal(name, value) {
+    root[name] = value;
+    if (win) {
+      win[name] = value;
+    }
+  }
+
+  function readElementSize(target, fallbackWidth, fallbackHeight) {
+    const rect = target && typeof target.getBoundingClientRect === 'function'
+      ? target.getBoundingClientRect()
+      : null;
+    const width = Number(target?.clientWidth || target?.offsetWidth || rect?.width || target?.width || fallbackWidth || 1);
+    const height = Number(target?.clientHeight || target?.offsetHeight || rect?.height || target?.height || fallbackHeight || 1);
+
+    return {
+      width: Math.max(1, Math.round(width)),
+      height: Math.max(1, Math.round(height))
+    };
+  }
+
+  function installBrowserShims() {
+    if (!root.performance) {
+      defineGlobal('performance', { now: () => Date.now() });
+    }
+
+    if (!root.location) {
+      defineGlobal('location', {
+        href: 'https://localhost/JavaScriptPlayground',
+        protocol: 'https:',
+        host: 'localhost',
+        hostname: 'localhost',
+        pathname: '/JavaScriptPlayground',
+        search: '',
+        hash: ''
+      });
+    }
+
+    if (typeof root.URL !== 'function') {
+      class AvaloniaURL {
+        constructor(input, base) {
+          const raw = String(input ?? '');
+          const baseText = String(base ?? root.location?.href ?? 'https://localhost/');
+          this.href = this._resolve(raw, baseText);
+          this._parse();
+        }
+
+        _resolve(raw, baseText) {
+          if (/^[a-z][a-z0-9+.-]*:/i.test(raw)) {
+            return raw;
+          }
+
+          const baseMatch = /^([a-z][a-z0-9+.-]*:\/\/[^/?#]*)([^?#]*)/i.exec(baseText);
+          const origin = baseMatch?.[1] ?? 'https://localhost';
+          const basePath = baseMatch?.[2] ?? '/';
+          if (raw.startsWith('/')) {
+            return `${origin}${raw}`;
+          }
+
+          const directory = basePath.endsWith('/') ? basePath : basePath.replace(/\/[^/]*$/, '/');
+          return `${origin}${directory}${raw}`;
+        }
+
+        _parse() {
+          const match = /^([a-z][a-z0-9+.-]*:)?\/\/([^/?#]*)([^?#]*)(\?[^#]*)?(#.*)?$/i.exec(this.href);
+          this.protocol = match?.[1] ?? '';
+          this.host = match?.[2] ?? '';
+          this.hostname = this.host.split(':')[0] ?? '';
+          this.pathname = match?.[3] || '/';
+          this.search = match?.[4] ?? '';
+          this.hash = match?.[5] ?? '';
+          this.origin = this.protocol && this.host ? `${this.protocol}//${this.host}` : '';
+        }
+
+        toString() {
+          return this.href;
+        }
+      }
+
+      AvaloniaURL.createObjectURL = () => 'blob:avalonia-object-url';
+      AvaloniaURL.revokeObjectURL = () => {};
+      defineGlobal('URL', AvaloniaURL);
+    }
+
+    if (win && typeof win.matchMedia !== 'function') {
+      win.matchMedia = query => ({
+        matches: false,
+        media: String(query ?? ''),
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false
+      });
+    }
+
+    if (typeof root.ResizeObserver !== 'function') {
+      class AvaloniaResizeObserver {
+        constructor(callback) {
+          this._callback = callback;
+          this._targets = [];
+        }
+
+        observe(target) {
+          if (!target || this._targets.indexOf(target) >= 0) {
+            return;
+          }
+
+          this._targets.push(target);
+          this._notify(target);
+        }
+
+        unobserve(target) {
+          this._targets = this._targets.filter(item => item !== target);
+        }
+
+        disconnect() {
+          this._targets = [];
+        }
+
+        _notify(target) {
+          const size = readElementSize(target);
+          const ratio = Math.max(1, Number(win?.devicePixelRatio || 1));
+          const entry = {
+            target,
+            contentRect: {
+              x: 0,
+              y: 0,
+              top: 0,
+              left: 0,
+              right: size.width,
+              bottom: size.height,
+              width: size.width,
+              height: size.height
+            },
+            contentBoxSize: [{ inlineSize: size.width, blockSize: size.height }],
+            borderBoxSize: [{ inlineSize: size.width, blockSize: size.height }],
+            devicePixelContentBoxSize: [{
+              inlineSize: Math.max(1, Math.round(size.width * ratio)),
+              blockSize: Math.max(1, Math.round(size.height * ratio))
+            }]
+          };
+
+          this._callback([entry], this);
+        }
+      }
+
+      defineGlobal('ResizeObserver', AvaloniaResizeObserver);
+    }
+
+    try {
+      if (document && typeof document.defaultView === 'undefined') {
+        document.defaultView = win;
+      }
+    } catch (error) {
+    }
+  }
+
+  function patchElement(element) {
+    if (!element) {
+      return element;
+    }
+
+    try {
+      if (typeof element.getClientRects !== 'function') {
+        element.getClientRects = function () {
+          const rect = typeof this.getBoundingClientRect === 'function'
+            ? this.getBoundingClientRect()
+            : readElementSize(this);
+          return [rect];
+        };
+      }
+    } catch (error) {
+    }
+
+    try {
+      if (element.ownerDocument && typeof element.ownerDocument.defaultView === 'undefined') {
+        element.ownerDocument.defaultView = win;
+      }
+    } catch (error) {
+    }
+
+    return element;
+  }
+
+  function getRequiredElement(id) {
+    const element = document.getElementById(id);
+    if (!element) {
+      throw new Error(`${id} element not found`);
+    }
+
+    return patchElement(element);
+  }
+
+  function removeChildren(element) {
+    const children = Array.from(element.children || []);
+    children.forEach(child => {
+      if (child && typeof child.remove === 'function') {
+        child.remove();
+      } else if (element.removeChild) {
+        element.removeChild(child);
+      }
+    });
+  }
+
+  function collectCanvasElements(element, result) {
+    if (!element) {
+      return result;
+    }
+
+    if (String(element.nodeName || element.tagName || '').toLowerCase() === 'canvas') {
+      result.push(element);
+    }
+
+    Array.from(element.children || []).forEach(child => collectCanvasElements(child, result));
+    return result;
+  }
+
+  function getChartCanvasStats(chartHost) {
+    const canvases = collectCanvasElements(chartHost, []);
+    let commandCount = 0;
+
+    canvases.forEach(canvas => {
+      try {
+        const context = typeof canvas.getContext === 'function' ? canvas.getContext('2d') : null;
+        if (context && typeof context.CommandCount === 'number') {
+          commandCount += context.CommandCount;
+        }
+      } catch (error) {
+      }
+    });
+
+    return {
+      canvasCount: canvases.length,
+      commandCount
+    };
+  }
+
+  function loadLightweightCharts(status) {
+    let module;
+    try {
+      module = require(LIGHTWEIGHT_CHARTS_URL);
+    } catch (error) {
+      const message = `Failed to load TradingView Lightweight Charts: ${error}`;
+      if (status) {
+        status.textContent = message;
+      }
+      console.error(message);
+      throw error;
+    }
+
+    const api = module?.createChart
+      ? module
+      : module?.default?.createChart
+        ? module.default
+        : root.LightweightCharts || win?.LightweightCharts;
+
+    if (!api?.createChart) {
+      throw new Error('TradingView Lightweight Charts API was not detected');
+    }
+
+    return api;
+  }
+
+  function nextIsoDate(isoDate) {
+    const date = new Date(`${isoDate}T00:00:00Z`);
+    date.setUTCDate(date.getUTCDate() + 1);
+    return date.toISOString().slice(0, 10);
+  }
+
+  function createMarketData() {
+    const rows = [];
+    let time = '2025-01-02';
+    let close = 186.4;
+
+    for (let index = 0; index < 96; index++) {
+      const wave = Math.sin(index / 5) * 2.8 + Math.cos(index / 11) * 1.7;
+      const drift = index * 0.11;
+      const open = close + Math.sin(index / 3) * 1.1;
+      close = Math.max(120, open + wave * 0.35 + drift * 0.03);
+      const high = Math.max(open, close) + 1.4 + Math.abs(Math.sin(index / 4)) * 2.2;
+      const low = Math.min(open, close) - 1.2 - Math.abs(Math.cos(index / 6)) * 1.8;
+      const volume = 520000 + Math.round((Math.sin(index / 6) + 1.4) * 180000 + index * 4200);
+
+      rows.push({
+        time,
+        open: Number(open.toFixed(2)),
+        high: Number(high.toFixed(2)),
+        low: Number(low.toFixed(2)),
+        close: Number(close.toFixed(2)),
+        volume
+      });
+
+      time = nextIsoDate(time);
+    }
+
+    return rows;
+  }
+
+  function movingAverage(rows, length) {
+    const result = [];
+    for (let index = 0; index < rows.length; index++) {
+      if (index + 1 < length) {
+        continue;
+      }
+
+      let sum = 0;
+      for (let cursor = index - length + 1; cursor <= index; cursor++) {
+        sum += rows[cursor].close;
+      }
+
+      result.push({
+        time: rows[index].time,
+        value: Number((sum / length).toFixed(2))
+      });
+    }
+
+    return result;
+  }
+
+  function toSeriesTime(row) {
+    return Math.floor(new Date(`${row.time}T00:00:00Z`).getTime() / 1000);
+  }
+
+  function createProgram(gl, vertexSource, fragmentSource) {
+    const vertexShader = gl.createShader(gl.VERTEX_SHADER);
+    gl.shaderSource(vertexShader, vertexSource);
+    gl.compileShader(vertexShader);
+    if (!gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS)) {
+      throw new Error(`Vertex shader failed: ${gl.getShaderInfoLog(vertexShader)}`);
+    }
+
+    const fragmentShader = gl.createShader(gl.FRAGMENT_SHADER);
+    gl.shaderSource(fragmentShader, fragmentSource);
+    gl.compileShader(fragmentShader);
+    if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
+      throw new Error(`Fragment shader failed: ${gl.getShaderInfoLog(fragmentShader)}`);
+    }
+
+    const program = gl.createProgram();
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.bindAttribLocation(program, 0, 'position');
+    gl.bindAttribLocation(program, 1, 'color');
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      throw new Error(`WebGL program failed: ${gl.getProgramInfoLog(program)}`);
+    }
+
+    return program;
+  }
+
+  function createVolumeGeometry(rows) {
+    const visible = rows.slice(-72);
+    const maxVolume = Math.max(1, ...visible.map(row => row.volume));
+    const vertices = [];
+    const indices = [];
+    const left = -0.96;
+    const right = 0.96;
+    const baseY = -0.82;
+    const span = right - left;
+    const step = span / visible.length;
+    const gap = Math.min(0.006, step * 0.18);
+
+    visible.forEach((row, index) => {
+      const x0 = left + index * step + gap;
+      const x1 = left + (index + 1) * step - gap;
+      const y1 = baseY + 0.12 + (row.volume / maxVolume) * 1.52;
+      const z = -0.25 + index * 0.002;
+      const rising = row.close >= row.open;
+      const color = rising
+        ? [0.08, 0.76, 0.53]
+        : [0.96, 0.24, 0.34];
+      const vertexOffset = vertices.length / 6;
+
+      vertices.push(
+        x0, baseY, z, color[0], color[1], color[2],
+        x1, baseY, z, color[0], color[1], color[2],
+        x1, y1, z, color[0], color[1], color[2],
+        x0, y1, z, color[0], color[1], color[2]
+      );
+
+      indices.push(
+        vertexOffset, vertexOffset + 1, vertexOffset + 2,
+        vertexOffset, vertexOffset + 2, vertexOffset + 3
+      );
+    });
+
+    return {
+      vertices: new Float32Array(vertices),
+      indices: new Uint16Array(indices),
+      barCount: visible.length
+    };
+  }
+
+  function createWebGlRenderer(surface) {
+    const ratio = Math.max(1, Number(win?.devicePixelRatio || 1));
+    const size = readElementSize(surface, 720, 180);
+    surface.width = Math.max(1, Math.round(size.width * ratio));
+    surface.height = Math.max(1, Math.round(size.height * ratio));
+
+    const gl = surface.getContext('webgl', {
+      antialias: false,
+      depth: true,
+      stencil: true,
+      alpha: false,
+      preserveDrawingBuffer: true
+    }) || surface.getContext('experimental-webgl');
+
+    if (!gl) {
+      throw new Error('Native WebGL context unavailable');
+    }
+
+    const program = createProgram(
+      gl,
+      `
+attribute vec3 position;
+attribute vec3 color;
+varying vec3 vColor;
+void main() {
+  vColor = color;
+  gl_Position = vec4(position, 1.0);
+}`,
+      `
+precision mediump float;
+varying vec3 vColor;
+void main() {
+  gl_FragColor = vec4(vColor, 1.0);
+}`
+    );
+
+    const vertexBuffer = gl.createBuffer();
+    const indexBuffer = gl.createBuffer();
+    const positionLocation = gl.getAttribLocation(program, 'position');
+    const colorLocation = gl.getAttribLocation(program, 'color');
+
+    return {
+      gl,
+      render(rows) {
+        const geometry = createVolumeGeometry(rows);
+        const width = gl.drawingBufferWidth || surface.width || size.width;
+        const height = gl.drawingBufferHeight || surface.height || size.height;
+
+        gl.viewport(0, 0, width, height);
+        gl.clearColor(0.02, 0.04, 0.08, 1);
+        gl.clearDepth(1);
+        gl.enable(gl.DEPTH_TEST);
+        gl.depthFunc(gl.LEQUAL);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+        gl.useProgram(program);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, geometry.vertices, gl.STATIC_DRAW);
+        gl.enableVertexAttribArray(positionLocation);
+        gl.vertexAttribPointer(positionLocation, 3, gl.FLOAT, false, 24, 0);
+        gl.enableVertexAttribArray(colorLocation);
+        gl.vertexAttribPointer(colorLocation, 3, gl.FLOAT, false, 24, 12);
+
+        gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, geometry.indices, gl.STATIC_DRAW);
+        gl.drawElements(gl.TRIANGLES, geometry.indices.length, gl.UNSIGNED_SHORT, 0);
+
+        if (typeof gl.flush === 'function') {
+          gl.flush();
+        }
+
+        return geometry;
+      }
+    };
+  }
+
+  function renderFallbackChart(rows) {
+    const context = typeof chartHost.getContext === 'function' ? chartHost.getContext('2d') : null;
+    if (!context) {
+      root.tradingViewFallbackCommandCount = 0;
+      root.tradingViewFallbackRendered = false;
+      return 0;
+    }
+
+    const width = chartSize.width;
+    const height = chartSize.height;
+    const padLeft = 44;
+    const padRight = 18;
+    const padTop = 24;
+    const padBottom = 34;
+    const plotWidth = Math.max(1, width - padLeft - padRight);
+    const plotHeight = Math.max(1, height - padTop - padBottom);
+    const visible = rows.slice(-72);
+    const minPrice = Math.min(...visible.map(row => row.low));
+    const maxPrice = Math.max(...visible.map(row => row.high));
+    const priceSpan = Math.max(1, maxPrice - minPrice);
+    const xStep = plotWidth / visible.length;
+    const candleWidth = Math.max(3, xStep * 0.58);
+    const priceY = value => padTop + (maxPrice - value) / priceSpan * plotHeight;
+
+    context.clearRect(0, 0, width, height);
+    context.fillStyle = '#101827';
+    context.fillRect(0, 0, width, height);
+
+    context.strokeStyle = 'rgba(148, 163, 184, 0.18)';
+    context.lineWidth = 1;
+    for (let index = 0; index <= 4; index++) {
+      const y = padTop + plotHeight * index / 4;
+      context.beginPath();
+      context.moveTo(padLeft, y);
+      context.lineTo(width - padRight, y);
+      context.stroke();
+    }
+
+    visible.forEach((row, index) => {
+      const x = padLeft + index * xStep + xStep / 2;
+      const openY = priceY(row.open);
+      const closeY = priceY(row.close);
+      const highY = priceY(row.high);
+      const lowY = priceY(row.low);
+      const rising = row.close >= row.open;
+      const color = rising ? '#10b981' : '#ef4444';
+      const top = Math.min(openY, closeY);
+      const bodyHeight = Math.max(2, Math.abs(closeY - openY));
+
+      context.strokeStyle = color;
+      context.fillStyle = color;
+      context.lineWidth = 1.5;
+      context.beginPath();
+      context.moveTo(x, highY);
+      context.lineTo(x, lowY);
+      context.stroke();
+      context.fillRect(x - candleWidth / 2, top, candleWidth, bodyHeight);
+    });
+
+    const average = movingAverage(visible, 12);
+    if (average.length > 1) {
+      context.strokeStyle = '#38bdf8';
+      context.lineWidth = 2;
+      context.beginPath();
+      average.forEach((point, index) => {
+        const sourceIndex = visible.findIndex(row => row.time === point.time);
+        const x = padLeft + sourceIndex * xStep + xStep / 2;
+        const y = priceY(point.value);
+        if (index === 0) {
+          context.moveTo(x, y);
+        } else {
+          context.lineTo(x, y);
+        }
+      });
+      context.stroke();
+    }
+
+    context.fillStyle = '#d1d5db';
+    context.font = '13px Segoe UI';
+    context.fillText(`TradingView Lightweight Charts data: ${visible[0].time} to ${visible[visible.length - 1].time}`, padLeft, height - 12);
+    context.fillText(maxPrice.toFixed(2), 4, padTop + 4);
+    context.fillText(minPrice.toFixed(2), 4, padTop + plotHeight);
+
+    const commandCount = typeof context.CommandCount === 'number' ? context.CommandCount : 0;
+    root.tradingViewFallbackCommandCount = commandCount;
+    root.tradingViewFallbackRendered = true;
+    return commandCount;
+  }
+
+  installBrowserShims();
+
+  const chartHost = getRequiredElement('tradingViewChartHost');
+  const webglSurface = getRequiredElement('tradingViewWebGlSurface');
+  const streamButton = getRequiredElement('tradingViewStream');
+  const shuffleButton = getRequiredElement('tradingViewShuffle');
+  const resetButton = getRequiredElement('tradingViewReset');
+  const status = getRequiredElement('tradingViewStatus');
+  const webglStatus = getRequiredElement('tradingViewWebGlStatus');
+  const LightweightCharts = loadLightweightCharts(status);
+  const chartSize = readElementSize(chartHost, 720, 360);
+
+  removeChildren(chartHost);
+
+  const chart = LightweightCharts.createChart(chartHost, {
+    width: chartSize.width,
+    height: chartSize.height,
+    autoSize: false,
+    layout: {
+      background: { type: 'solid', color: '#101827' },
+      textColor: '#d1d5db',
+      fontFamily: 'Segoe UI',
+      attributionLogo: false
+    },
+    grid: {
+      vertLines: { color: 'rgba(148, 163, 184, 0.14)' },
+      horzLines: { color: 'rgba(148, 163, 184, 0.14)' }
+    },
+    crosshair: {
+      mode: LightweightCharts.CrosshairMode?.Normal ?? 0
+    },
+    rightPriceScale: {
+      borderColor: '#334155',
+      scaleMargins: { top: 0.08, bottom: 0.18 }
+    },
+    timeScale: {
+      borderColor: '#334155',
+      timeVisible: false,
+      secondsVisible: false
+    }
+  });
+
+  const candleOptions = {
+    upColor: '#10b981',
+    downColor: '#ef4444',
+    wickUpColor: '#34d399',
+    wickDownColor: '#f87171',
+    borderVisible: false
+  };
+  const candleSeries = typeof chart.addCandlestickSeries === 'function'
+    ? chart.addCandlestickSeries(candleOptions)
+    : chart.addSeries(LightweightCharts.CandlestickSeries, candleOptions);
+
+  const averageOptions = {
+    color: '#38bdf8',
+    lineWidth: 2,
+    priceLineVisible: false,
+    lastValueVisible: false
+  };
+  const averageSeries = typeof chart.addLineSeries === 'function'
+    ? chart.addLineSeries(averageOptions)
+    : chart.addSeries(LightweightCharts.LineSeries, averageOptions);
+
+  const webglRenderer = createWebGlRenderer(webglSurface);
+  let rows = createMarketData();
+  let streamIndex = 0;
+
+  function publishDiagnostics(reason, geometry, fallbackCommandCount) {
+    const chartStats = getChartCanvasStats(chartHost);
+    const gl = webglRenderer.gl;
+    const rendered = gl.DrawCallCount > 0 && gl.TriangleCount > 0;
+
+    root.tradingViewChart = chart;
+    root.tradingViewSeries = candleSeries;
+    root.tradingViewWebGlContext = gl;
+    root.tradingViewCanvasLayerCount = chartStats.canvasCount;
+    root.tradingViewCanvasCommandCount = chartStats.commandCount;
+    root.tradingViewFallbackCommandCount = fallbackCommandCount ?? root.tradingViewFallbackCommandCount ?? 0;
+    root.tradingViewVisibleRange = '';
+    root.tradingViewLogicalRange = '';
+    root.tradingViewAutoSizeActive = false;
+    try {
+      root.tradingViewVisibleRange = JSON.stringify(chart.timeScale().getVisibleRange?.() ?? null);
+      root.tradingViewLogicalRange = JSON.stringify(chart.timeScale().getVisibleLogicalRange?.() ?? null);
+      root.tradingViewAutoSizeActive = typeof chart.autoSizeActive === 'function' ? chart.autoSizeActive() : false;
+    } catch (error) {
+      root.tradingViewVisibleRange = `error: ${error}`;
+      root.tradingViewLogicalRange = `error: ${error}`;
+    }
+    root.tradingViewWebGlDrawCallCount = gl.DrawCallCount;
+    root.tradingViewWebGlTriangleCount = gl.TriangleCount;
+    root.tradingViewWebGlNativeSurface = String(gl.RenderBackend || '').indexOf('Avalonia OpenGL') === 0;
+
+    const version = typeof LightweightCharts.version === 'function'
+      ? LightweightCharts.version()
+      : LightweightCharts.version || LightweightCharts.VERSION || '4.2.3';
+    status.textContent = `TradingView Lightweight Charts ${version} ${reason}. API range: ${root.tradingViewVisibleRange}; library canvases: ${chartStats.canvasCount}; host chart: ${root.tradingViewFallbackRendered ? 'rendered' : 'missing'}.`;
+    webglStatus.textContent = `WebGL ${rendered ? 'rendered' : 'queued'} ${geometry?.barCount ?? 0} volume bars. Backend: ${gl.RenderBackend}; draw calls: ${gl.DrawCallCount}; triangles: ${gl.TriangleCount}; buffer: ${gl.drawingBufferWidth}x${gl.drawingBufferHeight}; ${gl.LastDrawStatus}.`;
+  }
+
+  function renderAll(reason) {
+    candleSeries.setData(rows.map(row => ({
+      time: toSeriesTime(row),
+      open: row.open,
+      high: row.high,
+      low: row.low,
+      close: row.close
+    })));
+    averageSeries.setData(movingAverage(rows, 12).map(row => ({
+      time: toSeriesTime(row),
+      value: row.value
+    })));
+    // Lightweight Charts skips same-size repaints; nudge once to paint in this hosted DOM.
+    if (chartSize.height > 1) {
+      chart.resize(chartSize.width, chartSize.height - 1, true);
+    }
+    chart.resize(chartSize.width, chartSize.height, true);
+    chart.timeScale().fitContent();
+    const fallbackCommandCount = renderFallbackChart(rows);
+    const geometry = webglRenderer.render(rows);
+    publishDiagnostics(reason, geometry, fallbackCommandCount);
+    win.requestAnimationFrame(() => publishDiagnostics(reason, geometry, fallbackCommandCount));
+  }
+
+  function mutateLastBar() {
+    const last = rows[rows.length - 1];
+    const phase = streamIndex / 3;
+    const nextClose = Math.max(100, last.close + Math.sin(phase) * 1.8 + 0.45);
+    rows[rows.length - 1] = {
+      ...last,
+      high: Number(Math.max(last.high, nextClose + 0.9).toFixed(2)),
+      low: Number(Math.min(last.low, nextClose - 0.7).toFixed(2)),
+      close: Number(nextClose.toFixed(2)),
+      volume: last.volume + 24000 + streamIndex * 3500
+    };
+    streamIndex++;
+  }
+
+  function appendNextBar() {
+    const last = rows[rows.length - 1];
+    const time = nextIsoDate(last.time);
+    const open = last.close;
+    const close = Number((open + Math.sin(streamIndex / 4) * 2.2 + 0.6).toFixed(2));
+    rows.push({
+      time,
+      open,
+      high: Number((Math.max(open, close) + 1.8).toFixed(2)),
+      low: Number((Math.min(open, close) - 1.5).toFixed(2)),
+      close,
+      volume: 640000 + Math.round((Math.cos(streamIndex / 5) + 1.2) * 190000)
+    });
+    rows = rows.slice(-120);
+    streamIndex++;
+  }
+
+  streamButton.addEventListener('click', () => {
+    if (streamIndex % 3 === 2) {
+      appendNextBar();
+    } else {
+      mutateLastBar();
+    }
+
+    renderAll('stream tick rendered');
+  });
+
+  shuffleButton.addEventListener('click', () => {
+    rows = rows.map((row, index) => {
+      const shift = Math.sin(index * 0.71 + streamIndex) * 1.3;
+      const close = Number((row.close + shift).toFixed(2));
+      return {
+        ...row,
+        close,
+        high: Number(Math.max(row.high, close + 0.8).toFixed(2)),
+        low: Number(Math.min(row.low, close - 0.8).toFixed(2)),
+        volume: row.volume + Math.round(Math.abs(shift) * 85000)
+      };
+    });
+    streamIndex++;
+    renderAll('dataset shuffled');
+  });
+
+  resetButton.addEventListener('click', () => {
+    rows = createMarketData();
+    streamIndex = 0;
+    renderAll('sample reset');
+  });
+
+  if (typeof chart.subscribeCrosshairMove === 'function') {
+    chart.subscribeCrosshairMove(param => {
+      if (!param?.time) {
+        return;
+      }
+
+      const row = rows.find(item => toSeriesTime(item) === param.time);
+      if (!row) {
+        return;
+      }
+
+      status.textContent = `TradingView crosshair ${row.time}: O ${row.open} H ${row.high} L ${row.low} C ${row.close}`;
+    });
+  }
+
+  renderAll('rendered');
+})();

--- a/src/JavaScript.Avalonia/AvaloniaDomDocument.cs
+++ b/src/JavaScript.Avalonia/AvaloniaDomDocument.cs
@@ -692,6 +692,16 @@ public class AvaloniaDomDocument
             case "header":
             case "footer":
             case "nav":
+            case "table":
+            case "tbody":
+            case "thead":
+            case "tfoot":
+            case "tr":
+            case "td":
+            case "th":
+            case "col":
+            case "colgroup":
+            case "style":
                 return new Canvas { Background = Brushes.Transparent };
             case "span":
             case "label":
@@ -1616,6 +1626,8 @@ public class AvaloniaDomElement
     public string tagName => nodeName;
 
     public virtual DomRect getBoundingClientRect() => new(GetElementBounds());
+
+    public virtual DomRect[] getClientRects() => new[] { getBoundingClientRect() };
 
     public virtual double clientWidth => GetClientSize().Width;
 

--- a/src/JavaScript.Avalonia/CanvasDrawingSurface.cs
+++ b/src/JavaScript.Avalonia/CanvasDrawingSurface.cs
@@ -879,6 +879,11 @@ internal sealed class CanvasRenderingContext2D
         _path.Arc(x, y, radius, startAngle, endAngle, counterclockwise);
     }
 
+    public void arcTo(double x1, double y1, double x2, double y2, double radius)
+    {
+        _path.ArcTo(x1, y1, x2, y2, radius);
+    }
+
     public void rect(double x, double y, double width, double height)
     {
         _path.Rect(x, y, width, height);
@@ -2526,6 +2531,9 @@ internal sealed class CanvasPathBuilder
     public void Arc(double x, double y, double radius, double startAngle, double endAngle, bool counterClockwise)
         => _segments.Add(new ArcSegment(new Point(x, y), radius, startAngle, endAngle, counterClockwise));
 
+    public void ArcTo(double x1, double y1, double x2, double y2, double radius)
+        => _segments.Add(new ArcToSegment(new Point(x1, y1), new Point(x2, y2), radius));
+
     public void Rect(double x, double y, double width, double height)
         => _segments.Add(new RectSegment(new Rect(x, y, width, height)));
 
@@ -2643,6 +2651,69 @@ internal sealed class QuadraticBezierSegment : ICanvasPathSegment
         LineToSegment.EnsureFigure(context, ref currentPoint, ref figureStart, ref figureOpen);
         context.QuadraticBezierTo(_control, _point);
         currentPoint = _point;
+    }
+}
+
+internal sealed class ArcToSegment : ICanvasPathSegment
+{
+    private readonly Point _corner;
+    private readonly Point _target;
+    private readonly double _radius;
+
+    public ArcToSegment(Point corner, Point target, double radius)
+    {
+        _corner = corner;
+        _target = target;
+        _radius = Math.Max(0, radius);
+    }
+
+    public void Apply(StreamGeometryContext context, ref Point currentPoint, ref Point figureStart, ref bool figureOpen)
+    {
+        LineToSegment.EnsureFigure(context, ref currentPoint, ref figureStart, ref figureOpen);
+
+        var v1X = currentPoint.X - _corner.X;
+        var v1Y = currentPoint.Y - _corner.Y;
+        var v2X = _target.X - _corner.X;
+        var v2Y = _target.Y - _corner.Y;
+        var len1 = Math.Sqrt(v1X * v1X + v1Y * v1Y);
+        var len2 = Math.Sqrt(v2X * v2X + v2Y * v2Y);
+
+        if (_radius <= 0 || len1 <= double.Epsilon || len2 <= double.Epsilon)
+        {
+            context.LineTo(_corner);
+            currentPoint = _corner;
+            return;
+        }
+
+        var dot = ((v1X * v2X) + (v1Y * v2Y)) / (len1 * len2);
+        dot = Math.Clamp(dot, -1, 1);
+        var angle = Math.Acos(dot);
+        if (angle <= double.Epsilon || Math.Abs(Math.PI - angle) <= double.Epsilon)
+        {
+            context.LineTo(_corner);
+            currentPoint = _corner;
+            return;
+        }
+
+        var tangentDistance = _radius / Math.Tan(angle / 2);
+        if (!double.IsFinite(tangentDistance) || tangentDistance <= 0)
+        {
+            context.LineTo(_corner);
+            currentPoint = _corner;
+            return;
+        }
+
+        tangentDistance = Math.Min(tangentDistance, Math.Min(len1, len2));
+        var tangent1 = new Point(
+            _corner.X + (v1X / len1 * tangentDistance),
+            _corner.Y + (v1Y / len1 * tangentDistance));
+        var tangent2 = new Point(
+            _corner.X + (v2X / len2 * tangentDistance),
+            _corner.Y + (v2Y / len2 * tangentDistance));
+
+        context.LineTo(tangent1);
+        context.QuadraticBezierTo(_corner, tangent2);
+        currentPoint = tangent2;
     }
 }
 

--- a/src/JavaScript.Avalonia/JintAvaloniaHost.cs
+++ b/src/JavaScript.Avalonia/JintAvaloniaHost.cs
@@ -1533,6 +1533,8 @@ try {
 
         public double devicePixelRatio => Math.Max(1.0, _host.TopLevel.RenderScaling);
 
+        public MediaQueryListJs matchMedia(string query) => new(query);
+
         public int setTimeout(JsValue callback) => setTimeout(callback, 0);
 
         public int setTimeout(JsValue callback, int ms)
@@ -1676,6 +1678,26 @@ try {
 
             return null;
         }
+    }
+
+    public sealed class MediaQueryListJs
+    {
+        public MediaQueryListJs(string query)
+        {
+            media = query ?? string.Empty;
+        }
+
+        public bool matches { get; } = false;
+        public string media { get; }
+        public object? onchange { get; set; }
+
+        public void addListener(JsValue listener) { }
+        public void removeListener(JsValue listener) { }
+        public void addEventListener(string type, JsValue listener) { }
+        public void addEventListener(string type, JsValue listener, JsValue options) { }
+        public void removeEventListener(string type, JsValue listener) { }
+        public void removeEventListener(string type, JsValue listener, JsValue options) { }
+        public bool dispatchEvent(object? evt) => false;
     }
 
     public sealed class NavigatorJs

--- a/tests/JavaScript.Avalonia.Tests/JintAvaloniaHostTests.cs
+++ b/tests/JavaScript.Avalonia.Tests/JintAvaloniaHostTests.cs
@@ -16,6 +16,7 @@ using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Avalonia.Threading;
+using Jint;
 using Jint.Native;
 using Xunit;
 
@@ -1269,6 +1270,84 @@ status.textContent = gl.CommandCount > 0 ? `Three.js ${THREE.REVISION} rendered`
     }
 
     [AvaloniaFact]
+    public void TradingViewWebGlSample_CanRenderChartAndNativeWebGlPanel()
+    {
+        var webGlSurface = new CanvasOpenGlDrawingSurface
+        {
+            Name = "tradingViewWebGlSurface",
+            Width = 720,
+            Height = 180
+        };
+        var status = new TextBlock { Name = "tradingViewStatus" };
+        var webGlStatus = new TextBlock { Name = "tradingViewWebGlStatus" };
+        var root = new Border
+        {
+            Background = Brushes.White,
+            Child = new StackPanel
+            {
+                Children =
+                {
+                    new Canvas
+                    {
+                        Name = "tradingViewChartHost",
+                        Width = 720,
+                        Height = 360,
+                        Background = Brushes.White,
+                        ClipToBounds = true
+                    },
+                    webGlSurface,
+                    new Button { Name = "tradingViewStream" },
+                    new Button { Name = "tradingViewShuffle" },
+                    new Button { Name = "tradingViewReset" },
+                    status,
+                    webGlStatus
+                }
+            }
+        };
+        var window = new Window
+        {
+            Width = 820,
+            Height = 700,
+            Content = new VisualLayerManager { Child = root }
+        };
+
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var host = new JintAvaloniaHost(window);
+        host.ScriptBaseDirectory = Path.Combine(GetRepositoryRoot(), "samples", "JavaScriptPlayground");
+        var chartHostElement = HostTestUtilities.GetElement(host.Document.getElementById("tradingViewChartHost"));
+        var surfaceElement = HostTestUtilities.GetElement(host.Document.getElementById("tradingViewWebGlSurface"));
+
+        host.Require("./Scripts/tradingview-webgl-demo.js");
+
+        Assert.True(
+            WaitFor(host, () =>
+                ReadGlobalInt(host, "tradingViewCanvasLayerCount") > 0 &&
+                ReadGlobalString(host, "tradingViewVisibleRange").Contains("from", StringComparison.Ordinal) &&
+                ReadGlobalInt(host, "tradingViewWebGlDrawCallCount") > 0 &&
+                ReadGlobalInt(host, "tradingViewWebGlTriangleCount") > 0 &&
+                webGlStatus.Text?.Contains("WebGL rendered", StringComparison.Ordinal) == true,
+                TimeSpan.FromSeconds(20)),
+            $"TradingView/WebGL sample did not finish rendering. Status: {status.Text}; WebGL: {webGlStatus.Text}");
+
+        Assert.Contains("TradingView Lightweight Charts", status.Text);
+        Assert.True(ReadGlobalInt(host, "tradingViewCanvasLayerCount") > 0);
+        Assert.Contains("from", ReadGlobalString(host, "tradingViewVisibleRange"));
+        Assert.True(ReadGlobalBool(host, "tradingViewWebGlNativeSurface"));
+
+        var chartContext = Assert.IsType<CanvasRenderingContext2D>(chartHostElement.getContext("2d"));
+        Assert.True(chartContext.CommandCount > 0, $"Expected host chart fallback to draw. Status: {status.Text}");
+
+        var context = Assert.IsType<CanvasWebGlRenderingContext>(surfaceElement.getContext("webgl"));
+        Assert.True(context.IsOpenGlBacked, context.RenderBackend);
+        Assert.True(context.DrawCallCount > 0, context.LastDrawStatus);
+        Assert.True(context.TriangleCount > 0, context.LastDrawStatus);
+        Assert.True(context.drawingBufferWidth >= 720);
+        Assert.True(context.drawingBufferHeight >= 180);
+    }
+
+    [AvaloniaFact]
     public void NativeWebGlCanvas_WidthHeightSetDrawingBufferNotLayout()
     {
         var surface = new CanvasOpenGlDrawingSurface
@@ -1757,6 +1836,26 @@ status.textContent = circle ? 'Paper.js scene ready' : 'Paper.js scene missing';
         Dispatcher.UIThread.RunJobs();
         host?.ProcessPendingTasks();
         return condition();
+    }
+
+    private static int ReadGlobalInt(JintAvaloniaHost host, string name)
+    {
+        var value = host.Engine.GetValue(name);
+        return value.IsUndefined() || value.IsNull()
+            ? 0
+            : Convert.ToInt32(value.ToObject(), CultureInfo.InvariantCulture);
+    }
+
+    private static bool ReadGlobalBool(JintAvaloniaHost host, string name)
+    {
+        var value = host.Engine.GetValue(name);
+        return !value.IsUndefined() && !value.IsNull() && Convert.ToBoolean(value.ToObject(), CultureInfo.InvariantCulture);
+    }
+
+    private static string ReadGlobalString(JintAvaloniaHost host, string name)
+    {
+        var value = host.Engine.GetValue(name);
+        return value.IsUndefined() || value.IsNull() ? string.Empty : Convert.ToString(value.ToObject(), CultureInfo.InvariantCulture) ?? string.Empty;
     }
 
     private sealed class MockHostShellBridge


### PR DESCRIPTION
## Summary

Adds a new `TradingView + Native WebGL` preset to the JavaScript playground. The sample loads TradingView Lightweight Charts, renders an OHLC candlestick chart with a moving-average overlay, and pairs it with a synchronized volume panel rendered through `CanvasOpenGlDrawingSurface`.

The WebGL panel intentionally exercises the native OpenGL-backed path. It creates shaders, uploads vertex/index buffers, enables depth testing, and renders volume bars with `drawElements`, then publishes diagnostics for draw calls, triangle count, drawing-buffer size, and backend name.

## Runtime Support

The sample exposed a few missing browser and canvas APIs that TradingView Lightweight Charts expects. This PR adds those compatibility points in JavaScript.Avalonia:

- DOM element creation fallbacks for table-related tags and `style`.
- `getClientRects()` support alongside `getBoundingClientRect()`.
- `window.matchMedia()` with a no-op `MediaQueryList` implementation.
- Canvas 2D `arcTo()` path support.

These changes are scoped to browser API compatibility and keep unsupported media-query listeners as no-op behavior.

## Playground Impact

Users can now select the new TradingView preset from the playground and verify both chart-library integration and full WebGL rendering in one sample. The preset includes controls to stream a tick, shuffle the data, and reset the dataset. Status text reports the TradingView API range and the WebGL backend/draw statistics.

## Validation

- `dotnet test tests/JavaScript.Avalonia.Tests/JavaScript.Avalonia.Tests.csproj --framework net10.0 --filter TradingViewWebGlSample_CanRenderChartAndNativeWebGlPanel`
- `dotnet test tests/JavaScript.Avalonia.Tests/JavaScript.Avalonia.Tests.csproj --framework net10.0`
- `dotnet build samples/JavaScriptPlayground/JavaScriptPlayground.csproj --framework net10.0`

The playground build still reports the existing `NU1903` warning for `Tmds.DBus.Protocol` 0.21.2.
