### PR TITLE
Implement Windows DirectWrite font positioning

### DIFF
--- a/docs/v8-inspector-debugging.md
+++ b/docs/v8-inspector-debugging.md
@@ -100,10 +100,10 @@ The discovery document includes an authenticated
 `chrome://inspect` can poll it, while every WebSocket connection requires the
 random access token. Non-loopback binding requires
 `AllowRemoteConnections = true`; supply a strong explicit token when a stable
-remote URL is needed. Remote `/json`, `/json/list`, and `/json/version` requests
-must first present that token as a `token` query parameter or
-`Authorization: Bearer` header, so unauthenticated discovery cannot disclose
-the WebSocket credential.
+remote URL is needed. When remote mode is enabled, `/json`, `/json/list`, and
+`/json/version` requests must first present that token as a `token` query
+parameter or `Authorization: Bearer` header—even if the configured address is
+loopback—so unauthenticated discovery cannot disclose the WebSocket credential.
 
 The showcase command-line launcher requires a caller-known token for a
 non-loopback endpoint. Set `WEBSCENE_INSPECT_TOKEN` to at least 32 characters

--- a/experiments/WebScene.GlyphDiagnostics/Program.cs
+++ b/experiments/WebScene.GlyphDiagnostics/Program.cs
@@ -15,6 +15,17 @@ var coreTextSourcePath = Path.Combine(AppContext.BaseDirectory, "CoreTextRendere
 var outputDirectory = ResolveOutputDirectory(args);
 Directory.CreateDirectory(outputDirectory);
 
+if (OperatingSystem.IsWindows())
+{
+    WindowsGlyphDiagnostics.Run(
+        args,
+        configurationPath,
+        chromeDocumentPath,
+        chromeCapturePath,
+        outputDirectory);
+    return;
+}
+
 if (!OperatingSystem.IsMacOS())
 {
     throw new PlatformNotSupportedException(

--- a/experiments/WebScene.GlyphDiagnostics/README.md
+++ b/experiments/WebScene.GlyphDiagnostics/README.md
@@ -1,7 +1,18 @@
 # Glyph-level text diagnostics
 
-This macOS-only experiment compares the same system-UI glyph corpus through several
-rendering paths:
+This cross-platform experiment compares the same system-UI glyph corpus through
+platform-specific positioning and shared Skia painting paths.
+
+On Windows it captures:
+
+- WebScene's HarfBuzz/Skia baseline;
+- whole-run DirectWrite positions painted with the same Skia glyph masks;
+- a normal Avalonia `TextBlock` control;
+- Chromium canvas and DOM output;
+- glyph IDs, clusters, advances, offsets, verified face identity, device scale, and
+  canvas matrix at 100%, 125%, 150%, and 200% scaling.
+
+On macOS it captures:
 
 - WebScene's production HarfBuzz/Skia text path;
 - the same shaped glyphs with Skia's default font raster settings;
@@ -26,6 +37,18 @@ Run it from the repository root on macOS:
 dotnet run --project experiments/WebScene.GlyphDiagnostics -c Release
 ```
 
+Run the Windows matrix from the repository root:
+
+```powershell
+dotnet run --project experiments/WebScene.GlyphDiagnostics -c Release -f net10.0 -- `
+  --platform windows --scales 1,1.25,1.5,2 `
+  --output TestResults/GlyphDiagnostics/windows-x64
+```
+
+Set `WEBSCENE_NODE_EXECUTABLE` when Node.js is not on `PATH`. The Windows launcher
+accepts Chrome or Edge as the Chromium oracle and records the executable's exact
+product version in the report.
+
 Set `WEBSCENE_CHROMIUM_EXECUTABLE` if Google Chrome is not installed in its standard
 application path. Generated PNGs, native/Chromium glyph metrics, `report.json`, and a
 compact `report.md` are written to `TestResults/GlyphDiagnostics` by default. Pass
@@ -39,6 +62,26 @@ glyph masks and compositing. Coverage and edge-pixel counts help distinguish a h
 glyph mask from different antialiasing.
 
 ## Current finding
+
+The Windows report validates the automatically selected DirectWrite path. Regular-weight
+Segoe UI runs use DirectWrite only after font-table fingerprints and complete glyph
+sequences match the active Skia typeface. Web fonts, named families, Apple aliases
+without a Windows fallback, non-Latin or emoji runs, authored feature flags, italic
+text, and currently unproven weights fall back per run to HarfBuzz.
+`WEBSCENE_TEXT_POSITIONING=directwrite` remains available as an explicit diagnostic
+value, while `WEBSCENE_TEXT_POSITIONING=harfbuzz` is the rollback control. At 100%
+scale verified DirectWrite runs use the Windows Chromium-oracle grayscale Skia profile;
+higher scales retain the host profile. The report computes pixel-weighted corpus error
+plus per-case and isolated-glyph regression guards at every required scale; all four
+passed together with the managed, WPT, and performance gates before automatic selection
+was enabled.
+
+The diagnostic performance gate requires cold factory/face/run creation within 50 ms,
+a warm cached shape within 10 µs and at most one managed byte per call, positioned draw
+time no more than 10% above the HarfBuzz baseline, and no increase in per-draw managed
+allocation. It also records the bounded 2,048-run and 64-face cache limits.
+
+### macOS
 
 On the reference macOS run with Chrome 151, WebScene's production Skia path was
 pixel-identical to Chromium canvas and DOM for all six isolated glyph cases at both 1x

--- a/experiments/WebScene.GlyphDiagnostics/WebScene.GlyphDiagnostics.csproj
+++ b/experiments/WebScene.GlyphDiagnostics/WebScene.GlyphDiagnostics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Skia" />
+    <PackageReference Include="Avalonia.Headless" />
     <PackageReference Include="SkiaSharp" />
     <PackageReference Include="SkiaSharp.HarfBuzz" />
   </ItemGroup>

--- a/experiments/WebScene.GlyphDiagnostics/WindowsGlyphDiagnostics.cs
+++ b/experiments/WebScene.GlyphDiagnostics/WindowsGlyphDiagnostics.cs
@@ -1,0 +1,756 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using SkiaSharp;
+using SkiaSharp.HarfBuzz;
+using WebScene.Backends.Avalonia.Native;
+
+internal sealed class WindowsGlyphDiagnosticApp : Application;
+
+internal static class WindowsGlyphDiagnostics
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    internal static void Run(
+        string[] arguments,
+        string configurationPath,
+        string chromeDocumentPath,
+        string chromeCapturePath,
+        string outputDirectory)
+    {
+        var requestedPlatform = Option(arguments, "--platform");
+        if (requestedPlatform is not null
+            && !requestedPlatform.Equals("windows", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException(
+                $"This host cannot run the requested '{requestedPlatform}' diagnostic.");
+        }
+        var scales = ParseScales(Option(arguments, "--scales"));
+        var configuration = JsonSerializer.Deserialize<WindowsConfiguration>(
+            File.ReadAllText(configurationPath),
+            JsonOptions)
+            ?? throw new InvalidDataException("Could not read glyph diagnostic cases.");
+        var chrome = ResolveChromeExecutable();
+        var node = ResolveNodeExecutable();
+        var browserVersion = FileVersionInfo.GetVersionInfo(chrome);
+        var chromiumVersion = $"{browserVersion.ProductName ?? Path.GetFileName(chrome)} "
+            + $"{browserVersion.ProductVersion ?? "unknown"}";
+        var performance = Benchmark(configuration);
+
+        AppBuilder.Configure<WindowsGlyphDiagnosticApp>()
+            .UseSkia()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions
+            {
+                UseHeadlessDrawing = false
+            })
+            .SetupWithoutStarting();
+
+        var scaleReports = new List<WindowsScaleReport>();
+        foreach (var scale in scales)
+        {
+            var suffix = ScaleSuffix(scale);
+            var harfBuzzImage = Path.Combine(outputDirectory, $"harfbuzz-{suffix}.png");
+            var directWriteImage = Path.Combine(outputDirectory, $"directwrite-skia-{suffix}.png");
+            var frameworkImage = Path.Combine(outputDirectory, $"avalonia-text-{suffix}.png");
+            var chromeImage = Path.Combine(outputDirectory, $"chrome-{suffix}.png");
+            var chromeMetrics = Path.Combine(outputDirectory, $"chrome-{suffix}.metrics.json");
+            var harfBuzzRuns = RenderSkia(
+                configuration,
+                scale,
+                directWrite: false,
+                harfBuzzImage);
+            var directWriteRuns = RenderSkia(
+                configuration,
+                scale,
+                directWrite: true,
+                directWriteImage);
+            RenderAvalonia(configuration, scale, frameworkImage);
+            RunProcess(node,
+            [
+                chromeCapturePath,
+                "--chrome", chrome,
+                "--document", chromeDocumentPath,
+                "--output", chromeImage,
+                "--metrics", chromeMetrics,
+                "--scale", scale.ToString(CultureInfo.InvariantCulture),
+                "--width", configuration.Width.ToString(CultureInfo.InvariantCulture),
+                "--height", (configuration.Height * 3).ToString(CultureInfo.InvariantCulture)
+            ]);
+
+            File.WriteAllText(
+                Path.Combine(outputDirectory, $"harfbuzz-{suffix}.metrics.json"),
+                JsonSerializer.Serialize(harfBuzzRuns, JsonOptions));
+            File.WriteAllText(
+                Path.Combine(outputDirectory, $"directwrite-skia-{suffix}.metrics.json"),
+                JsonSerializer.Serialize(directWriteRuns, JsonOptions));
+            scaleReports.Add(AnalyzeScale(
+                configuration,
+                scale,
+                harfBuzzImage,
+                directWriteImage,
+                frameworkImage,
+                chromeImage,
+                directWriteRuns));
+        }
+
+        var report = new WindowsDiagnosticReport(
+            DateTimeOffset.UtcNow,
+            Environment.OSVersion.VersionString,
+            RuntimeInformation.RuntimeIdentifier,
+            chromiumVersion,
+            Environment.CommandLine,
+            performance,
+            scaleReports);
+        File.WriteAllText(
+            Path.Combine(outputDirectory, "report.json"),
+            JsonSerializer.Serialize(report, JsonOptions));
+        File.WriteAllText(
+            Path.Combine(outputDirectory, "report.md"),
+            FormatReport(report));
+        Console.WriteLine(Path.Combine(outputDirectory, "report.md"));
+    }
+
+    private static List<WindowsRunMetrics> RenderSkia(
+        WindowsConfiguration configuration,
+        float scale,
+        bool directWrite,
+        string outputPath)
+    {
+        var width = checked((int)MathF.Round(configuration.Width * scale));
+        var height = checked((int)MathF.Round(configuration.Height * scale));
+        using var bitmap = new SKBitmap(new SKImageInfo(width, height, SKColorType.Bgra8888));
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColor.Parse(configuration.Background));
+        canvas.Scale(scale);
+        var metrics = new List<WindowsRunMetrics>(configuration.Cases.Length);
+        var positioner = directWrite ? new WindowsDirectWriteRunPositioner() : null;
+        foreach (var item in configuration.Cases)
+        {
+            var typeface = NativeTextShaping.ResolveTypeface(
+                configuration.Family,
+                item.Weight);
+            using var paint = new SKPaint
+            {
+                Typeface = typeface,
+                TextSize = item.Size,
+                Color = SKColor.Parse(configuration.Foreground),
+                IsAntialias = true
+            };
+            using var shaper = new SKShaper(typeface);
+            var shaped = shaper.Shape(item.Text, 0, 0, paint);
+            NativePositionedTextRun? positioned = null;
+            if (positioner is not null)
+            {
+                var request = new NativeTextRunPositionRequest(
+                    item.Text,
+                    configuration.Family,
+                    item.Size,
+                    item.Weight,
+                    SKFontStyleSlant.Upright,
+                    0,
+                    shaped.Codepoints,
+                    null,
+                    typeface);
+                positioner.TryPosition(in request, out positioned);
+            }
+            NativeTextShaping.DrawShapedText(
+                canvas,
+                shaper,
+                item.Text,
+                item.X,
+                item.Baseline,
+                paint,
+                0,
+                measuredWidth: positioned?.AdvanceWidth ?? shaped.Width,
+                deviceScaleFactor: scale,
+                positionedRun: positioned);
+            metrics.Add(new WindowsRunMetrics(
+                item.Id,
+                (positioned?.Glyphs.Select(static glyph => (uint)glyph).ToArray()
+                    ?? shaped.Codepoints),
+                positioned?.Clusters ?? [],
+                positioned?.Positions.Select(static point => new[] { point.X, point.Y }).ToArray()
+                    ?? shaped.Points.Select(static point => new[] { point.X, point.Y }).ToArray(),
+                positioned?.Advances ?? [],
+                positioned?.Offsets?.Select(static point => new[] { point.X, point.Y }).ToArray()
+                    ?? [],
+                positioned?.AdvanceWidth ?? shaped.Width,
+                positioned?.FaceIdentity,
+                scale,
+                new[] { scale, 0f, 0f, scale, 0f, 0f }));
+        }
+        using var image = SKImage.FromBitmap(bitmap);
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        using var stream = File.Create(outputPath);
+        data.SaveTo(stream);
+        return metrics;
+    }
+
+    private static void RenderAvalonia(
+        WindowsConfiguration configuration,
+        float scale,
+        string outputPath)
+    {
+        var width = checked((int)MathF.Round(configuration.Width * scale));
+        var height = checked((int)MathF.Round(configuration.Height * scale));
+        var panel = new Canvas
+        {
+            Width = width,
+            Height = height,
+            Background = Brush.Parse(configuration.Background)
+        };
+        foreach (var item in configuration.Cases)
+        {
+            var text = new TextBlock
+            {
+                Text = item.Text,
+                FontFamily = new FontFamily("Segoe UI"),
+                FontSize = item.Size * scale,
+                FontWeight = (FontWeight)item.Weight,
+                Foreground = Brush.Parse(configuration.Foreground),
+                LineHeight = item.Size * scale
+            };
+            Canvas.SetLeft(text, item.X * scale);
+            Canvas.SetTop(text, (item.Baseline - item.Size) * scale);
+            panel.Children.Add(text);
+        }
+        var window = new Window
+        {
+            Width = width,
+            Height = height,
+            Content = panel,
+            Background = Brush.Parse(configuration.Background),
+            CanResize = false,
+            SystemDecorations = SystemDecorations.None
+        };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            using var frame = window.CaptureRenderedFrame()
+                ?? throw new InvalidOperationException("Avalonia returned no rendered frame.");
+            frame.Save(outputPath);
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    private static WindowsScaleReport AnalyzeScale(
+        WindowsConfiguration configuration,
+        float scale,
+        string harfBuzzPath,
+        string directWritePath,
+        string frameworkPath,
+        string chromePath,
+        IReadOnlyList<WindowsRunMetrics> directWriteRuns)
+    {
+        using var harfBuzz = SKBitmap.Decode(harfBuzzPath);
+        using var directWrite = SKBitmap.Decode(directWritePath);
+        using var framework = SKBitmap.Decode(frameworkPath);
+        using var chrome = SKBitmap.Decode(chromePath);
+        var expectedHeight = checked((int)MathF.Round(configuration.Height * scale));
+        var sources = new Dictionary<string, ImageSlice>
+        {
+            ["harfbuzz-skia"] = new(harfBuzz, 0),
+            ["directwrite-skia"] = new(directWrite, 0),
+            ["avalonia-text"] = new(framework, 0),
+            ["chrome-canvas"] = new(chrome, 0),
+            ["chrome-dom"] = new(chrome, expectedHeight)
+        };
+        var cases = new List<WindowsCaseReport>();
+        foreach (var item in configuration.Cases)
+        {
+            var region = ResolveRegion(configuration, item, scale);
+            var comparisons = new List<WindowsPixelComparison>();
+            foreach (var candidate in new[] { "harfbuzz-skia", "directwrite-skia", "avalonia-text" })
+            {
+                comparisons.Add(Compare(
+                    candidate,
+                    sources[candidate],
+                    sources["chrome-canvas"],
+                    region,
+                    checked((int)MathF.Ceiling(2 * scale)),
+                    "chrome-canvas"));
+                comparisons.Add(Compare(
+                    candidate + "-vs-dom",
+                    sources[candidate],
+                    sources["chrome-dom"],
+                    region,
+                    checked((int)MathF.Ceiling(2 * scale)),
+                    "chrome-dom"));
+            }
+            cases.Add(new WindowsCaseReport(
+                item.Id,
+                item.Text.EnumerateRunes().Count() == 1,
+                comparisons,
+                directWriteRuns.Single(run => run.Id == item.Id)));
+        }
+        var eligible = cases.Where(item => !item.IsolatedGlyph
+            && item.DirectWrite.FaceIdentity is not null).ToArray();
+        var harfBuzzComparisons = eligible.Select(item => item.Comparisons.Single(
+            comparison => comparison.Source == "harfbuzz-skia")).ToArray();
+        var directWriteComparisons = eligible.Select(item => item.Comparisons.Single(
+            comparison => comparison.Source == "directwrite-skia")).ToArray();
+        var harfBuzzErrors = harfBuzzComparisons
+            .Select(comparison => comparison.MeanAbsoluteError).ToArray();
+        var directWriteErrors = directWriteComparisons
+            .Select(comparison => comparison.MeanAbsoluteError).ToArray();
+        var totalSamples = harfBuzzComparisons.Sum(comparison => (long)comparison.Samples);
+        var harfBuzzCorpusError = totalSamples == 0
+            ? 0
+            : harfBuzzComparisons.Sum(
+                comparison => comparison.MeanAbsoluteError * comparison.Samples)
+                / totalSamples;
+        var directWriteCorpusError = totalSamples == 0
+            ? 0
+            : directWriteComparisons.Sum(
+                comparison => comparison.MeanAbsoluteError * comparison.Samples)
+                / totalSamples;
+        var regressions = directWriteErrors.Zip(
+            harfBuzzErrors,
+            static (directWrite, harfBuzz) => directWrite - harfBuzz).ToArray();
+        var isolatedRegressions = cases.Where(item => item.IsolatedGlyph
+                && item.DirectWrite.FaceIdentity is not null)
+            .Select(item =>
+                item.Comparisons.Single(comparison => comparison.Source == "directwrite-skia")
+                    .MeanAbsoluteError
+                - item.Comparisons.Single(comparison => comparison.Source == "harfbuzz-skia")
+                    .MeanAbsoluteError)
+            .ToArray();
+        var maximumIsolatedRegression = isolatedRegressions.Length == 0
+            ? 0
+            : isolatedRegressions.Max();
+        var summary = new WindowsScaleSummary(
+            harfBuzzCorpusError,
+            directWriteCorpusError,
+            regressions.Length == 0 ? 0 : regressions.Max(),
+            maximumIsolatedRegression,
+            directWriteErrors.Length > 0
+                && directWriteCorpusError < harfBuzzCorpusError
+                && regressions.All(regression => regression <= .001)
+                && maximumIsolatedRegression <= .001);
+        return new WindowsScaleReport(scale, cases, summary);
+    }
+
+    private static WindowsPerformanceReport Benchmark(WindowsConfiguration configuration)
+    {
+        var item = configuration.Cases.First(candidate =>
+            candidate.Weight == 400 && candidate.Text.Length > 8
+            && candidate.Text.All(character => character <= '\u024f'));
+        var typeface = NativeTextShaping.ResolveTypeface(configuration.Family, item.Weight);
+        using var paint = new SKPaint
+        {
+            Typeface = typeface,
+            TextSize = item.Size,
+            IsAntialias = true,
+            Color = SKColors.White
+        };
+        using var shaper = new SKShaper(typeface);
+        var shaped = shaper.Shape(item.Text, 0, 0, paint);
+        var request = new NativeTextRunPositionRequest(
+            item.Text,
+            configuration.Family,
+            item.Size,
+            item.Weight,
+            SKFontStyleSlant.Upright,
+            0,
+            shaped.Codepoints,
+            null,
+            typeface);
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        var managedBefore = GC.GetTotalMemory(forceFullCollection: true);
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        var started = Stopwatch.GetTimestamp();
+        var positioner = new WindowsDirectWriteRunPositioner();
+        if (!positioner.TryPosition(in request, out var positioned))
+            throw new InvalidOperationException("DirectWrite rejected the benchmark run.");
+        var coldElapsed = Stopwatch.GetElapsedTime(started);
+        var coldAllocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        var managedAfterCold = GC.GetTotalMemory(forceFullCollection: true);
+
+        const int shapeIterations = 10_000;
+        allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        started = Stopwatch.GetTimestamp();
+        for (var index = 0; index < shapeIterations; index++)
+        {
+            if (!positioner.TryPosition(in request, out _))
+                throw new InvalidOperationException("A cached DirectWrite run was rejected.");
+        }
+        var warmElapsed = Stopwatch.GetElapsedTime(started);
+        var warmAllocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        const int drawIterations = 10_000;
+        using var bitmap = new SKBitmap(400, 80);
+        using var canvas = new SKCanvas(bitmap);
+        for (var index = 0; index < 100; index++)
+        {
+            NativeTextShaping.DrawShapedText(
+                canvas, shaper, item.Text, 0, 40, paint, 0,
+                measuredWidth: positioned.AdvanceWidth,
+                positionedRun: positioned);
+            NativeTextShaping.DrawShapedText(
+                canvas, shaper, item.Text, 0, 40, paint, 0,
+                measuredWidth: shaped.Width);
+        }
+        allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        started = Stopwatch.GetTimestamp();
+        for (var index = 0; index < drawIterations; index++)
+        {
+            NativeTextShaping.DrawShapedText(
+                canvas,
+                shaper,
+                item.Text,
+                0,
+                40,
+                paint,
+                0,
+                measuredWidth: positioned.AdvanceWidth,
+                positionedRun: positioned);
+        }
+        var drawElapsed = Stopwatch.GetElapsedTime(started);
+        var drawAllocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        started = Stopwatch.GetTimestamp();
+        for (var index = 0; index < drawIterations; index++)
+        {
+            NativeTextShaping.DrawShapedText(
+                canvas,
+                shaper,
+                item.Text,
+                0,
+                40,
+                paint,
+                0,
+                measuredWidth: shaped.Width);
+        }
+        var harfBuzzDrawElapsed = Stopwatch.GetElapsedTime(started);
+        var harfBuzzDrawAllocated =
+            GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        var warmShapeNanoseconds = warmElapsed.TotalNanoseconds / shapeIterations;
+        var warmShapeAllocated = warmAllocated / (double)shapeIterations;
+        var drawNanoseconds = drawElapsed.TotalNanoseconds / drawIterations;
+        var drawAllocatedPerIteration = drawAllocated / (double)drawIterations;
+        var harfBuzzDrawNanoseconds =
+            harfBuzzDrawElapsed.TotalNanoseconds / drawIterations;
+        var harfBuzzDrawAllocatedPerIteration =
+            harfBuzzDrawAllocated / (double)drawIterations;
+        return new WindowsPerformanceReport(
+            item.Id,
+            coldElapsed.TotalMilliseconds,
+            coldAllocated,
+            managedAfterCold - managedBefore,
+            warmShapeNanoseconds,
+            warmShapeAllocated,
+            drawNanoseconds,
+            drawAllocatedPerIteration,
+            harfBuzzDrawNanoseconds,
+            harfBuzzDrawAllocatedPerIteration,
+            coldElapsed.TotalMilliseconds <= 50
+                && warmShapeNanoseconds <= 10_000
+                && warmShapeAllocated <= 1
+                && drawNanoseconds <= harfBuzzDrawNanoseconds * 1.1
+                && drawAllocatedPerIteration <= harfBuzzDrawAllocatedPerIteration,
+            2048,
+            64);
+    }
+
+    private static WindowsPixelComparison Compare(
+        string sourceName,
+        ImageSlice source,
+        ImageSlice reference,
+        PixelBox region,
+        int radius,
+        string referenceName)
+    {
+        WindowsPixelComparison? best = null;
+        for (var dy = -radius; dy <= radius; dy++)
+        for (var dx = -radius; dx <= radius; dx++)
+        {
+            double absolute = 0;
+            double squared = 0;
+            var samples = 0;
+            var differing = 0;
+            for (var y = region.Top; y < region.Bottom; y++)
+            for (var x = region.Left; x < region.Right; x++)
+            {
+                var left = source.GetPixel(x + dx, y);
+                var right = reference.GetPixel(x, y);
+                var difference = (
+                    Math.Abs(left.Red - right.Red)
+                    + Math.Abs(left.Green - right.Green)
+                    + Math.Abs(left.Blue - right.Blue)) / (3d * 255d);
+                absolute += difference;
+                squared += difference * difference;
+                samples++;
+                if (difference > 0) differing++;
+            }
+            var comparison = new WindowsPixelComparison(
+                sourceName,
+                referenceName,
+                dx,
+                dy,
+                absolute / samples,
+                Math.Sqrt(squared / samples),
+                differing,
+                samples);
+            if (best is null || comparison.MeanAbsoluteError < best.MeanAbsoluteError)
+                best = comparison;
+        }
+        return best!;
+    }
+
+    private static PixelBox ResolveRegion(
+        WindowsConfiguration configuration,
+        WindowsGlyphCase item,
+        float scale)
+        => new(
+            Math.Max(0, (int)MathF.Floor((item.X - 4) * scale)),
+            Math.Max(0, (int)MathF.Floor((item.Baseline - item.Size * 1.6f) * scale)),
+            Math.Min(
+                checked((int)MathF.Round(configuration.Width * scale)),
+                (int)MathF.Ceiling((item.X + Math.Max(80, item.Text.Length * item.Size * .8f + 20)) * scale)),
+            Math.Min(
+                checked((int)MathF.Round(configuration.Height * scale)),
+                (int)MathF.Ceiling((item.Baseline + item.Size * .65f) * scale)));
+
+    private static string FormatReport(WindowsDiagnosticReport report)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("# Windows glyph diagnostic");
+        builder.AppendLine();
+        builder.AppendLine($"- Generated: {report.GeneratedUtc:O}");
+        builder.AppendLine($"- OS: {report.OperatingSystem}");
+        builder.AppendLine($"- RID: {report.RuntimeIdentifier}");
+        builder.AppendLine($"- Chromium oracle: {report.ChromiumVersion}");
+        builder.AppendLine($"- Command: `{report.Command}`");
+        builder.AppendLine(
+            $"- Performance ({report.Performance.CaseId}): cold shape "
+            + $"{report.Performance.ColdShapeMilliseconds:F3} ms / "
+            + $"{report.Performance.ColdAllocatedBytes} B allocated; warm cache hit "
+            + $"{report.Performance.WarmShapeNanoseconds:F1} ns / "
+            + $"{report.Performance.WarmAllocatedBytes:F1} B; positioned draw "
+            + $"{report.Performance.DrawNanoseconds:F1} ns / "
+            + $"{report.Performance.DrawAllocatedBytes:F1} B; HarfBuzz draw "
+            + $"{report.Performance.HarfBuzzDrawNanoseconds:F1} ns / "
+            + $"{report.Performance.HarfBuzzDrawAllocatedBytes:F1} B; budget "
+            + $"{(report.Performance.PassesBudget ? "pass" : "fail")}");
+        foreach (var scale in report.Scales)
+        {
+            builder.AppendLine();
+            builder.AppendLine($"## Scale {scale.DeviceScaleFactor:P0}");
+            builder.AppendLine();
+            builder.AppendLine(
+                $"Eligible multi-glyph canvas MAE: HarfBuzz {scale.Summary.HarfBuzzMeanAbsoluteError:F6}, "
+                + $"DirectWrite {scale.Summary.DirectWriteMeanAbsoluteError:F6}; "
+                + $"maximum per-case regression {scale.Summary.MaximumPerCaseRegression:F6}; "
+                + $"maximum isolated-glyph regression "
+                + $"{scale.Summary.MaximumIsolatedGlyphRegression:F6}; "
+                + $"rollout gate: {(scale.Summary.PassesPixelGate ? "pass" : "fail") }.");
+            builder.AppendLine();
+            builder.AppendLine("| Case | Source | shift | MAE | RMSE | differing | face |");
+            builder.AppendLine("|---|---|---:|---:|---:|---:|---|");
+            foreach (var item in scale.Cases)
+            foreach (var comparison in item.Comparisons)
+            {
+                builder.AppendLine(
+                    $"| {item.Id} | {comparison.Source} | {comparison.OffsetX},{comparison.OffsetY} "
+                    + $"| {comparison.MeanAbsoluteError:F6} | {comparison.RootMeanSquareError:F6} "
+                    + $"| {comparison.DifferingPixels}/{comparison.Samples} "
+                    + $"| {item.DirectWrite.FaceIdentity?.FamilyName ?? "fallback"} |");
+            }
+        }
+        return builder.ToString();
+    }
+
+    private static float[] ParseScales(string? value)
+    {
+        var scales = string.IsNullOrWhiteSpace(value)
+            ? [1f, 1.25f, 1.5f, 2f]
+            : value.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                .Select(item => float.Parse(item, CultureInfo.InvariantCulture))
+                .ToArray();
+        if (scales.Length == 0 || scales.Any(scale => !float.IsFinite(scale) || scale <= 0))
+            throw new ArgumentException("--scales must contain positive finite values.");
+        return scales;
+    }
+
+    private static string? Option(IReadOnlyList<string> arguments, string name)
+    {
+        for (var index = 0; index < arguments.Count; index++)
+        {
+            if (!arguments[index].Equals(name, StringComparison.OrdinalIgnoreCase)) continue;
+            if (index + 1 >= arguments.Count)
+                throw new ArgumentException($"Missing value for {name}.");
+            return arguments[index + 1];
+        }
+        return null;
+    }
+
+    private static string ScaleSuffix(float scale)
+        => $"{scale.ToString("0.##", CultureInfo.InvariantCulture)}x";
+
+    private static string ResolveChromeExecutable()
+    {
+        var configured = Environment.GetEnvironmentVariable("WEBSCENE_CHROMIUM_EXECUTABLE");
+        if (!string.IsNullOrWhiteSpace(configured) && File.Exists(configured)) return configured;
+        var candidates = new[]
+        {
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                "Google", "Chrome", "Application", "chrome.exe"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Google", "Chrome", "Application", "chrome.exe"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                "Google", "Chrome", "Application", "chrome.exe"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                "Microsoft", "Edge", "Application", "msedge.exe"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                "Microsoft", "Edge", "Application", "msedge.exe")
+        };
+        return candidates.FirstOrDefault(File.Exists)
+            ?? throw new FileNotFoundException(
+                "Install Chrome or set WEBSCENE_CHROMIUM_EXECUTABLE to a Chromium-compatible executable.");
+    }
+
+    private static string ResolveNodeExecutable()
+    {
+        var configured = Environment.GetEnvironmentVariable("WEBSCENE_NODE_EXECUTABLE");
+        if (!string.IsNullOrWhiteSpace(configured) && File.Exists(configured)) return configured;
+        return "node";
+    }
+
+    private static string RunProcess(string executable, IReadOnlyList<string> arguments)
+    {
+        var startInfo = new ProcessStartInfo(executable)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var argument in arguments) startInfo.ArgumentList.Add(argument);
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Could not start {executable}.");
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(120_000))
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException($"{executable} did not complete within 120 seconds.");
+        }
+        Task.WaitAll(standardOutput, standardError);
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException(
+                $"{executable} failed with exit code {process.ExitCode}: {standardError.Result.Trim()}");
+        return standardOutput.Result;
+    }
+
+    private sealed record WindowsConfiguration(
+        int Width,
+        int Height,
+        string Background,
+        string Foreground,
+        string Family,
+        WindowsGlyphCase[] Cases);
+
+    private sealed record WindowsGlyphCase(
+        string Id,
+        string Text,
+        float Size,
+        int Weight,
+        float X,
+        float Baseline);
+
+    private sealed record WindowsRunMetrics(
+        string Id,
+        uint[] Glyphs,
+        uint[] Clusters,
+        float[][] Positions,
+        float[] Advances,
+        float[][] Offsets,
+        float Width,
+        NativeTextRunFaceIdentity? FaceIdentity,
+        float DeviceScale,
+        float[] CanvasMatrix);
+
+    private sealed record WindowsPixelComparison(
+        string Source,
+        string Reference,
+        int OffsetX,
+        int OffsetY,
+        double MeanAbsoluteError,
+        double RootMeanSquareError,
+        int DifferingPixels,
+        int Samples);
+
+    private sealed record WindowsCaseReport(
+        string Id,
+        bool IsolatedGlyph,
+        List<WindowsPixelComparison> Comparisons,
+        WindowsRunMetrics DirectWrite);
+
+    private sealed record WindowsScaleReport(
+        float DeviceScaleFactor,
+        List<WindowsCaseReport> Cases,
+        WindowsScaleSummary Summary);
+
+    private sealed record WindowsScaleSummary(
+        double HarfBuzzMeanAbsoluteError,
+        double DirectWriteMeanAbsoluteError,
+        double MaximumPerCaseRegression,
+        double MaximumIsolatedGlyphRegression,
+        bool PassesPixelGate);
+
+    private sealed record WindowsDiagnosticReport(
+        DateTimeOffset GeneratedUtc,
+        string OperatingSystem,
+        string RuntimeIdentifier,
+        string ChromiumVersion,
+        string Command,
+        WindowsPerformanceReport Performance,
+        List<WindowsScaleReport> Scales);
+
+    private sealed record WindowsPerformanceReport(
+        string CaseId,
+        double ColdShapeMilliseconds,
+        long ColdAllocatedBytes,
+        long ColdManagedMemoryDelta,
+        double WarmShapeNanoseconds,
+        double WarmAllocatedBytes,
+        double DrawNanoseconds,
+        double DrawAllocatedBytes,
+        double HarfBuzzDrawNanoseconds,
+        double HarfBuzzDrawAllocatedBytes,
+        bool PassesBudget,
+        int MaximumCachedRuns,
+        int MaximumCachedFaces);
+
+    private readonly record struct PixelBox(int Left, int Top, int Right, int Bottom);
+
+    private readonly record struct ImageSlice(SKBitmap Bitmap, int OffsetY)
+    {
+        internal SKColor GetPixel(int x, int y)
+        {
+            var resolvedY = y + OffsetY;
+            return x >= 0 && x < Bitmap.Width && resolvedY >= 0 && resolvedY < Bitmap.Height
+                ? Bitmap.GetPixel(x, resolvedY)
+                : SKColors.Transparent;
+        }
+    }
+}

--- a/experiments/WebScene.GlyphDiagnostics/cases.json
+++ b/experiments/WebScene.GlyphDiagnostics/cases.json
@@ -1,9 +1,9 @@
 {
   "width": 720,
-  "height": 640,
+  "height": 1220,
   "background": "#202020",
   "foreground": "#d1d4dc",
-  "family": "-apple-system, BlinkMacSystemFont, sans-serif",
+  "family": "system-ui",
   "cases": [
     { "id": "capital-a", "text": "A", "size": 14, "weight": 400, "x": 24, "baseline": 38 },
     { "id": "lowercase-a", "text": "a", "size": 14, "weight": 400, "x": 24, "baseline": 88 },
@@ -16,6 +16,17 @@
     { "id": "mixed-weight-copy", "text": "It’ll open fully in 25 minutes.", "size": 14, "weight": 700, "x": 24, "baseline": 442 },
     { "id": "timeline", "text": "THU 09:30 16:00", "size": 12, "weight": 400, "x": 24, "baseline": 494 },
     { "id": "latin-shapes", "text": "Hamburgefontsiv", "size": 14, "weight": 400, "x": 24, "baseline": 546 },
-    { "id": "digits-punctuation", "text": "0123456789 .,:;’", "size": 14, "weight": 400, "x": 24, "baseline": 598 }
+    { "id": "digits-punctuation", "text": "0123456789 .,:;’", "size": 14, "weight": 400, "x": 24, "baseline": 598 },
+    { "id": "kerning-av", "text": "AV AVATAR", "size": 20, "weight": 400, "x": 24, "baseline": 650 },
+    { "id": "kerning-to", "text": "To Tomorrow", "size": 20, "weight": 400, "x": 24, "baseline": 702 },
+    { "id": "ligature-ffi", "text": "office affinity ffi", "size": 18, "weight": 400, "x": 24, "baseline": 754 },
+    { "id": "compact-price", "text": "$189.39 +0.52%", "size": 13, "weight": 600, "x": 24, "baseline": 806 },
+    { "id": "semibold-prose", "text": "Semibold system interface text", "size": 14, "weight": 600, "x": 24, "baseline": 858 },
+    { "id": "style-boundary-space", "text": "before after", "size": 14, "weight": 400, "x": 24, "baseline": 910 },
+    { "id": "complex-fallback", "text": "مرحبا दुनिया", "size": 18, "weight": 400, "x": 24, "baseline": 962 },
+    { "id": "emoji-fallback", "text": "Status ✅ 😀", "size": 18, "weight": 400, "x": 24, "baseline": 1014 },
+    { "id": "raster-size-16", "text": "AV To office ffi", "size": 16, "weight": 400, "x": 24, "baseline": 1066 },
+    { "id": "raster-size-17", "text": "AV To office ffi", "size": 17, "weight": 400, "x": 24, "baseline": 1118 },
+    { "id": "raster-size-18", "text": "AV To office ffi", "size": 18, "weight": 400, "x": 24, "baseline": 1170 }
   ]
 }

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_native_dom_layout.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_native_dom_layout.inc
@@ -2200,7 +2200,11 @@ void native_document::layout_children(dom_node& parent)
                 assigned.height,
                 containing.height);
             const auto flex_static_main_offset = [&] {
-                if (!flex_container) return horizontal ? cursor : 0.0F;
+                // An auto-inset out-of-flow child keeps the position its
+                // margin box would have occupied in normal flow. `cursor` is
+                // the inline-axis cursor for inline formatting and the
+                // block-axis cursor for ordinary block formatting.
+                if (!flex_container) return cursor;
                 if (parent.style.justify_content == justify_mode::center) {
                     return horizontal
                         ? (content.width - assigned.width) * 0.5F
@@ -2593,24 +2597,45 @@ void native_document::layout_children(dom_node& parent)
                 }
                 return std::nullopt;
             };
-            auto target_baseline = -std::numeric_limits<float>::infinity();
-            for (const auto* child : ordered_children) {
+            struct inline_baseline_item final {
+                dom_node* node{nullptr};
+                float baseline{0};
+            };
+            struct inline_baseline_line final {
+                float y{0};
+                float target{-std::numeric_limits<float>::infinity()};
+                std::vector<inline_baseline_item> items;
+            };
+            std::vector<inline_baseline_line> baseline_lines;
+            for (auto* child : ordered_children) {
+                const auto& vertical_align = child->style.textual().vertical_align;
                 if (!participates_in_flow(child) || !child->visible
-                    || child->style.textual().vertical_align == "middle") continue;
-                if (const auto baseline = inline_item_baseline(
-                        inline_item_baseline, *child)) {
-                    target_baseline = std::max(target_baseline, *baseline);
+                    || child->tag == "br"
+                    || vertical_align == "middle"
+                    || vertical_align == "bottom") continue;
+                const auto baseline = inline_item_baseline(
+                    inline_item_baseline, *child).value_or(
+                        child->layout.y + child->layout.height);
+                auto line = std::find_if(
+                    baseline_lines.begin(),
+                    baseline_lines.end(),
+                    [&](const auto& candidate) {
+                        return std::abs(candidate.y - child->layout.y) < 0.01F;
+                    });
+                if (line == baseline_lines.end()) {
+                    baseline_lines.push_back({child->layout.y, baseline, {{child, baseline}}});
+                } else {
+                    line->target = std::max(line->target, baseline);
+                    line->items.push_back({child, baseline});
                 }
             }
-            if (std::isfinite(target_baseline)) {
-                for (auto* child : ordered_children) {
-                    if (!participates_in_flow(child) || !child->visible
-                        || child->style.textual().vertical_align == "middle") continue;
-                    const auto baseline = inline_item_baseline(
-                        inline_item_baseline, *child).value_or(
-                            child->layout.y + child->layout.height);
+            for (const auto& line : baseline_lines) {
+                if (!std::isfinite(line.target)) continue;
+                for (const auto& item : line.items) {
                     shift_subtree_y(
-                        shift_subtree_y, *child, target_baseline - baseline);
+                        shift_subtree_y,
+                        *item.node,
+                        line.target - item.baseline);
                 }
             }
         }

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_css_layout_tests.inc
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_css_layout_tests.inc
@@ -992,6 +992,43 @@ void test_empty_inline_element_does_not_stretch_cross_size(webscene_engine* engi
         "an empty inline element stretched to its containing block: " + result);
 }
 
+void test_br_keeps_inline_block_on_its_own_line(webscene_engine* engine)
+{
+    const auto result = evaluate(engine, R"JS(
+        (() => {
+          document.body.innerHTML = `
+            <style>
+              div { font-size: 10px; line-height: 1; }
+              .blue {
+                display: inline-block;
+                vertical-align: bottom;
+                width: 10px;
+                height: 10px;
+              }
+            </style>
+            <div>x<span class="blue"></span></div>
+            <div>x<br><span class="blue"></span></div>`;
+          const origin = document.body.getBoundingClientRect();
+          const rect = element => {
+            const value = element.getBoundingClientRect();
+            return [
+              value.x - origin.x,
+              value.y - origin.y,
+              value.width,
+              value.height
+            ];
+          };
+          return {
+            rows: Array.from(document.querySelectorAll('div')).map(rect),
+            boxes: Array.from(document.querySelectorAll('.blue')).map(rect)
+          };
+        })()
+    )JS", "native-br-inline-block-lines.js");
+    require(
+        result == R"JSON({"rows":[[0,0,320,10],[0,10,320,20]],"boxes":[[5.5,0,10,10],[0,20,10,10]]})JSON",
+        "baseline alignment moved an inline-block across a forced line break: " + result);
+}
+
 void test_hover_invalidation_updates_functional_and_sibling_subjects(
     webscene_engine* engine)
 {

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_tests.cpp
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_tests.cpp
@@ -307,6 +307,7 @@ int main()
     test_complex_is_specificity_ignores_non_element_siblings(engine);
     test_inline_relative_line_height_uses_cascaded_font_size(engine);
     test_empty_inline_element_does_not_stretch_cross_size(engine);
+    test_br_keeps_inline_block_on_its_own_line(engine);
     test_hover_invalidation_updates_functional_and_sibling_subjects(engine);
     test_hover_moves_between_block_and_display_contents_child(engine);
     test_single_fractional_grid_track_stays_one_column(engine);

--- a/font-rendering-plan.md
+++ b/font-rendering-plan.md
@@ -46,6 +46,20 @@ selection, shaping/positioning, and rasterization.
   per run to HarfBuzz/Skia. `WEBSCENE_TEXT_POSITIONING=harfbuzz` retains the previous path
   as a before/after and rollback control. Chromium-compatible macOS font flags are the
   default; `WEBSCENE_TEXT_RASTERIZATION=current` retains the former profile.
+- The Windows x64 diagnostic now captures HarfBuzz/Skia, DirectWrite-positioned/Skia-
+  painted, Avalonia text-control, and Chromium canvas/DOM output at 100%, 125%, 150%,
+  and 200%. On the current Windows 11/Chrome-for-Testing 152 oracle, verified regular-weight
+  DirectWrite positioning plus the proven 100%-scale grayscale Skia profile improves
+  corpus pixel error at all four scales without a material per-case or isolated-glyph
+  regression. Semibold and bold showed fractional-scale regressions and remain
+  fallback-only. A current-source Windows native engine (DLL SHA-256
+  `0FD7FAA086085D88153E57FD55502DD1EB27AC785BC376D496B4CD413385C264`) passes all
+  four native tests. Its required WPT runs produce identical DirectWrite and HarfBuzz
+  results: 115/115 documents and 440/440 subtests pass, including
+  `contracts/font-shaping-and-inline-layout.html`. The complete managed solution passes
+  on both target frameworks, including the Windows-safe inspector discovery coverage.
+  Automatic Windows selection is enabled for eligible runs; explicit `harfbuzz`,
+  `legacy`, `off`, or `0` values remain the rollback control.
 
 ## Architecture
 
@@ -372,9 +386,13 @@ systems and installed font versions.
 
 ### Phase 2: Windows
 
-- Correct `system-ui` resolution without changing `sans-serif` semantics.
-- Add the DirectWrite diagnostic and scaling matrix.
-- Implement and enable DirectWrite positioning only for demonstrated wins.
+- [x] Correct `system-ui` resolution without changing `sans-serif` semantics.
+- [x] Add the DirectWrite diagnostic and 100%, 125%, 150%, and 200% scaling matrix.
+- [x] Implement bounded whole-run DirectWrite positioning with exact DirectWrite/Skia
+  face and glyph identity checks, shared measurement/painting, and per-run fallback.
+- [x] Verify pixel, fallback, WPT, managed, native, and performance gates, then enable
+  DirectWrite automatically for eligible Windows runs while preserving HarfBuzz as the
+  explicit rollback path.
 
 ### Phase 3: Linux
 

--- a/samples/NativeTradingViewTerminal/README.md
+++ b/samples/NativeTradingViewTerminal/README.md
@@ -13,9 +13,9 @@ dotnet run --project samples/NativeTradingViewTerminal \
   -- --native-library /absolute/path/to/libwebscene_native_engine.dylib
 ```
 
-On macOS, platform CoreText positioning for eligible system-font runs is enabled by
-default while Skia continues to paint the glyphs. Launch separate processes with the
-following modes for a direct before/after comparison:
+Platform positioning for eligible system-font runs is enabled by default while Skia
+continues to paint the glyphs: CoreText on macOS and DirectWrite on Windows. Launch
+separate processes with the following modes for a direct before/after comparison:
 
 ```bash
 WEBSCENE_TEXT_POSITIONING=harfbuzz dotnet run \
@@ -27,9 +27,12 @@ WEBSCENE_TEXT_POSITIONING=coretext dotnet run \
   --native-library /absolute/path/to/libwebscene_native_engine.dylib
 ```
 
-`harfbuzz`, `legacy`, `off`, or `0` selects the previous renderer. An unset value,
-`auto`, or `coretext` enables the platform service. Unsupported fonts, scripts,
-styles, features, or glyph identities always fall back to HarfBuzz/Skia per run.
+On Windows, use `WEBSCENE_TEXT_POSITIONING=directwrite` for an explicit candidate run.
+
+`harfbuzz`, `legacy`, `off`, or `0` selects the previous renderer. An unset value or
+`auto` enables the platform service; `coretext` and `directwrite` select their matching
+platform candidate explicitly. Unsupported fonts, scripts, styles, features, or glyph
+identities always fall back to HarfBuzz/Skia per run.
 
 The macOS default also applies Chromium-compatible Skia font flags. Use
 `WEBSCENE_TEXT_RASTERIZATION=current` to retain the former rasterization profile or

--- a/scripts/build-native-engine-runtime.ps1
+++ b/scripts/build-native-engine-runtime.ps1
@@ -5,6 +5,7 @@ param(
     [string] $Rid,
 
     [string] $Output,
+    [string] $BuildDirectory,
     [string] $PackageVersion,
     [string] $V8Root,
     [string] $V8Workspace,
@@ -190,7 +191,11 @@ if (-not $hasRequestedPartitionAlloc) {
     throw "The V8 SDK at '$v8OutputRoot' does not match requested PartitionAlloc=$partitionAllocValue."
 }
 
-$buildDir = Join-Path $repoRoot "artifacts/native-engine-runtime-build/$Rid$buildVariant"
+$buildDir = if ([string]::IsNullOrWhiteSpace($BuildDirectory)) {
+    Join-Path $repoRoot "artifacts/native-engine-runtime-build/$Rid$buildVariant"
+} else {
+    $BuildDirectory
+}
 & cmake -S (Join-Path $repoRoot "experiments/WebScene.NativeEngine.Probe") -B $buildDir `
     -A $(if ($cpu -eq "arm64") { "ARM64" } else { "x64" }) `
     -DWEBSCENE_NATIVE_ENGINE_ENABLE_V8=ON `

--- a/src/WebScene.Backend.Avalonia/NativeCanvasSceneRenderer.cs
+++ b/src/WebScene.Backend.Avalonia/NativeCanvasSceneRenderer.cs
@@ -717,7 +717,7 @@ internal sealed unsafe class NativeCanvasSceneRenderer
             NumberStyles.Float,
             CultureInfo.InvariantCulture,
             out var parsedLineHeight)
-            && parsedLineHeight > 0
+            && parsedLineHeight >= 0
             ? parsedLineHeight
             : fontSize * 1.2f;
         var fontWeight = int.TryParse(
@@ -791,8 +791,7 @@ internal sealed unsafe class NativeCanvasSceneRenderer
         var baseline = command.Y
             + Math.Max(0, (command.Height - contentHeight) * 0.5f)
             + (contentHeight - glyphHeight) * 0.5f
-            - metrics.Ascent
-            + (parsedLineHeight == 0 ? 3f : 0f);
+            - metrics.Ascent;
         NativeTextShaping.DrawShapedText(
             canvas,
             shaper,

--- a/src/WebScene.Backend.Avalonia/NativeTextRunPositioning.cs
+++ b/src/WebScene.Backend.Avalonia/NativeTextRunPositioning.cs
@@ -15,12 +15,24 @@ internal readonly record struct NativeTextRunPositionRequest(
     SKFontStyleSlant Slant,
     uint FeatureFlags,
     uint[] ExpectedGlyphs,
-    NativeTextShaping.WebTypefaceRegistry? WebTypefaces);
+    NativeTextShaping.WebTypefaceRegistry? WebTypefaces,
+    SKTypeface? Typeface = null);
+
+internal sealed record NativeTextRunFaceIdentity(
+    string FamilyName,
+    int Weight,
+    int Stretch,
+    int Style,
+    string FontTableFingerprint);
 
 internal sealed record NativePositionedTextRun(
     ushort[] Glyphs,
     SKPoint[] Positions,
-    float AdvanceWidth);
+    float AdvanceWidth,
+    uint[]? Clusters = null,
+    float[]? Advances = null,
+    SKPoint[]? Offsets = null,
+    NativeTextRunFaceIdentity? FaceIdentity = null);
 
 internal interface INativeTextRunPositioner
 {
@@ -37,13 +49,22 @@ internal sealed class DefaultNativeTextRunPositioner : INativeTextRunPositioner
     internal static readonly DefaultNativeTextRunPositioner Instance = new();
 
     private readonly bool _platformPositioningEnabled;
+    private readonly bool _windowsDirectWriteEnabled;
     private readonly MacCoreTextRunPositioner _macCoreText = new();
+    private readonly WindowsDirectWriteRunPositioner _windowsDirectWrite = new();
 
     private DefaultNativeTextRunPositioner()
+        : this(Environment.GetEnvironmentVariable(ModeEnvironmentVariable))
     {
-        var mode = Environment.GetEnvironmentVariable(ModeEnvironmentVariable);
-        _platformPositioningEnabled = mode?.Trim().ToLowerInvariant()
+    }
+
+    internal DefaultNativeTextRunPositioner(string? mode)
+    {
+        var normalizedMode = mode?.Trim().ToLowerInvariant();
+        _platformPositioningEnabled = normalizedMode
             is not ("harfbuzz" or "legacy" or "off" or "0");
+        _windowsDirectWriteEnabled = string.IsNullOrEmpty(normalizedMode)
+            || normalizedMode is "auto" or "automatic" or "directwrite";
     }
 
     public bool TryPosition(
@@ -51,7 +72,9 @@ internal sealed class DefaultNativeTextRunPositioner : INativeTextRunPositioner
         out NativePositionedTextRun run)
     {
         if (IsEligible(in request)
-            && _macCoreText.TryPosition(in request, out run))
+            && (OperatingSystem.IsWindows()
+                ? _windowsDirectWrite.TryPosition(in request, out run)
+                : _macCoreText.TryPosition(in request, out run)))
         {
             return true;
         }
@@ -64,7 +87,10 @@ internal sealed class DefaultNativeTextRunPositioner : INativeTextRunPositioner
     }
 
     public bool IsEligible(in NativeTextRunPositionRequest request)
-        => _platformPositioningEnabled && _macCoreText.IsEligible(in request);
+        => _platformPositioningEnabled
+            && (OperatingSystem.IsWindows()
+                ? _windowsDirectWriteEnabled && _windowsDirectWrite.IsEligible(in request)
+                : _macCoreText.IsEligible(in request));
 }
 
 internal sealed class MacCoreTextRunPositioner : INativeTextRunPositioner

--- a/src/WebScene.Backend.Avalonia/NativeTextShaping.cs
+++ b/src/WebScene.Backend.Avalonia/NativeTextShaping.cs
@@ -236,11 +236,17 @@ public static class NativeTextShaping
             {
                 var family = rawFamily.Trim('"', '\'');
                 var genericFamily = family.ToLowerInvariant();
-                if (genericFamily is "-apple-system" or "blinkmacsystemfont" or "system-ui"
-                    or "sans-serif")
+                if (genericFamily is "-apple-system" or "blinkmacsystemfont")
                 {
-                    family = OperatingSystem.IsMacOS() ? ".AppleSystemUIFont" : "Arial";
+                    if (OperatingSystem.IsMacOS()) family = ".AppleSystemUIFont";
+                    else continue;
                 }
+                else if (genericFamily == "system-ui")
+                    family = OperatingSystem.IsMacOS()
+                        ? ".AppleSystemUIFont"
+                        : OperatingSystem.IsWindows() ? "Segoe UI" : "sans-serif";
+                else if (genericFamily == "sans-serif")
+                    family = OperatingSystem.IsMacOS() ? "Helvetica" : "Arial";
                 else if (genericFamily == "serif") family = "Times New Roman";
                 else if (genericFamily == "monospace") family = OperatingSystem.IsMacOS() ? "Menlo" : "Consolas";
 
@@ -542,7 +548,8 @@ public static class NativeTextShaping
             slant,
             featureFlags,
             [],
-            registry);
+            registry,
+            shaper.Typeface);
         if (!TextRunPositioner.IsEligible(in request)) return false;
         var shaped = shaper.Shape(text, 0, 0, paint);
         if (shaped.Codepoints.Length == 0
@@ -779,7 +786,13 @@ public static class NativeTextShaping
     {
         using var font = paint.ToFont();
         font.Typeface = shaper.Typeface;
-        ApplyFontRasterizationProfile(font, deviceScaleFactor, rasterizationMode);
+        ApplyFontRasterizationProfile(
+            font,
+            deviceScaleFactor,
+            ResolvePositionedRunRasterizationMode(
+                positionedRun,
+                deviceScaleFactor,
+                rasterizationMode));
         using var builder = new SKTextBlobBuilder();
         var run = builder.AllocatePositionedRun(font, positionedRun.Glyphs.Length);
         positionedRun.Glyphs.AsSpan().CopyTo(run.GetGlyphSpan());
@@ -1005,6 +1018,61 @@ public static class NativeTextShaping
             {
                 return false;
             }
+        }
+        return false;
+    }
+
+    internal static NativeFontRasterizationMode? ResolvePositionedRunRasterizationMode(
+        NativePositionedTextRun positionedRun,
+        float deviceScaleFactor,
+        NativeFontRasterizationMode? requestedMode)
+    {
+        if (requestedMode is not null
+            || !OperatingSystem.IsWindows()
+            || positionedRun.FaceIdentity is null
+            || !float.IsFinite(deviceScaleFactor)
+            || deviceScaleFactor > 1f
+            || !string.IsNullOrWhiteSpace(ConfiguredRasterizationValue))
+        {
+            return requestedMode;
+        }
+        // At 100% scaling Chromium's Windows canvas/DOM oracle uses grayscale
+        // antialiasing with subpixel positioning and linear metrics. Higher
+        // scale profiles retain the host defaults demonstrated by their own
+        // oracle rows. Keep this attached to verified DirectWrite runs only;
+        // HarfBuzz fallback and explicit process settings remain authoritative.
+        return NativeFontRasterizationMode.ChromiumGrayscale;
+    }
+
+    internal static bool UsesWindowsSystemUiMetrics(
+        string familyList,
+        WebTypefaceRegistry? registry)
+    {
+        if (registry is null
+            && familyList.Equals("system-ui", StringComparison.OrdinalIgnoreCase)
+            && !WebTypefaces.ContainsKey("system-ui"))
+        {
+            return true;
+        }
+        foreach (var rawFamily in familyList.Split(
+                     ',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+        {
+            var family = rawFamily.Trim('"', '\'');
+            if (registry?.Contains(family) == true
+                || WebTypefaces.ContainsKey(family))
+            {
+                return false;
+            }
+            if (family.Equals("system-ui", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+            if (family.Equals("-apple-system", StringComparison.OrdinalIgnoreCase)
+                || family.Equals("BlinkMacSystemFont", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            return false;
         }
         return false;
     }

--- a/src/WebScene.Backend.Avalonia/WindowsDirectWriteRunPositioner.cs
+++ b/src/WebScene.Backend.Avalonia/WindowsDirectWriteRunPositioner.cs
@@ -1,0 +1,504 @@
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using SkiaSharp;
+
+#if WEBSCENE_UNO
+namespace WebScene.Backends.Uno.Native;
+#else
+namespace WebScene.Backends.Avalonia.Native;
+#endif
+
+internal sealed unsafe class WindowsDirectWriteRunPositioner : INativeTextRunPositioner
+{
+    private const int MaximumCachedRuns = 2048;
+    private const int MaximumCachedFaces = 64;
+    private const int MaximumEligibleTextLength = 4096;
+    private const int ENotSufficientBuffer = unchecked((int)0x8007007A);
+    private static readonly Guid FactoryInterfaceId =
+        new("B859EE5A-D838-4B5B-A2E8-1ADC7D93DB48");
+    private static readonly Lazy<DirectWriteState> SharedState =
+        new(CreateState, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private readonly object _cacheGate = new();
+    private readonly Dictionary<RunKey, NativePositionedTextRun> _runs = [];
+    private readonly Queue<RunKey> _runOrder = [];
+    private readonly Dictionary<FaceKey, FaceState> _faces = [];
+
+    public bool IsEligible(in NativeTextRunPositionRequest request)
+        => OperatingSystem.IsWindows()
+            && request.Typeface is not null
+            && request.Slant == SKFontStyleSlant.Upright
+            && request.FeatureFlags == 0
+            // The Windows oracle currently proves regular weight at every
+            // required scale. Semibold and bold remain visible in the corpus
+            // but fall back until their fractional-scale regressions are gone.
+            && request.FontWeight == 400
+            && request.Text.Length is > 0 and <= MaximumEligibleTextLength
+            && NativeTextShaping.UsesWindowsSystemUiMetrics(
+                request.FamilyList,
+                request.WebTypefaces)
+            && NativeTextShaping.UsesMacSystemUiPlatformAdvances(request.Text);
+
+    public bool TryPosition(
+        in NativeTextRunPositionRequest request,
+        out NativePositionedTextRun run)
+    {
+        run = null!;
+        if (!IsEligible(in request)) return false;
+
+        var typeface = request.Typeface!;
+        var key = new RunKey(
+            request.Text,
+            request.FontSize,
+            request.FontWeight,
+            request.FamilyList);
+        lock (_cacheGate)
+        {
+            if (_runs.TryGetValue(key, out var cached))
+            {
+                if (!GlyphsMatch(cached.Glyphs, request.ExpectedGlyphs)) return false;
+                run = cached;
+                return true;
+            }
+        }
+
+        NativePositionedTextRun positioned;
+        try
+        {
+            using var face = GetFace(typeface, request.FontWeight);
+            positioned = Shape(
+                SharedState.Value.Analyzer,
+                face.State,
+                request.Text,
+                request.FontSize);
+        }
+        catch (Exception error) when (error is not OutOfMemoryException)
+        {
+            return false;
+        }
+        if (!GlyphsMatch(positioned.Glyphs, request.ExpectedGlyphs)) return false;
+
+        lock (_cacheGate)
+        {
+            if (_runs.TryGetValue(key, out var cached))
+            {
+                run = cached;
+                return GlyphsMatch(cached.Glyphs, request.ExpectedGlyphs);
+            }
+            if (_runs.Count >= MaximumCachedRuns)
+            {
+                _runs.Remove(_runOrder.Dequeue());
+            }
+            _runs.Add(key, positioned);
+            _runOrder.Enqueue(key);
+        }
+        run = positioned;
+        return true;
+    }
+
+    private FaceLease GetFace(SKTypeface typeface, int requestedWeight)
+    {
+        var family = typeface.FamilyName
+            ?? throw new InvalidOperationException("Skia did not expose a font family name.");
+        var key = new FaceKey(family, requestedWeight);
+        lock (_cacheGate)
+        {
+            if (_faces.TryGetValue(key, out var cached))
+            {
+                ValidateSkiaIdentity(cached, typeface);
+                return new FaceLease(cached, release: false);
+            }
+        }
+
+        var created = CreateFace(SharedState.Value.Collection, family, requestedWeight);
+        try
+        {
+            ValidateSkiaIdentity(created, typeface);
+            lock (_cacheGate)
+            {
+                if (_faces.TryGetValue(key, out var cached))
+                {
+                    ValidateSkiaIdentity(cached, typeface);
+                    Release(created.Face);
+                    return new FaceLease(cached, release: false);
+                }
+                if (_faces.Count < MaximumCachedFaces)
+                {
+                    _faces.Add(key, created);
+                    return new FaceLease(created, release: false);
+                }
+            }
+            return new FaceLease(created, release: true);
+        }
+        catch
+        {
+            Release(created.Face);
+            throw;
+        }
+    }
+
+    private static DirectWriteState CreateState()
+    {
+        var factoryId = FactoryInterfaceId;
+        ThrowIfFailed(DWriteCreateFactory(0, in factoryId, out var factory));
+        IntPtr collection = IntPtr.Zero;
+        IntPtr analyzer = IntPtr.Zero;
+        try
+        {
+            var factoryVtable = GetVtable(factory);
+            ThrowIfFailed(((delegate* unmanaged[Stdcall]<void*, void**, int, int>)factoryVtable[3])(
+                (void*)factory,
+                (void**)&collection,
+                0));
+            ThrowIfFailed(((delegate* unmanaged[Stdcall]<void*, void**, int>)factoryVtable[21])(
+                (void*)factory,
+                (void**)&analyzer));
+            return new DirectWriteState(factory, collection, analyzer);
+        }
+        catch
+        {
+            Release(analyzer);
+            Release(collection);
+            Release(factory);
+            throw;
+        }
+    }
+
+    private static FaceState CreateFace(
+        IntPtr collection,
+        string familyName,
+        int requestedWeight)
+    {
+        IntPtr family = IntPtr.Zero;
+        IntPtr font = IntPtr.Zero;
+        IntPtr face = IntPtr.Zero;
+        try
+        {
+            uint familyIndex;
+            int exists;
+            fixed (char* familyNamePointer = familyName)
+            {
+                ThrowIfFailed(((delegate* unmanaged[Stdcall]<void*, char*, uint*, int*, int>)
+                    GetVtable(collection)[5])(
+                    (void*)collection,
+                    familyNamePointer,
+                    &familyIndex,
+                    &exists));
+            }
+            if (exists == 0)
+            {
+                throw new InvalidOperationException(
+                    $"DirectWrite did not find the Skia family '{familyName}'.");
+            }
+            ThrowIfFailed(((delegate* unmanaged[Stdcall]<void*, uint, void**, int>)
+                GetVtable(collection)[4])((void*)collection, familyIndex, (void**)&family));
+            ThrowIfFailed(((delegate* unmanaged[Stdcall]<void*, uint, uint, uint, void**, int>)
+                GetVtable(family)[7])(
+                (void*)family,
+                checked((uint)requestedWeight),
+                5,
+                0,
+                (void**)&font));
+            var fontVtable = GetVtable(font);
+            var actualWeight = checked((int)((delegate* unmanaged[Stdcall]<void*, uint>)
+                fontVtable[4])((void*)font));
+            var stretch = checked((int)((delegate* unmanaged[Stdcall]<void*, uint>)
+                fontVtable[5])((void*)font));
+            var style = checked((int)((delegate* unmanaged[Stdcall]<void*, uint>)
+                fontVtable[6])((void*)font));
+            ThrowIfFailed(((delegate* unmanaged[Stdcall]<void*, void**, int>)fontVtable[13])(
+                (void*)font,
+                (void**)&face));
+            var fingerprint = GetDirectWriteFingerprint(face);
+            return new FaceState(
+                face,
+                new NativeTextRunFaceIdentity(
+                    familyName,
+                    actualWeight,
+                    stretch,
+                    style,
+                    fingerprint));
+        }
+        finally
+        {
+            Release(font);
+            Release(family);
+        }
+    }
+
+    private static void ValidateSkiaIdentity(FaceState face, SKTypeface typeface)
+    {
+        if (!string.Equals(
+                face.Identity.FamilyName,
+                typeface.FamilyName,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("DirectWrite and Skia selected different families.");
+        }
+        var skiaFingerprint = GetSkiaFingerprint(typeface);
+        if (!string.Equals(
+                face.Identity.FontTableFingerprint,
+                skiaFingerprint,
+                StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "DirectWrite and Skia selected different physical font faces.");
+        }
+    }
+
+    private static NativePositionedTextRun Shape(
+        IntPtr analyzer,
+        FaceState face,
+        string text,
+        float fontSize)
+    {
+        var glyphCapacity = checked(text.Length * 2 + 16);
+        while (true)
+        {
+            var clusterMap = new ushort[text.Length];
+            var textProperties = new ushort[text.Length];
+            var glyphs = new ushort[glyphCapacity];
+            var glyphProperties = new ushort[glyphCapacity];
+            uint actualGlyphCount = 0;
+            var analysis = new ScriptAnalysis(0, 0);
+            int result;
+            fixed (char* textPointer = text)
+            fixed (ushort* clusterPointer = clusterMap)
+            fixed (ushort* textPropertiesPointer = textProperties)
+            fixed (ushort* glyphPointer = glyphs)
+            fixed (ushort* glyphPropertiesPointer = glyphProperties)
+            {
+                result = ((delegate* unmanaged[Stdcall]<
+                    void*, char*, uint, void*, int, int, ScriptAnalysis*, char*, void*,
+                    void*, uint*, uint, uint, ushort*, ushort*, ushort*, ushort*, uint*, int>)
+                    GetVtable(analyzer)[7])(
+                    (void*)analyzer,
+                    textPointer,
+                    checked((uint)text.Length),
+                    (void*)face.Face,
+                    0,
+                    0,
+                    &analysis,
+                    null,
+                    null,
+                    null,
+                    null,
+                    0,
+                    checked((uint)glyphCapacity),
+                    clusterPointer,
+                    textPropertiesPointer,
+                    glyphPointer,
+                    glyphPropertiesPointer,
+                    &actualGlyphCount);
+            }
+            if (result == ENotSufficientBuffer)
+            {
+                glyphCapacity = checked(glyphCapacity * 2);
+                continue;
+            }
+            ThrowIfFailed(result);
+
+            Array.Resize(ref glyphs, checked((int)actualGlyphCount));
+            Array.Resize(ref glyphProperties, glyphs.Length);
+            var advances = new float[glyphs.Length];
+            var nativeOffsets = new GlyphOffset[glyphs.Length];
+            fixed (char* textPointer = text)
+            fixed (ushort* clusterPointer = clusterMap)
+            fixed (ushort* textPropertiesPointer = textProperties)
+            fixed (ushort* glyphPointer = glyphs)
+            fixed (ushort* glyphPropertiesPointer = glyphProperties)
+            fixed (float* advancesPointer = advances)
+            fixed (GlyphOffset* offsetsPointer = nativeOffsets)
+            {
+                ThrowIfFailed(((delegate* unmanaged[Stdcall]<
+                    void*, char*, ushort*, ushort*, uint, ushort*, ushort*, uint, void*, float,
+                    int, int, ScriptAnalysis*, char*, void*, uint*, uint, float*, GlyphOffset*, int>)
+                    GetVtable(analyzer)[8])(
+                    (void*)analyzer,
+                    textPointer,
+                    clusterPointer,
+                    textPropertiesPointer,
+                    checked((uint)text.Length),
+                    glyphPointer,
+                    glyphPropertiesPointer,
+                    actualGlyphCount,
+                    (void*)face.Face,
+                    fontSize,
+                    0,
+                    0,
+                    &analysis,
+                    null,
+                    null,
+                    null,
+                    0,
+                    advancesPointer,
+                    offsetsPointer));
+            }
+
+            var positions = new SKPoint[glyphs.Length];
+            var offsets = new SKPoint[glyphs.Length];
+            var x = 0f;
+            for (var index = 0; index < glyphs.Length; index++)
+            {
+                offsets[index] = new SKPoint(
+                    nativeOffsets[index].AdvanceOffset,
+                    -nativeOffsets[index].AscenderOffset);
+                positions[index] = new SKPoint(
+                    x + offsets[index].X,
+                    offsets[index].Y);
+                x += advances[index];
+            }
+            if (!float.IsFinite(x) || x < 0)
+            {
+                throw new InvalidOperationException("DirectWrite returned an invalid run width.");
+            }
+            return new NativePositionedTextRun(
+                glyphs,
+                positions,
+                x,
+                ResolveGlyphClusters(clusterMap, glyphs.Length),
+                advances,
+                offsets,
+                face.Identity);
+        }
+    }
+
+    private static uint[] ResolveGlyphClusters(ushort[] textClusters, int glyphCount)
+    {
+        var clusters = Enumerable.Repeat(uint.MaxValue, glyphCount).ToArray();
+        for (var textIndex = 0; textIndex < textClusters.Length; textIndex++)
+        {
+            var glyphIndex = textClusters[textIndex];
+            if (glyphIndex < clusters.Length && clusters[glyphIndex] == uint.MaxValue)
+            {
+                clusters[glyphIndex] = checked((uint)textIndex);
+            }
+        }
+        uint previous = 0;
+        for (var index = 0; index < clusters.Length; index++)
+        {
+            if (clusters[index] == uint.MaxValue) clusters[index] = previous;
+            else previous = clusters[index];
+        }
+        return clusters;
+    }
+
+    private static string GetDirectWriteFingerprint(IntPtr face)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        AppendDirectWriteTable(hash, face, 0x64616568); // head
+        AppendDirectWriteTable(hash, face, 0x656D616E); // name
+        return Convert.ToHexString(hash.GetHashAndReset());
+    }
+
+    private static void AppendDirectWriteTable(
+        IncrementalHash hash,
+        IntPtr face,
+        uint directWriteTag)
+    {
+        void* data = null;
+        uint size = 0;
+        void* context = null;
+        int exists = 0;
+        ThrowIfFailed(((delegate* unmanaged[Stdcall]<
+            void*, uint, void**, uint*, void**, int*, int>)GetVtable(face)[12])(
+            (void*)face,
+            directWriteTag,
+            &data,
+            &size,
+            &context,
+            &exists));
+        try
+        {
+            if (exists == 0 || data == null || size == 0)
+                throw new InvalidOperationException("DirectWrite did not expose a required font table.");
+            hash.AppendData(new ReadOnlySpan<byte>(data, checked((int)size)));
+        }
+        finally
+        {
+            if (context != null)
+            {
+                ((delegate* unmanaged[Stdcall]<void*, void*, void>)GetVtable(face)[13])(
+                    (void*)face,
+                    context);
+            }
+        }
+    }
+
+    private static string GetSkiaFingerprint(SKTypeface typeface)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        AppendSkiaTable(hash, typeface, 0x68656164); // head
+        AppendSkiaTable(hash, typeface, 0x6E616D65); // name
+        return Convert.ToHexString(hash.GetHashAndReset());
+    }
+
+    private static void AppendSkiaTable(
+        IncrementalHash hash,
+        SKTypeface typeface,
+        uint skiaTag)
+    {
+        var data = typeface.GetTableData(skiaTag);
+        if (data is null || data.Length == 0)
+            throw new InvalidOperationException("Skia did not expose a required font table.");
+        hash.AppendData(data);
+    }
+
+    private static bool GlyphsMatch(ushort[] actual, uint[] expected)
+    {
+        if (actual.Length != expected.Length) return false;
+        for (var index = 0; index < actual.Length; index++)
+        {
+            if (actual[index] != expected[index]) return false;
+        }
+        return true;
+    }
+
+    private static void ThrowIfFailed(int result)
+    {
+        if (result < 0) Marshal.ThrowExceptionForHR(result);
+    }
+
+    private static void** GetVtable(IntPtr instance)
+        => instance == IntPtr.Zero
+            ? throw new InvalidOperationException("DirectWrite returned a null COM interface.")
+            : *(void***)instance;
+
+    private static void Release(IntPtr instance)
+    {
+        if (instance == IntPtr.Zero) return;
+        ((delegate* unmanaged[Stdcall]<void*, uint>)GetVtable(instance)[2])((void*)instance);
+    }
+
+    [DllImport("dwrite.dll", ExactSpelling = true)]
+    private static extern int DWriteCreateFactory(
+        uint factoryType,
+        in Guid interfaceId,
+        out IntPtr factory);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private readonly record struct ScriptAnalysis(ushort Script, ushort Shapes);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private readonly record struct GlyphOffset(float AdvanceOffset, float AscenderOffset);
+
+    private readonly record struct RunKey(
+        string Text,
+        float FontSize,
+        int FontWeight,
+        string FamilyName);
+
+    private readonly record struct FaceKey(string FamilyName, int FontWeight);
+    private sealed record DirectWriteState(IntPtr Factory, IntPtr Collection, IntPtr Analyzer);
+    private sealed record FaceState(IntPtr Face, NativeTextRunFaceIdentity Identity);
+
+    private readonly struct FaceLease(FaceState state, bool release) : IDisposable
+    {
+        internal FaceState State { get; } = state;
+
+        public void Dispose()
+        {
+            if (release) Release(State.Face);
+        }
+    }
+}

--- a/src/WebScene.Backend.Uno/WebScene.Backend.Uno.csproj
+++ b/src/WebScene.Backend.Uno/WebScene.Backend.Uno.csproj
@@ -39,6 +39,7 @@
     <Compile Include="..\WebScene.Backend.Avalonia\NativeSceneRuntime.cs" Link="NativeSceneRuntime.cs" />
     <Compile Include="..\WebScene.Backend.Avalonia\NativeTextShaping.cs" Link="NativeTextShaping.cs" />
     <Compile Include="..\WebScene.Backend.Avalonia\NativeTextRunPositioning.cs" Link="NativeTextRunPositioning.cs" />
+    <Compile Include="..\WebScene.Backend.Avalonia\WindowsDirectWriteRunPositioner.cs" Link="WindowsDirectWriteRunPositioner.cs" />
     <Compile Include="..\WebScene.Backend.Avalonia\NativeInteropCallbacks.cs" Link="NativeInteropCallbacks.cs" />
     <Compile Include="..\WebScene.Backend.Avalonia\NativeInteropResult.cs" Link="NativeInteropResult.cs" />
     <Compile Include="..\WebScene.Backend.Avalonia\NativeInteropTransport.cs" Link="NativeInteropTransport.cs" />

--- a/src/WebScene.Diagnostics.Cdp/README.md
+++ b/src/WebScene.Diagnostics.Cdp/README.md
@@ -43,11 +43,12 @@ used. Set `Port = 0` to request an ephemeral loopback port, then log or read
 `inspector.DiscoveryUri`/`inspector.BoundPort` after `StartAsync`.
 
 Inspector hosting is disabled unless `Enabled = true`. Loopback is the default;
-non-loopback bindings require `AllowRemoteConnections = true`. Remote discovery
-requests and WebSocket clients must present the generated token as a `token`
-query parameter or `Authorization: Bearer` header; unauthenticated remote
-discovery never publishes the bearer secret. Chrome DevTools origins are the
-only non-empty origins accepted.
+non-loopback bindings require `AllowRemoteConnections = true`. Enabling that
+remote mode also protects discovery when the selected address is loopback.
+Remote-mode discovery requests and all WebSocket clients must present the
+generated token as a `token` query parameter or `Authorization: Bearer` header;
+unauthenticated discovery never publishes the bearer secret. Chrome DevTools
+origins are the only non-empty origins accepted.
 
 Inspector sessions require WebScene's normal dedicated-isolate mode. The
 opt-in `WEBSCENE_V8_SHARED_ISOLATE` lane intentionally reports the inspector as

--- a/src/WebScene.Diagnostics.Cdp/WebSceneV8InspectorHost.cs
+++ b/src/WebScene.Diagnostics.Cdp/WebSceneV8InspectorHost.cs
@@ -299,7 +299,7 @@ public sealed class WebSceneV8InspectorHost : IAsyncDisposable
         }
         var isDiscoveryRequest = path is "/json/version" or "/json" or "/json/list";
         if (isDiscoveryRequest
-            && !IPAddress.IsLoopback(_options.Address)
+            && _options.AllowRemoteConnections
             && !IsAuthorized(context.Request))
         {
             context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;

--- a/tests/WebPlatformSubset/runner/ChromiumReftestOracle.cs
+++ b/tests/WebPlatformSubset/runner/ChromiumReftestOracle.cs
@@ -170,6 +170,12 @@ internal sealed class ChromiumReftestOracle
 
     private string ReadIdentity()
     {
+        if (OperatingSystem.IsWindows())
+        {
+            var version = FileVersionInfo.GetVersionInfo(_executable);
+            return $"{version.ProductName ?? Path.GetFileName(_executable)} "
+                + $"{version.ProductVersion ?? "unknown"}";
+        }
         var startInfo = new ProcessStartInfo(_executable)
         {
             RedirectStandardOutput = true,

--- a/tests/WebPlatformSubset/runner/EngineAdapters.cs
+++ b/tests/WebPlatformSubset/runner/EngineAdapters.cs
@@ -1056,7 +1056,7 @@ internal sealed unsafe class NativeSceneSnapshotRenderer : IDisposable
             NumberStyles.Float,
             CultureInfo.InvariantCulture,
             out var parsedLineHeight)
-            && parsedLineHeight > 0
+            && parsedLineHeight >= 0
             ? parsedLineHeight
             : size * 1.2f;
         var fontWeight = int.TryParse(
@@ -1107,8 +1107,7 @@ internal sealed unsafe class NativeSceneSnapshotRenderer : IDisposable
         var baseline = command.Y
             + Math.Max(0, (command.Height - contentHeight) * 0.5f)
             + (contentHeight - glyphHeight) * 0.5f
-            - metrics.Ascent
-            + (parsedLineHeight == 0 ? 3f : 0f);
+            - metrics.Ascent;
         NativeTextShaping.DrawShapedText(
             canvas,
             shaper,

--- a/tests/WebScene.Backend.Avalonia.Tests/NativeTextShapingTests.cs
+++ b/tests/WebScene.Backend.Avalonia.Tests/NativeTextShapingTests.cs
@@ -7,6 +7,190 @@ namespace WebScene.Backend.Avalonia.Tests;
 
 public sealed class NativeTextShapingTests
 {
+    [Fact]
+    public void WindowsGenericFamiliesKeepSystemUiAndSansSerifDistinct()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var systemUi = NativeTextShaping.ResolveTypeface("system-ui", 400);
+        var sansSerif = NativeTextShaping.ResolveTypeface("sans-serif", 400);
+        var appleFallback = NativeTextShaping.ResolveTypeface(
+            "-apple-system, BlinkMacSystemFont, 'Trebuchet MS', sans-serif",
+            400);
+
+        Assert.Equal("Segoe UI", systemUi.FamilyName, ignoreCase: true);
+        Assert.Equal("Arial", sansSerif.FamilyName, ignoreCase: true);
+        Assert.NotEqual(systemUi.FamilyName, sansSerif.FamilyName);
+        Assert.Equal("Trebuchet MS", appleFallback.FamilyName, ignoreCase: true);
+    }
+
+    [Theory]
+    [InlineData(400, SKFontStyleSlant.Upright)]
+    [InlineData(600, SKFontStyleSlant.Upright)]
+    [InlineData(700, SKFontStyleSlant.Upright)]
+    [InlineData(400, SKFontStyleSlant.Italic)]
+    public void WindowsSystemUiResolvesRequestedWeightAndStyle(
+        int weight,
+        SKFontStyleSlant slant)
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var typeface = NativeTextShaping.ResolveTypeface(
+            "missing-webscene-family, system-ui",
+            weight,
+            slant,
+            null);
+
+        Assert.Equal("Segoe UI", typeface.FamilyName, ignoreCase: true);
+        Assert.Equal(slant, typeface.FontSlant);
+        Assert.InRange(typeface.FontWeight, weight - 100, weight + 100);
+    }
+
+    [Fact]
+    public void WindowsDirectWritePositionerReturnsVerifiedCachedWholeRun()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        const string family = "system-ui";
+        const string text = "AAPL data is delayed by 15 minutes.";
+        var typeface = NativeTextShaping.ResolveTypeface(family, 400);
+        using var paint = new SKPaint { Typeface = typeface, TextSize = 14 };
+        using var shaper = new SKShaper(typeface);
+        var shaped = shaper.Shape(text, 0, 0, paint);
+        var request = new NativeTextRunPositionRequest(
+            text,
+            family,
+            14,
+            400,
+            SKFontStyleSlant.Upright,
+            0,
+            shaped.Codepoints,
+            null,
+            typeface);
+        var positioner = new WindowsDirectWriteRunPositioner();
+
+        Assert.True(positioner.TryPosition(in request, out var first));
+        Assert.Equal(shaped.Codepoints, first.Glyphs.Select(static glyph => (uint)glyph));
+        Assert.Equal(first.Glyphs.Length, first.Positions.Length);
+        Assert.Equal(first.Glyphs.Length, first.Clusters?.Length);
+        Assert.Equal(first.Glyphs.Length, first.Advances?.Length);
+        Assert.Equal("Segoe UI", first.FaceIdentity?.FamilyName, ignoreCase: true);
+        Assert.False(string.IsNullOrWhiteSpace(first.FaceIdentity?.FontTableFingerprint));
+        Assert.True(float.IsFinite(first.AdvanceWidth));
+        Assert.True(first.AdvanceWidth > 0);
+        Assert.True(positioner.TryPosition(in request, out var second));
+        Assert.Same(first, second);
+        var mismatched = request with
+        {
+            ExpectedGlyphs = request.ExpectedGlyphs
+                .Select((glyph, index) => index == 0 ? glyph + 1 : glyph)
+                .ToArray()
+        };
+        Assert.False(positioner.TryPosition(in mismatched, out _));
+    }
+
+    [Fact]
+    public void WindowsDirectWriteIsAutomaticAndHarfBuzzRemainsRollback()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        const string text = "AV To ffi";
+        var typeface = NativeTextShaping.ResolveTypeface("system-ui", 400);
+        using var paint = new SKPaint { Typeface = typeface, TextSize = 18 };
+        using var shaper = new SKShaper(typeface);
+        var shaped = shaper.Shape(text, 0, 0, paint);
+        var request = new NativeTextRunPositionRequest(
+            text, "system-ui", 18, 400, SKFontStyleSlant.Upright,
+            0, shaped.Codepoints, null, typeface);
+        var automatic = new DefaultNativeTextRunPositioner(null);
+        var explicitCandidate = new DefaultNativeTextRunPositioner("directwrite");
+        var rollback = new DefaultNativeTextRunPositioner("harfbuzz");
+
+        Assert.True(automatic.IsEligible(in request));
+        Assert.True(explicitCandidate.IsEligible(in request));
+        Assert.True(automatic.TryPosition(in request, out var positioned));
+        Assert.Equal(positioned.AdvanceWidth, positioned.Advances!.Sum(), precision: 4);
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(
+                NativeTextShaping.RasterizationModeEnvironmentVariable)))
+        {
+            Assert.Equal(
+                NativeTextShaping.NativeFontRasterizationMode.ChromiumGrayscale,
+                NativeTextShaping.ResolvePositionedRunRasterizationMode(
+                    positioned,
+                    1,
+                    null));
+            Assert.Null(NativeTextShaping.ResolvePositionedRunRasterizationMode(
+                positioned,
+                1.25f,
+                null));
+        }
+        Assert.Equal(
+            NativeTextShaping.NativeFontRasterizationMode.Current,
+            NativeTextShaping.ResolvePositionedRunRasterizationMode(
+                positioned,
+                1,
+                NativeTextShaping.NativeFontRasterizationMode.Current));
+        Assert.False(rollback.IsEligible(in request));
+        Assert.False(rollback.TryPosition(in request, out _));
+    }
+
+    [Fact]
+    public void WindowsDirectWritePositionerPreservesPairKerning()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var typeface = NativeTextShaping.ResolveTypeface("system-ui", 400);
+        using var paint = new SKPaint { Typeface = typeface, TextSize = 24 };
+        using var shaper = new SKShaper(typeface);
+        var positioner = new WindowsDirectWriteRunPositioner();
+
+        NativePositionedTextRun Position(string text)
+        {
+            var shaped = shaper.Shape(text, 0, 0, paint);
+            var request = new NativeTextRunPositionRequest(
+                text, "system-ui", 24, 400, SKFontStyleSlant.Upright,
+                0, shaped.Codepoints, null, typeface);
+            Assert.True(positioner.TryPosition(in request, out var run));
+            return run;
+        }
+
+        var pair = Position("AV");
+        var isolated = Position("A").AdvanceWidth + Position("V").AdvanceWidth;
+        var space = Position(" ");
+
+        Assert.True(pair.AdvanceWidth < isolated - .05f);
+        Assert.True(space.AdvanceWidth > 0);
+    }
+
+    [Fact]
+    public void WindowsDirectWritePositionerRejectsUnsupportedRuns()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+
+        var typeface = NativeTextShaping.ResolveTypeface("system-ui", 400);
+        var positioner = new WindowsDirectWriteRunPositioner();
+        var italic = new NativeTextRunPositionRequest(
+            "text", "system-ui", 14, 400, SKFontStyleSlant.Italic, 0, [], null, typeface);
+        var tabular = new NativeTextRunPositionRequest(
+            "123", "system-ui", 14, 400, SKFontStyleSlant.Upright,
+            NativeTextShaping.TabularNumerals, [], null, typeface);
+        var emoji = new NativeTextRunPositionRequest(
+            "emoji 😀", "system-ui", 14, 400, SKFontStyleSlant.Upright,
+            0, [], null, typeface);
+        var namedFamily = new NativeTextRunPositionRequest(
+            "text", "Arial", 14, 400, SKFontStyleSlant.Upright,
+            0, [], null, typeface);
+        var semibold = new NativeTextRunPositionRequest(
+            "text", "system-ui", 14, 600, SKFontStyleSlant.Upright,
+            0, [], null, typeface);
+
+        Assert.False(positioner.IsEligible(in italic));
+        Assert.False(positioner.IsEligible(in tabular));
+        Assert.False(positioner.IsEligible(in emoji));
+        Assert.False(positioner.IsEligible(in namedFamily));
+        Assert.False(positioner.IsEligible(in semibold));
+    }
+
     [Theory]
     [InlineData(0, false, true)]
     [InlineData(1, false, true)]

--- a/tests/WebScene.Backend.Avalonia.Tests/WebSceneV8InspectorHostTests.cs
+++ b/tests/WebScene.Backend.Avalonia.Tests/WebSceneV8InspectorHostTests.cs
@@ -269,9 +269,14 @@ public sealed class WebSceneV8InspectorHostTests
     }
 
     [Fact]
-    public async Task RemoteDiscoveryRequiresTokenBeforePublishingWebSocketUrl()
+    public async Task RemoteModeDiscoveryRequiresTokenBeforePublishingWebSocketUrl()
     {
-        var address = GetNonLoopbackAddress();
+        // HTTP.sys requires an elevated URL ACL for non-loopback prefixes on
+        // Windows. Exercise the same remote-mode authorization policy through
+        // loopback there; Unix hosts still cover the physical non-loopback bind.
+        var address = OperatingSystem.IsWindows()
+            ? IPAddress.Loopback
+            : GetNonLoopbackAddress();
         await using var host = new WebSceneV8InspectorHost(
             () => new FakeInspectorSession(),
             () => "webscene://remote",


### PR DESCRIPTION
## Summary

- resolve Windows `system-ui` to Segoe UI while keeping `sans-serif` mapped independently and allowing Apple aliases to follow normal Windows fallback
- add bounded whole-run DirectWrite glyph positioning for verified regular-weight system-UI Latin runs, with exact font-table and glyph-sequence identity checks
- reuse accepted DirectWrite advances for measurement and Skia painting, retaining per-run HarfBuzz fallback and an explicit rollback switch
- extend the glyph diagnostic to Windows at 100%, 125%, 150%, and 200%, including Chromium canvas/DOM, Avalonia, face identity, pixel gates, and performance budgets
- fix the native layout/reference and Windows inspector portability issues uncovered by the required verification suite
- enable automatic DirectWrite selection on Windows after all rollout gates passed

## Rollout and fallback

The new path remains intentionally narrow: regular-weight, upright, single-face `system-ui` Latin/punctuation runs with no authored features. Semibold, bold, italic, emoji, complex scripts, web fonts, named families, and any identity mismatch continue through HarfBuzz/Skia.

Set `WEBSCENE_TEXT_POSITIONING=harfbuzz` (or `legacy`, `off`, or `0`) to restore the previous positioning path. `directwrite` remains available as an explicit diagnostic mode.

## Verification

- `dotnet test WebScene.sln -c Release`
  - all managed projects passed
  - Avalonia backend: 105/105 on .NET 8 and 105/105 on .NET 10
- native CTest suite: 4/4 passed
- required Windows WPT subset:
  - automatic DirectWrite: 115/115 documents, 440/440 subtests
  - HarfBuzz rollback: 115/115 documents, 440/440 subtests
- Chrome for Testing 152.0.7977.54 pixel oracle:
  - 100%: MAE 0.010438 → 0.007566
  - 125%: MAE 0.008834 → 0.008831
  - 150%: MAE 0.005676 → 0.005463
  - 200%: MAE 0.004213 → 0.004028
  - all per-case and isolated-glyph regression guards passed
- performance gate:
  - cold shape: 11.571 ms
  - warm cache hit: 1.393 µs, 0 B allocated
  - positioned draw: 4.789 µs / 320 B
  - HarfBuzz draw: 8.505 µs / 2,560 B
- interactive NativeTradingViewTerminal launched successfully against the freshly built Windows native engine

## Native engine identity

Verified DLL SHA-256: `0FD7FAA086085D88153E57FD55502DD1EB27AC785BC376D496B4CD413385C264`
