### PR TITLE
Optimize Avalonia retained scene rendering

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -96,3 +96,28 @@ WEBSCENE_NATIVE_ENGINE_PATH=/absolute/path/to/libwebscene_native_engine.dylib \
   --warmup-seconds 5 --seconds 10 --hz 60 \
   --chrome-reference artifacts/chrome-resize.json
 ```
+
+## Retained scene rendering
+
+The retained-render probe exercises the Avalonia Skia renderer without requiring the
+native V8 library. It clears the surface before every render, checks the sparse result
+against a visible-only pixel reference, and reports sparse and fully-visible timing so
+viewport-culling gains can be weighed against their dense-scene overhead:
+
+```bash
+dotnet run --project benchmarks/WebScene.NativeEngine.Benchmarks -c Release -- \
+  probe native-retained-render --layers 2048 --visible 32 --iterations 40 --samples 11
+```
+
+The companion apply probe measures one-layer replacement, batched replacement, and
+z-order changes independently. It is intended to catch linear identity lookup and
+unnecessary total-order rebuilds in the retained consumer:
+
+```bash
+dotnet run --project benchmarks/WebScene.NativeEngine.Benchmarks -c Release -- \
+  probe native-retained-apply --layers 4096 --batch 256 --iterations 100 --samples 11
+```
+
+The complete NativePF candidate inventory, measurements, and accepted/rejected
+decisions are recorded in
+[`docs/nativepf-render-optimization-audit.md`](../docs/nativepf-render-optimization-audit.md).

--- a/benchmarks/WebScene.NativeEngine.Benchmarks/NativeRetainedApplyProbe.cs
+++ b/benchmarks/WebScene.NativeEngine.Benchmarks/NativeRetainedApplyProbe.cs
@@ -1,0 +1,274 @@
+using System.Diagnostics;
+using System.Text.Json;
+using WebScene.Backends.Avalonia.Native;
+
+namespace WebScene.NativeEngine.Benchmarks;
+
+internal static unsafe class NativeRetainedApplyProbe
+{
+    private const uint SceneCheckpoint = 1;
+    private const uint LayerReplace = 1;
+    private const uint FillRect = 22;
+
+    internal static int Run(string[] args)
+    {
+        var layerCount = ReadIntOption(args, "--layers", 4_096);
+        var batchSize = ReadIntOption(args, "--batch", 256);
+        var iterations = ReadIntOption(args, "--iterations", 100);
+        var samples = ReadIntOption(args, "--samples", 11);
+        if (layerCount is < 2 or > 100_000
+            || batchSize is < 1 || batchSize > layerCount
+            || iterations is < 1 or > 10_000
+            || samples is < 3 or > 101)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(args),
+                "Layers must be 2-100000, batch must be within that range, " +
+                "iterations must be 1-10000, and samples must be 3-101.");
+        }
+
+        using var sparseFixture = new ApplyFixture(layerCount, changeCount: 1);
+        using var batchFixture = new ApplyFixture(layerCount, batchSize);
+        using var reorderFixture = new ApplyFixture(
+            layerCount,
+            changeCount: 1,
+            reorder: true);
+        sparseFixture.WarmUp();
+        batchFixture.WarmUp();
+        reorderFixture.WarmUp();
+
+        var sparseTiming = Measure(
+            sparseFixture.ApplyNext,
+            iterations,
+            samples);
+        var batchTiming = Measure(
+            batchFixture.ApplyNext,
+            iterations,
+            samples);
+        var reorderTiming = Measure(
+            reorderFixture.ApplyNext,
+            iterations,
+            samples);
+        if (!sparseFixture.HasConsistentOrder
+            || !batchFixture.HasConsistentOrder
+            || !reorderFixture.HasConsistentOrder)
+        {
+            throw new InvalidOperationException(
+                "The retained renderer's layer identity/order index is inconsistent.");
+        }
+
+        var result = new
+        {
+            schema = "webscene-native-retained-apply-v1",
+            capturedUtc = DateTimeOffset.UtcNow,
+            options = new { layerCount, batchSize, iterations, samples },
+            correctness = new { retainedOrderConsistent = true },
+            sparseReplacement = sparseTiming,
+            batchReplacement = batchTiming,
+            zOrderChange = reorderTiming
+        };
+        Console.WriteLine(JsonSerializer.Serialize(
+            result,
+            new JsonSerializerOptions { WriteIndented = true }));
+        return 0;
+    }
+
+    private static TimingSummary Measure(
+        Action operation,
+        int iterations,
+        int samples)
+    {
+        var nanosecondsPerOperation = new double[samples];
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        for (var sample = 0; sample < samples; sample++)
+        {
+            var started = Stopwatch.GetTimestamp();
+            for (var iteration = 0; iteration < iterations; iteration++)
+            {
+                operation();
+            }
+            nanosecondsPerOperation[sample] =
+                Stopwatch.GetElapsedTime(started).TotalNanoseconds / iterations;
+        }
+        var allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        Array.Sort(nanosecondsPerOperation);
+        return new TimingSummary(
+            nanosecondsPerOperation[samples / 2],
+            Percentile(nanosecondsPerOperation, 0.95),
+            nanosecondsPerOperation.Average(),
+            allocatedBytes / checked(samples * iterations));
+    }
+
+    private static double Percentile(IReadOnlyList<double> sorted, double percentile)
+    {
+        var index = (int)Math.Ceiling(percentile * sorted.Count) - 1;
+        return sorted[Math.Clamp(index, 0, sorted.Count - 1)];
+    }
+
+    private static int ReadIntOption(
+        IReadOnlyList<string> args,
+        string name,
+        int fallback)
+    {
+        for (var index = 0; index + 1 < args.Count; index++)
+        {
+            if (string.Equals(args[index], name, StringComparison.OrdinalIgnoreCase)
+                && int.TryParse(args[index + 1], out var value))
+            {
+                return value;
+            }
+        }
+        return fallback;
+    }
+
+    private sealed class ApplyFixture : IDisposable
+    {
+        private readonly NativeCanvasSceneRenderer _renderer = new();
+        private readonly int _layerCount;
+        private readonly bool _reorder;
+        private readonly NativeCanvasLayer[] _changes;
+        private readonly NativeCanvasCommand[] _commands;
+        private ulong _revision = 1;
+        private ulong _generation = 1;
+        private int _nextIndex;
+        private bool _movedToEnd;
+
+        internal ApplyFixture(int layerCount, int changeCount, bool reorder = false)
+        {
+            _layerCount = layerCount;
+            _reorder = reorder;
+            _changes = new NativeCanvasLayer[changeCount];
+            _commands = CreateCommands(changeCount);
+            var checkpointLayers = new NativeCanvasLayer[layerCount];
+            for (var index = 0; index < layerCount; index++)
+            {
+                checkpointLayers[index] = CreateLayer(
+                    index,
+                    commandOffset: index,
+                    generation: 1,
+                    zOrder: checked((uint)index));
+            }
+            Apply(
+                checkpointLayers,
+                CreateCommands(layerCount),
+                checkpoint: true);
+        }
+
+        internal void WarmUp()
+        {
+            for (var iteration = 0; iteration < 20; iteration++)
+            {
+                ApplyNext();
+            }
+        }
+
+        internal void ApplyNext()
+        {
+            _generation++;
+            for (var change = 0; change < _changes.Length; change++)
+            {
+                var index = _reorder
+                    ? 0
+                    : (_nextIndex + change) % _layerCount;
+                var zOrder = _reorder && !_movedToEnd
+                    ? checked((uint)_layerCount + 1)
+                    : checked((uint)index);
+                _changes[change] = CreateLayer(
+                    index,
+                    commandOffset: change,
+                    _generation,
+                    zOrder);
+            }
+            _nextIndex = (_nextIndex + _changes.Length) % _layerCount;
+            if (_reorder)
+            {
+                _movedToEnd = !_movedToEnd;
+            }
+            Apply(_changes, _commands, checkpoint: false);
+        }
+
+        internal bool HasConsistentOrder => _renderer.HasConsistentLayerOrder();
+
+        public void Dispose() => _renderer.Reset();
+
+        private void Apply(
+            NativeCanvasLayer[] layers,
+            NativeCanvasCommand[] commands,
+            bool checkpoint)
+        {
+            var baseRevision = checkpoint ? 0 : _revision;
+            if (!checkpoint)
+            {
+                _revision++;
+            }
+            fixed (NativeCanvasLayer* layerPointer = layers)
+            fixed (NativeCanvasCommand* commandPointer = commands)
+            {
+                var view = new NativeSceneView
+                {
+                    StructSize = checked((uint)sizeof(NativeSceneView)),
+                    AbiVersion = 2,
+                    Header = new SceneHeader
+                    {
+                        Revision = _revision,
+                        BaseRevision = baseRevision,
+                        ViewportWidth = 320,
+                        ViewportHeight = 240,
+                        CanvasLayerCount = checked((uint)layers.Length),
+                        Flags = checkpoint ? SceneCheckpoint : 0
+                    },
+                    CanvasLayers = layerPointer,
+                    CanvasCommands = commandPointer,
+                    CanvasCommandCount = checked((uint)commands.Length)
+                };
+                if (!_renderer.ApplyDiff(&view))
+                {
+                    throw new InvalidOperationException(
+                        "The retained renderer rejected an apply benchmark diff.");
+                }
+            }
+        }
+    }
+
+    private static NativeCanvasLayer CreateLayer(
+        int index,
+        int commandOffset,
+        ulong generation,
+        uint zOrder)
+        => new()
+        {
+            NodeId = checked((uint)index + 1),
+            Flags = LayerReplace,
+            CommandOffset = checked((uint)commandOffset),
+            CommandCount = 1,
+            Reserved = zOrder,
+            X = index % 32 * 10,
+            Y = index / 32 * 10,
+            Width = 8,
+            Height = 8,
+            BitmapWidth = 8,
+            BitmapHeight = 8,
+            Generation = generation
+        };
+
+    private static NativeCanvasCommand[] CreateCommands(int commandCount)
+    {
+        var commands = new NativeCanvasCommand[commandCount];
+        for (var index = 0; index < commandCount; index++)
+        {
+            commands[index] = new NativeCanvasCommand
+            {
+                Kind = FillRect,
+                V2 = 8,
+                V3 = 8
+            };
+        }
+        return commands;
+    }
+
+    private sealed record TimingSummary(
+        double MedianNanosecondsPerOperation,
+        double P95NanosecondsPerOperation,
+        double MeanNanosecondsPerOperation,
+        long AllocatedBytesPerOperation);
+}

--- a/benchmarks/WebScene.NativeEngine.Benchmarks/NativeRetainedRenderProbe.cs
+++ b/benchmarks/WebScene.NativeEngine.Benchmarks/NativeRetainedRenderProbe.cs
@@ -1,0 +1,353 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text.Json;
+using SkiaSharp;
+using WebScene.Backends.Avalonia.Native;
+
+namespace WebScene.NativeEngine.Benchmarks;
+
+internal static unsafe class NativeRetainedRenderProbe
+{
+    private const uint SceneCheckpoint = 1;
+    private const uint LayerReplace = 1;
+    private const uint FillRect = 22;
+    private const int ViewportWidth = 320;
+    private const int ViewportHeight = 240;
+    private const int LayerSize = 12;
+
+    internal static int Run(string[] args)
+    {
+        var layerCount = ReadIntOption(args, "--layers", 2_048);
+        var visibleLayerCount = ReadIntOption(args, "--visible", 32);
+        var iterations = ReadIntOption(args, "--iterations", 40);
+        var samples = ReadIntOption(args, "--samples", 11);
+        if (layerCount is < 1 or > 100_000
+            || visibleLayerCount is < 1 || visibleLayerCount > layerCount
+            || iterations is < 1 or > 10_000
+            || samples is < 3 or > 101)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(args),
+                "Layers must be 1-100000, visible layers must be within that range, " +
+                "iterations must be 1-10000, and samples must be 3-101.");
+        }
+
+        using var sparse = new RenderFixture(
+            layerCount,
+            visibleLayerCount,
+            placeAllInViewport: false);
+        using var visibleOnly = new RenderFixture(
+            visibleLayerCount,
+            visibleLayerCount,
+            placeAllInViewport: false);
+        using var dense = new RenderFixture(
+            layerCount,
+            layerCount,
+            placeAllInViewport: true);
+        using var sparseWithReplacement = new RenderFixture(
+            layerCount,
+            visibleLayerCount,
+            placeAllInViewport: false);
+
+        var sparseHash = sparse.RenderAndHash();
+        var referenceHash = visibleOnly.RenderAndHash();
+        if (!CryptographicOperations.FixedTimeEquals(
+                Convert.FromHexString(sparseHash),
+                Convert.FromHexString(referenceHash)))
+        {
+            throw new InvalidOperationException(
+                "The retained renderer's sparse frame differs from the visible-only reference frame.");
+        }
+
+        sparse.WarmUp();
+        dense.WarmUp();
+        sparseWithReplacement.WarmUpApplyAndRender();
+        var sparseTiming = Measure(sparse.Render, iterations, samples);
+        var denseTiming = Measure(dense.Render, iterations, samples);
+        var sparseReplacementTiming = Measure(
+            sparseWithReplacement.ApplyNextAndRender,
+            iterations,
+            samples);
+        var sparseReplacementHash = sparseWithReplacement.RenderAndHash();
+        if (!CryptographicOperations.FixedTimeEquals(
+                Convert.FromHexString(sparseReplacementHash),
+                Convert.FromHexString(referenceHash)))
+        {
+            throw new InvalidOperationException(
+                "A replaced sparse frame differs from the visible-only reference frame.");
+        }
+        Console.WriteLine(JsonSerializer.Serialize(
+            new
+            {
+                schema = "webscene-native-retained-render-v1",
+                capturedUtc = DateTimeOffset.UtcNow,
+                options = new
+                {
+                    layerCount,
+                    visibleLayerCount,
+                    iterations,
+                    samples,
+                    viewportWidth = ViewportWidth,
+                    viewportHeight = ViewportHeight
+                },
+                correctness = new
+                {
+                    surfaceClearedBeforeEveryRender = true,
+                    sparseFrameSha256 = sparseHash,
+                    sparseReplacementFrameSha256 = sparseReplacementHash,
+                    visibleOnlyReferenceSha256 = referenceHash,
+                    framesMatch = true
+                },
+                sparse = sparseTiming,
+                dense = denseTiming,
+                sparseWithReplacement = sparseReplacementTiming
+            },
+            new JsonSerializerOptions { WriteIndented = true }));
+        return 0;
+    }
+
+    private static TimingSummary Measure(
+        Action operation,
+        int iterations,
+        int samples)
+    {
+        var nanosecondsPerRender = new double[samples];
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        for (var sample = 0; sample < samples; sample++)
+        {
+            var started = Stopwatch.GetTimestamp();
+            for (var iteration = 0; iteration < iterations; iteration++)
+            {
+                operation();
+            }
+            nanosecondsPerRender[sample] =
+                Stopwatch.GetElapsedTime(started).TotalNanoseconds / iterations;
+        }
+        var allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        Array.Sort(nanosecondsPerRender);
+        return new TimingSummary(
+            nanosecondsPerRender[samples / 2],
+            Percentile(nanosecondsPerRender, 0.95),
+            nanosecondsPerRender.Average(),
+            allocatedBytes / checked(samples * iterations));
+    }
+
+    private static double Percentile(IReadOnlyList<double> sorted, double percentile)
+    {
+        var index = (int)Math.Ceiling(percentile * sorted.Count) - 1;
+        return sorted[Math.Clamp(index, 0, sorted.Count - 1)];
+    }
+
+    private static int ReadIntOption(
+        IReadOnlyList<string> args,
+        string name,
+        int fallback)
+    {
+        for (var index = 0; index + 1 < args.Count; index++)
+        {
+            if (string.Equals(args[index], name, StringComparison.OrdinalIgnoreCase)
+                && int.TryParse(args[index + 1], out var value))
+            {
+                return value;
+            }
+        }
+        return fallback;
+    }
+
+    private sealed class RenderFixture : IDisposable
+    {
+        private readonly NativeCanvasSceneRenderer _renderer = new();
+        private readonly SKSurface _surface;
+        private readonly NativeCanvasLayer[] _layouts;
+        private readonly NativeCanvasLayer[] _replacement = new NativeCanvasLayer[1];
+        private readonly NativeCanvasCommand[] _replacementCommand = CreateCommands(1);
+        private readonly int _visibleLayerCount;
+        private ulong _revision = 1;
+        private ulong _generation = 1;
+        private int _nextReplacement;
+
+        internal RenderFixture(
+            int layerCount,
+            int visibleLayerCount,
+            bool placeAllInViewport)
+        {
+            _visibleLayerCount = visibleLayerCount;
+            _surface = SKSurface.Create(new SKImageInfo(
+                ViewportWidth,
+                ViewportHeight,
+                SKColorType.Rgba8888,
+                SKAlphaType.Premul))
+                ?? throw new InvalidOperationException("Could not create the benchmark surface.");
+            _layouts = CreateLayers(
+                layerCount,
+                visibleLayerCount,
+                placeAllInViewport);
+            ApplyScene(
+                _renderer,
+                _layouts,
+                CreateCommands(layerCount),
+                revision: 1,
+                baseRevision: 0,
+                checkpoint: true);
+        }
+
+        internal void WarmUpApplyAndRender()
+        {
+            for (var iteration = 0; iteration < 20; iteration++)
+            {
+                ApplyNextAndRender();
+            }
+        }
+
+        internal void ApplyNextAndRender()
+        {
+            var index = _nextReplacement++ % _visibleLayerCount;
+            var replacement = _layouts[index];
+            replacement.CommandOffset = 0;
+            replacement.Generation = ++_generation;
+            _replacement[0] = replacement;
+            var baseRevision = _revision++;
+            ApplyScene(
+                _renderer,
+                _replacement,
+                _replacementCommand,
+                _revision,
+                baseRevision,
+                checkpoint: false);
+            Render();
+        }
+
+        internal void WarmUp()
+        {
+            for (var iteration = 0; iteration < 20; iteration++)
+            {
+                Render();
+            }
+        }
+
+        internal void Render()
+        {
+            // Never rely on Avalonia or Skia preserving pixels outside an
+            // invalidated area. A valid optimization must reconstruct the
+            // complete viewport from transparent on every callback.
+            _surface.Canvas.Clear(SKColors.Transparent);
+            _renderer.RenderRetained(
+                _surface.Canvas,
+                ViewportWidth,
+                ViewportHeight,
+                intersects: null);
+            _surface.Canvas.Flush();
+        }
+
+        internal string RenderAndHash()
+        {
+            Render();
+            using var image = _surface.Snapshot();
+            using var pixels = image.PeekPixels()
+                ?? throw new InvalidOperationException("Could not read benchmark pixels.");
+            var bytes = pixels.GetPixelSpan().ToArray();
+            return Convert.ToHexString(SHA256.HashData(bytes));
+        }
+
+        public void Dispose()
+        {
+            _renderer.Reset();
+            _surface.Dispose();
+        }
+    }
+
+    private static NativeCanvasLayer[] CreateLayers(
+        int layerCount,
+        int visibleLayerCount,
+        bool placeAllInViewport)
+    {
+        var layers = new NativeCanvasLayer[layerCount];
+        var columns = Math.Max(1, ViewportWidth / LayerSize);
+        for (var index = 0; index < layerCount; index++)
+        {
+            var inViewport = placeAllInViewport || index < visibleLayerCount;
+            var visibleIndex = placeAllInViewport
+                ? index % Math.Max(1, visibleLayerCount)
+                : index;
+            var x = inViewport
+                ? (visibleIndex % columns) * LayerSize
+                : ViewportWidth + LayerSize + (index % 32) * LayerSize;
+            var y = inViewport
+                ? (visibleIndex / columns * LayerSize) % ViewportHeight
+                : ViewportHeight + LayerSize + (index % 32) * LayerSize;
+            layers[index] = new NativeCanvasLayer
+            {
+                NodeId = checked((uint)index + 1),
+                Flags = LayerReplace,
+                CommandOffset = checked((uint)index),
+                CommandCount = 1,
+                Reserved = checked((uint)index),
+                X = x,
+                Y = y,
+                Width = LayerSize,
+                Height = LayerSize,
+                BitmapWidth = LayerSize,
+                BitmapHeight = LayerSize,
+                Generation = 1
+            };
+        }
+        return layers;
+    }
+
+    private static NativeCanvasCommand[] CreateCommands(int layerCount)
+    {
+        var commands = new NativeCanvasCommand[layerCount];
+        for (var index = 0; index < layerCount; index++)
+        {
+            commands[index] = new NativeCanvasCommand
+            {
+                Kind = FillRect,
+                V2 = LayerSize,
+                V3 = LayerSize
+            };
+        }
+        return commands;
+    }
+
+    private static void ApplyScene(
+        NativeCanvasSceneRenderer renderer,
+        NativeCanvasLayer[] layers,
+        NativeCanvasCommand[] commands,
+        ulong revision,
+        ulong baseRevision,
+        bool checkpoint)
+    {
+        fixed (NativeCanvasLayer* layerPointer = layers)
+        fixed (NativeCanvasCommand* commandPointer = commands)
+        {
+            var view = new NativeSceneView
+            {
+                StructSize = checked((uint)sizeof(NativeSceneView)),
+                AbiVersion = 2,
+                Header = new SceneHeader
+                {
+                    Revision = revision,
+                    BaseRevision = baseRevision,
+                    ViewportWidth = ViewportWidth,
+                    ViewportHeight = ViewportHeight,
+                    CanvasLayerCount = checked((uint)layers.Length),
+                    Flags = checkpoint ? SceneCheckpoint : 0
+                },
+                CanvasLayers = layerPointer,
+                CanvasCommands = commandPointer,
+                CanvasCommandCount = checked((uint)commands.Length)
+            };
+            if (!renderer.ApplyDiff(&view))
+            {
+                throw new InvalidOperationException(
+                    "The retained renderer rejected the benchmark checkpoint.");
+            }
+        }
+    }
+
+    private sealed record TimingSummary(
+        double MedianNanosecondsPerRender,
+        double P95NanosecondsPerRender,
+        double MeanNanosecondsPerRender,
+        long AllocatedBytesPerRender);
+}

--- a/benchmarks/WebScene.NativeEngine.Benchmarks/Program.cs
+++ b/benchmarks/WebScene.NativeEngine.Benchmarks/Program.cs
@@ -24,13 +24,19 @@ if (args.Length > 0 && string.Equals(args[0], "probe", StringComparison.OrdinalI
                 return NativeResizeCadenceProbe.Run(probeArgs);
             case "native-inspector-disabled-performance":
                 return NativeInspectorDisabledPerformanceProbe.Run(probeArgs);
+            case "native-retained-render":
+                return NativeRetainedRenderProbe.Run(probeArgs);
+            case "native-retained-apply":
+                return NativeRetainedApplyProbe.Run(probeArgs);
         }
     }
 
     Console.Error.WriteLine(
         "Unknown probe. Use one of: generated-realtime-chart, native-interop-race, " +
         "native-runtime-work, native-dom-lookup, native-context-memory, native-lifecycle, " +
-        "native-resize-cadence, native-inspector-disabled-performance.");
+        "native-resize-cadence, native-inspector-disabled-performance, " +
+        "native-retained-render, " +
+        "native-retained-apply.");
     return 2;
 }
 

--- a/docs/nativepf-render-optimization-audit.md
+++ b/docs/nativepf-render-optimization-audit.md
@@ -1,0 +1,108 @@
+# NativePF render optimization audit
+
+## Scope and acceptance gate
+
+This audit covers the transferable rendering work in NativePF commits `00640f7`,
+`658eab3`, `fcd79e6`, and merge `218a0ef`: dirty publication, damage generation and
+normalization, transactional apply/presentation, preserved surfaces, spatial
+candidates, incremental identity/order, recyclable scene storage, steady-state
+allocation, opaque/occlusion trimming, and renderer resource profiles.
+
+Avalonia is the primary acceptance target. A candidate is retained only when it:
+
+1. reconstructs the same complete viewport from a cleared surface;
+2. does not depend on Avalonia retaining pixels outside an invalidation;
+3. improves a focused workload without regressing the corresponding dense/control
+   workload materially; and
+4. preserves the shared Uno build and renderer semantics.
+
+Timing values below are medians of the per-process medians from five fresh Release
+processes on the same host. They are useful for comparing the paired implementation
+stages, not as cross-machine absolute targets.
+
+## Accepted changes and measured results
+
+### Retained rendering
+
+The renderer now rejects canvas layers whose explicit destination rectangle is outside
+the viewport, and caches the ordered in-viewport candidate list until a layer diff or
+viewport change invalidates it. It still draws the DOM backdrop, all visible canvas
+layers, and the DOM overlay on every Avalonia render callback.
+
+| 2,048-layer workload | Original | Viewport culling | Cached candidates |
+|---|---:|---:|---:|
+| 32 visible, retained replay p50 | 265.5 us | 34.7 us | 12.6 us |
+| all visible, retained replay p50 | 421.4 us | 417.3 us | 396.8 us |
+| 32 visible, replace one layer then replay | n/a | 51.9 us | 41.8 us |
+| managed allocation for replay | 0 B | 0 B | 0 B |
+
+Every render benchmark iteration clears the target first. The sparse frame SHA-256 is
+then compared with a renderer containing only the visible layers, so a stale or
+preserved backing surface cannot make the test pass.
+
+### Incremental retained identity and order
+
+Each retained layer now stores its ordered index. Same-z replacements update that slot
+directly. A z-order change removes the old slot, finds the new slot with binary search,
+and updates only the shifted range. Checkpoints, additions, and removals retain the
+conservative complete sort.
+
+| 4,096-layer apply workload | Flat lookup/full sort | Indexed/incremental | Result |
+|---|---:|---:|---:|
+| replace one layer | 6.17 us | 4.04 us | 35% faster |
+| replace 256 unchanged-z layers | 822.6 us | 562.8 us | 32% faster |
+| move one layer through z order | 56.5 us | 5.66 us | 10.0x faster |
+
+The apply probe and unit tests verify dictionary identity, sorted order, and stored
+indices after sparse replacement, batched replacement, and movement in both directions.
+
+### Validate before mutation
+
+Layer flags and buffer ranges are now validated before checkpoint reset, DOM picture
+replacement, or live-layer mutation. This moves the existing validation pass rather
+than adding a second hot-path pass. A malformed checkpoint can no longer erase the
+accepted retained scene before returning failure. This is accepted primarily as the
+transactional prerequisite for future incremental work; the ordinary apply benchmark
+does not show a material throughput cost.
+
+## Full disposition matrix
+
+| NativePF idea | WebScene evaluation | Disposition |
+|---|---|---|
+| Viewport/subtree culling | Canvas layers have exact root-space destination rectangles and are clipped to those same rectangles. A separation test is therefore conservative. | **Accepted and implemented.** |
+| Damage-specific spatial hierarchy | WebScene has root canvas layers plus two monolithic DOM pictures, not retained DOM nodes with effective subtree bounds. For current layer counts, a cached ordered candidate list removes repeated scans with less state and maintenance. | **Accepted in reduced form:** cached viewport candidates. Full BVH discarded for this ABI. |
+| Stable identity and incremental child order | Canvas node IDs and z order are already stable, but replacement previously searched linearly and z changes sorted everything. | **Accepted and implemented.** |
+| Validate-then-apply transaction | Checkpoints previously called `Reset()` before validating layer ranges; an invalid checkpoint destroyed good retained state. | **Accepted and implemented** for flags/ranges before mutation. |
+| Old/new damage for moves/replacements/removals | The producer already adds old and new canvas bounds, removed bounds, and conservative old/new DOM command bounds. | **Accepted, already present.** Covered by native damage and Avalonia policy tests. |
+| Empty-damage suppression | An empty incremental scene is treated as a synchronization point and does not invalidate or render. | **Accepted, already present.** It preserves consumed-input sequencing without drawing. |
+| Validate and clip damage to viewport | `NativeSceneDamagePolicy` validates finite values, scales and clips them, and falls back to full damage for malformed/unspecified visual changes. | **Accepted, already present.** |
+| Merge/cap several damage rectangles | Avalonia's custom visual is invalidated with one `Rect`; WebScene already computes the union and records both summed and union area. A bounded eight-rect region would collapse to the same scheduling rectangle. | **Discarded as redundant** until a renderer owns a preserved surface. |
+| One-device-pixel final damage inflation | DOM command damage already carries two logical pixels of antialias padding; canvas presentation is clipped to its exact layer rectangle. Extra consumer inflation would only enlarge Avalonia scheduling. | **Discarded as redundant** for current commands. |
+| Treat wholly clipped damage as no work | NativePF can prove this from effective ancestor transforms/clips. WebScene transform commands do not yet provide effective subtree bounds, so an apparently offscreen command can affect visible descendants. | **Discarded for correctness** until scene bounds are authoritative. |
+| Damage-only replay into preserved content | Avalonia owns the custom-visual backing and can discard it. Commit `16c339a` records exposed/cleared pixels when WebScene returned early or drew only the render clip. | **Rejected:** known flicker risk. Complete replay remains mandatory. |
+| Renderer-owned preserved surface | NativePF owns a Metal texture and copies the complete result to transient drawables. WebScene receives an Avalonia Skia canvas and has no lifecycle-safe ownership of its backing texture. An extra WebScene bitmap would add a full-window allocation and copy. | **Rejected for Avalonia.** Reconsider only behind a renderer-owned surface abstraction with expose/resize/device-loss tests. |
+| Transactional `presented`/`skipped`/`device_lost` acknowledgement | When Avalonia has no Skia lease, WebScene retains pending presentation state and retries. Every later callback reconstructs the scene, so native damage is not consumed as preserved pixels. | **Accepted equivalent, already present.** Avalonia does not expose NativePF's surface result contract directly. |
+| Producer dirty journal and one-node DOM publication | `native_document.build_scene` still flattens a command stream, and the ABI has no stable parent/child record, effective clip, subtree bounds, or per-node command span. Pure synchronization scenes also carry consumed-input sequence. | **Discarded for this ABI change:** requires a versioned hierarchical scene contract and a separate producer benchmark/correctness project, not a local renderer shortcut. |
+| Remove dense paint order in favor of hierarchy | DOM order is encoded in the flat command stream; canvas order is a small explicit retained list. Removing either without parent/child ordering changes pixels. | **Discarded for the current ABI.** Incremental canvas order maintenance captures the applicable benefit. |
+| Recycle immutable scene allocations/leases | The native producer uses `shared_ptr<const scene>` across acknowledged, pending, and acquired lifetimes. Reusing its vectors safely needs exclusive lease return/custom-deleter ownership and native steady-allocation gates. | **Discarded as a local change.** Borrowed pointer views and bounded pending scenes already avoid a consumer serialization copy. |
+| Reuse renderer replay containers | A prototype reused the canvas state stack and text-shaper dictionary. It saved only 136 B per trivial compiled layer (3.8%), had no stable throughput gain, and retained worst-case container capacity for the renderer lifetime. | **Measured and reverted.** |
+| Zero-allocation scene update | Full layer replacement necessarily creates a new `SKPicture` and Skia wrappers. The measured trivial replacement still allocates about 3.6 KiB; removing that requires stable command chunks or mutable renderer resources, not collection pooling. | **Discarded for the current picture contract.** Render-only replay remains 0 B. |
+| Opaque occlusion trimming | The scene ABI does not assert layer opacity. Canvas clear/composite/global-alpha/shadow operations and transparent overlay canvases make command-stream inference unsafe. | **Rejected for pixel correctness.** Add an explicit producer-proven opacity flag before reconsidering. |
+| Minimized/hidden suspension and memory release | Detach and `SetPresentationActive(false)` already stop projection and notify the native engine; reactivation requests a checkpoint. Renderer pictures are reset on detached direct-draw surfaces. | **Accepted, already present.** Automatic OS occlusion is not portable/reliable through current Avalonia APIs. |
+| Embedded/balanced/desktop Graphite resource profiles | Avalonia owns the Skia/GPU context and its budgets. WebScene cannot safely trim or reconfigure those resources from a custom visual. | **Rejected at this layer.** This belongs in Avalonia/backend configuration. |
+| Idle GPU cache purge | Per-renderer pictures, typefaces, and SVG leases are released on reset; the process SVG cache is reference counted. GPU atlas/pipeline purge remains Avalonia-owned. | **Accepted existing ownership boundaries;** no extra purge added. |
+| Diagnostics and bounded-work gates | WebScene already reports diff apply, retained draw, Skia submit, damage count/area, memory, revisions, and rejected diffs. The new probes add repeatable render/apply gates. | **Accepted and extended.** |
+
+## Reproduction
+
+```bash
+dotnet run --project benchmarks/WebScene.NativeEngine.Benchmarks -c Release -- \
+  probe native-retained-render --layers 2048 --visible 32 --iterations 40 --samples 11
+
+dotnet run --project benchmarks/WebScene.NativeEngine.Benchmarks -c Release -- \
+  probe native-retained-apply --layers 4096 --batch 256 --iterations 100 --samples 11
+```
+
+The render probe is the flicker/pixel oracle. The apply probe reports managed
+allocation and rejects inconsistent retained identity/order. Run both from fresh
+processes when changing culling, ordering, picture compilation, or damage behavior.

--- a/src/WebScene.Backend.Avalonia/NativeCanvasSceneRenderer.cs
+++ b/src/WebScene.Backend.Avalonia/NativeCanvasSceneRenderer.cs
@@ -43,6 +43,7 @@ internal sealed unsafe class NativeCanvasSceneRenderer
 
     private readonly Dictionary<uint, RetainedLayer> s_layers = new();
     private readonly List<RetainedLayer> s_orderedLayers = [];
+    private readonly List<RetainedLayer> s_viewportLayers = [];
     private readonly Dictionary<StringKey, string> s_strings = new();
     private readonly Dictionary<string, SKTypeface> s_typefaces = new(StringComparer.Ordinal);
     private readonly Dictionary<string, SharedSvgPictureLease> s_svgPictures =
@@ -56,6 +57,9 @@ internal sealed unsafe class NativeCanvasSceneRenderer
     private uint s_domCommandCount;
     private ulong s_revision;
     private long s_totalCommandCount;
+    private float s_cachedViewportWidth;
+    private float s_cachedViewportHeight;
+    private bool s_viewportLayersValid;
     public static long RejectedDiffCount;
 
     public long TotalCommandCount => s_totalCommandCount;
@@ -140,17 +144,37 @@ internal sealed unsafe class NativeCanvasSceneRenderer
     {
         var header = view->Header;
         var checkpoint = (header.Flags & SceneCheckpoint) != 0;
-        if (checkpoint)
-        {
-            Reset();
-        }
-        else if (header.Revision != s_revision && header.BaseRevision != s_revision)
+        if (!checkpoint
+            && header.Revision != s_revision
+            && header.BaseRevision != s_revision)
         {
             Interlocked.Increment(ref RejectedDiffCount);
             return false;
         }
 
-        if (header.Revision != s_revision)
+        var shouldApply = checkpoint || header.Revision != s_revision;
+        var changes = shouldApply
+            ? new ReadOnlySpan<NativeCanvasLayer>(
+                view->CanvasLayers,
+                checked((int)header.CanvasLayerCount))
+            : ReadOnlySpan<NativeCanvasLayer>.Empty;
+        foreach (ref readonly var change in changes)
+        {
+            if ((change.Flags & LayerRemove) == 0
+                && ((change.Flags & LayerReplace) == 0
+                    || !ValidateLayer(view, change)))
+            {
+                Interlocked.Increment(ref RejectedDiffCount);
+                return false;
+            }
+        }
+
+        if (checkpoint)
+        {
+            Reset();
+        }
+
+        if (shouldApply)
         {
             if ((header.Flags & SceneDomReplacement) != 0)
             {
@@ -163,9 +187,10 @@ internal sealed unsafe class NativeCanvasSceneRenderer
             }
 
             var layerOrderChanged = false;
-            var changes = new ReadOnlySpan<NativeCanvasLayer>(
-                view->CanvasLayers,
-                checked((int)header.CanvasLayerCount));
+            if (!changes.IsEmpty)
+            {
+                InvalidateViewportLayers();
+            }
             foreach (ref readonly var change in changes)
             {
                 if ((change.Flags & LayerRemove) != 0)
@@ -178,18 +203,13 @@ internal sealed unsafe class NativeCanvasSceneRenderer
                     }
                     continue;
                 }
-                if ((change.Flags & LayerReplace) == 0 || !ValidateLayer(view, change))
-                {
-                    Interlocked.Increment(ref RejectedDiffCount);
-                    return false;
-                }
                 var replacement = CompileLayer(view, change);
                 var orderChanged = true;
                 if (s_layers.Remove(change.NodeId, out var previous))
                 {
-                    orderChanged =
-                        previous.ZOrder != replacement.ZOrder
-                        || !ReplaceOrderedLayer(previous, replacement);
+                    orderChanged = previous.ZOrder == replacement.ZOrder
+                        ? !ReplaceOrderedLayer(previous, replacement)
+                        : !RepositionOrderedLayer(previous, replacement);
                     s_totalCommandCount -= previous.CommandCount;
                     previous.Dispose();
                 }
@@ -207,6 +227,27 @@ internal sealed unsafe class NativeCanvasSceneRenderer
         return true;
     }
 
+    internal bool HasConsistentLayerOrder()
+    {
+        if (s_orderedLayers.Count != s_layers.Count)
+        {
+            return false;
+        }
+        for (var index = 0; index < s_orderedLayers.Count; index++)
+        {
+            var layer = s_orderedLayers[index];
+            if (layer.OrderedIndex != index
+                || !s_layers.TryGetValue(layer.NodeId, out var retained)
+                || !ReferenceEquals(layer, retained)
+                || (index != 0
+                    && CompareLayerOrder(s_orderedLayers[index - 1], layer) > 0))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public void RenderRetained(
         SKCanvas canvas,
         float viewportWidth,
@@ -218,13 +259,8 @@ internal sealed unsafe class NativeCanvasSceneRenderer
         {
             canvas.DrawPicture(s_domBackdropPicture);
         }
-        foreach (var layer in s_orderedLayers)
+        foreach (var layer in ViewportLayers(viewportWidth, viewportHeight))
         {
-            if (layer.Width <= 0 || layer.Height <= 0
-                || layer.BitmapWidth == 0 || layer.BitmapHeight == 0)
-            {
-                continue;
-            }
             if (intersects is not null
                 && !intersects(new SKRect(layer.X, layer.Y, layer.X + layer.Width, layer.Y + layer.Height)))
             {
@@ -249,6 +285,74 @@ internal sealed unsafe class NativeCanvasSceneRenderer
         {
             canvas.DrawPicture(s_domOverlayPicture);
         }
+    }
+
+    private List<RetainedLayer> ViewportLayers(
+        float viewportWidth,
+        float viewportHeight)
+    {
+        if (s_viewportLayersValid
+            && s_cachedViewportWidth == viewportWidth
+            && s_cachedViewportHeight == viewportHeight)
+        {
+            return s_viewportLayers;
+        }
+
+        s_viewportLayers.Clear();
+        s_viewportLayers.EnsureCapacity(s_orderedLayers.Count);
+        foreach (var layer in s_orderedLayers)
+        {
+            if (layer.Width <= 0 || layer.Height <= 0
+                || layer.BitmapWidth == 0 || layer.BitmapHeight == 0
+                || !IntersectsViewport(
+                    layer.X,
+                    layer.Y,
+                    layer.Width,
+                    layer.Height,
+                    viewportWidth,
+                    viewportHeight))
+            {
+                continue;
+            }
+            s_viewportLayers.Add(layer);
+        }
+        s_cachedViewportWidth = viewportWidth;
+        s_cachedViewportHeight = viewportHeight;
+        s_viewportLayersValid = true;
+        return s_viewportLayers;
+    }
+
+    private void InvalidateViewportLayers()
+    {
+        s_viewportLayers.Clear();
+        s_viewportLayersValid = false;
+    }
+
+    internal static bool IntersectsViewport(
+        float x,
+        float y,
+        float width,
+        float height,
+        float viewportWidth,
+        float viewportHeight)
+    {
+        if (!float.IsFinite(x)
+            || !float.IsFinite(y)
+            || !float.IsFinite(width)
+            || !float.IsFinite(height)
+            || !float.IsFinite(viewportWidth)
+            || !float.IsFinite(viewportHeight))
+        {
+            // Preserve the existing Skia behavior for malformed geometry.
+            // Culling is only safe when the separation is provable.
+            return true;
+        }
+        return viewportWidth > 0
+            && viewportHeight > 0
+            && x < viewportWidth
+            && y < viewportHeight
+            && x + width > 0
+            && y + height > 0;
     }
 
     private static bool ValidateLayer(NativeSceneView* view, in NativeCanvasLayer layer)
@@ -1825,6 +1929,8 @@ internal sealed unsafe class NativeCanvasSceneRenderer
         foreach (var layer in s_layers.Values) layer.Dispose();
         s_layers.Clear();
         s_orderedLayers.Clear();
+        InvalidateViewportLayers();
+        s_viewportLayers.TrimExcess();
         foreach (var typeface in s_typefaces.Values) typeface.Dispose();
         s_typefaces.Clear();
         foreach (var svg in s_svgPictures.Values) svg.Dispose();
@@ -1838,29 +1944,73 @@ internal sealed unsafe class NativeCanvasSceneRenderer
     {
         s_orderedLayers.Clear();
         s_orderedLayers.AddRange(s_layers.Values);
-        s_orderedLayers.Sort(static (left, right) =>
+        s_orderedLayers.Sort(CompareLayerOrder);
+        for (var index = 0; index < s_orderedLayers.Count; index++)
         {
-            var zOrder = left.ZOrder.CompareTo(right.ZOrder);
-            return zOrder != 0
-                ? zOrder
-                : left.NodeId.CompareTo(right.NodeId);
-        });
+            s_orderedLayers[index].OrderedIndex = index;
+        }
     }
 
     private bool ReplaceOrderedLayer(
         RetainedLayer previous,
         RetainedLayer replacement)
     {
-        for (var index = 0; index < s_orderedLayers.Count; index++)
+        var index = previous.OrderedIndex;
+        if ((uint)index >= (uint)s_orderedLayers.Count
+            || !ReferenceEquals(s_orderedLayers[index], previous))
         {
-            if (!ReferenceEquals(s_orderedLayers[index], previous))
-            {
-                continue;
-            }
-            s_orderedLayers[index] = replacement;
-            return true;
+            return false;
         }
-        return false;
+        replacement.OrderedIndex = index;
+        s_orderedLayers[index] = replacement;
+        return true;
+    }
+
+    private bool RepositionOrderedLayer(
+        RetainedLayer previous,
+        RetainedLayer replacement)
+    {
+        var previousIndex = previous.OrderedIndex;
+        if ((uint)previousIndex >= (uint)s_orderedLayers.Count
+            || !ReferenceEquals(s_orderedLayers[previousIndex], previous))
+        {
+            return false;
+        }
+
+        s_orderedLayers.RemoveAt(previousIndex);
+        var low = 0;
+        var high = s_orderedLayers.Count;
+        while (low < high)
+        {
+            var middle = low + (high - low) / 2;
+            if (CompareLayerOrder(s_orderedLayers[middle], replacement) < 0)
+            {
+                low = middle + 1;
+            }
+            else
+            {
+                high = middle;
+            }
+        }
+        var replacementIndex = low;
+        s_orderedLayers.Insert(replacementIndex, replacement);
+        var firstChangedIndex = Math.Min(previousIndex, replacementIndex);
+        var lastChangedIndex = Math.Max(previousIndex, replacementIndex);
+        for (var index = firstChangedIndex; index <= lastChangedIndex; index++)
+        {
+            s_orderedLayers[index].OrderedIndex = index;
+        }
+        return true;
+    }
+
+    private static int CompareLayerOrder(
+        RetainedLayer left,
+        RetainedLayer right)
+    {
+        var zOrder = left.ZOrder.CompareTo(right.ZOrder);
+        return zOrder != 0
+            ? zOrder
+            : left.NodeId.CompareTo(right.NodeId);
     }
 
     private readonly record struct StringKey(uint NodeId, ulong Generation, uint Index);
@@ -1905,6 +2055,8 @@ internal sealed unsafe class NativeCanvasSceneRenderer
         bool RequiresIsolation,
         SKPicture Picture) : IDisposable
     {
+        public int OrderedIndex { get; set; } = -1;
+
         public void Dispose() => Picture.Dispose();
     }
 

--- a/tests/WebScene.Backend.Avalonia.Tests/NativeCanvasSceneRendererCullingTests.cs
+++ b/tests/WebScene.Backend.Avalonia.Tests/NativeCanvasSceneRendererCullingTests.cs
@@ -1,0 +1,183 @@
+using WebScene.Backends.Avalonia.Native;
+using Xunit;
+
+namespace WebScene.Backend.Avalonia.Tests;
+
+public sealed unsafe class NativeCanvasSceneRendererCullingTests
+{
+    [Theory]
+    [InlineData(0, 0, 10, 10)]
+    [InlineData(-5, -5, 10, 10)]
+    [InlineData(95, 95, 10, 10)]
+    public void IntersectsViewport_keeps_visible_and_partially_visible_layers(
+        float x,
+        float y,
+        float width,
+        float height)
+    {
+        Assert.True(NativeCanvasSceneRenderer.IntersectsViewport(
+            x,
+            y,
+            width,
+            height,
+            viewportWidth: 100,
+            viewportHeight: 100));
+    }
+
+    [Theory]
+    [InlineData(-10, 0, 10, 10)]
+    [InlineData(0, -10, 10, 10)]
+    [InlineData(100, 0, 10, 10)]
+    [InlineData(0, 100, 10, 10)]
+    public void IntersectsViewport_culls_fully_separated_layers(
+        float x,
+        float y,
+        float width,
+        float height)
+    {
+        Assert.False(NativeCanvasSceneRenderer.IntersectsViewport(
+            x,
+            y,
+            width,
+            height,
+            viewportWidth: 100,
+            viewportHeight: 100));
+    }
+
+    [Fact]
+    public void IntersectsViewport_preserves_non_finite_geometry()
+    {
+        Assert.True(NativeCanvasSceneRenderer.IntersectsViewport(
+            float.NaN,
+            0,
+            10,
+            10,
+            viewportWidth: 100,
+            viewportHeight: 100));
+        Assert.True(NativeCanvasSceneRenderer.IntersectsViewport(
+            0,
+            0,
+            float.PositiveInfinity,
+            10,
+            viewportWidth: 100,
+            viewportHeight: 100));
+    }
+
+    [Fact]
+    public void Incremental_replacement_and_reposition_preserve_order_identity()
+    {
+        var renderer = new NativeCanvasSceneRenderer();
+        try
+        {
+            var layers = Enumerable.Range(0, 4)
+                .Select(index => Layer(index, index, checked((uint)index)))
+                .ToArray();
+            var commands = Commands(4);
+            Assert.True(Apply(renderer, layers, commands, 1, 0, checkpoint: true));
+            Assert.True(renderer.HasConsistentLayerOrder());
+
+            layers = [Layer(0, 0, 10)];
+            commands = Commands(1);
+            Assert.True(Apply(renderer, layers, commands, 2, 1, checkpoint: false));
+            Assert.True(renderer.HasConsistentLayerOrder());
+
+            layers = [Layer(0, 0, 10, generation: 3)];
+            Assert.True(Apply(renderer, layers, commands, 3, 2, checkpoint: false));
+            Assert.True(renderer.HasConsistentLayerOrder());
+
+            layers = [Layer(0, 0, 0, generation: 4)];
+            Assert.True(Apply(renderer, layers, commands, 4, 3, checkpoint: false));
+            Assert.True(renderer.HasConsistentLayerOrder());
+        }
+        finally
+        {
+            renderer.Reset();
+        }
+    }
+
+    [Fact]
+    public void Invalid_checkpoint_is_rejected_before_live_scene_reset()
+    {
+        var renderer = new NativeCanvasSceneRenderer();
+        try
+        {
+            var layers = Enumerable.Range(0, 4)
+                .Select(index => Layer(index, index, checked((uint)index)))
+                .ToArray();
+            Assert.True(Apply(renderer, layers, Commands(4), 1, 0, checkpoint: true));
+            Assert.Equal(4, renderer.TotalCommandCount);
+
+            var malformed = Layer(0, commandOffset: 1, zOrder: 0);
+            Assert.False(Apply(
+                renderer,
+                [malformed],
+                Commands(1),
+                revision: 2,
+                baseRevision: 0,
+                checkpoint: true));
+            Assert.Equal(4, renderer.TotalCommandCount);
+            Assert.True(renderer.HasConsistentLayerOrder());
+        }
+        finally
+        {
+            renderer.Reset();
+        }
+    }
+
+    private static NativeCanvasLayer Layer(
+        int index,
+        int commandOffset,
+        uint zOrder,
+        ulong generation = 1)
+        => new()
+        {
+            NodeId = checked((uint)index + 1),
+            Flags = 1,
+            CommandOffset = checked((uint)commandOffset),
+            CommandCount = 1,
+            Reserved = zOrder,
+            Width = 8,
+            Height = 8,
+            BitmapWidth = 8,
+            BitmapHeight = 8,
+            Generation = generation
+        };
+
+    private static NativeCanvasCommand[] Commands(int count)
+        => Enumerable.Range(0, count)
+            .Select(_ => new NativeCanvasCommand
+            {
+                Kind = 22,
+                V2 = 8,
+                V3 = 8
+            })
+            .ToArray();
+
+    private static bool Apply(
+        NativeCanvasSceneRenderer renderer,
+        NativeCanvasLayer[] layers,
+        NativeCanvasCommand[] commands,
+        ulong revision,
+        ulong baseRevision,
+        bool checkpoint)
+    {
+        fixed (NativeCanvasLayer* layerPointer = layers)
+        fixed (NativeCanvasCommand* commandPointer = commands)
+        {
+            var view = new NativeSceneView
+            {
+                Header = new SceneHeader
+                {
+                    Revision = revision,
+                    BaseRevision = baseRevision,
+                    CanvasLayerCount = checked((uint)layers.Length),
+                    Flags = checkpoint ? 1U : 0
+                },
+                CanvasLayers = layerPointer,
+                CanvasCommands = commandPointer,
+                CanvasCommandCount = checked((uint)commands.Length)
+            };
+            return renderer.ApplyDiff(&view);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- cull and cache ordered canvas layers that intersect the current viewport while preserving complete Avalonia callback replay
- replace linear retained-layer lookup and full z-order resorting with stored indices and incremental repositioning
- validate layer ranges before checkpoint reset or retained-scene mutation
- add deterministic retained-render and retained-apply probes plus the complete NativePF optimization disposition audit

## Performance

Five fresh Release processes, median of per-process medians:

| Workload | Before | After |
|---|---:|---:|
| 2,048 layers, 32 visible replay | 265.5 us | 12.6 us |
| 2,048 layers, all visible replay | 421.4 us | 396.8 us |
| replace one of 4,096 layers | 6.17 us | 4.04 us |
| replace 256 layers | 822.6 us | 562.8 us |
| move one layer through z order | 56.5 us | 5.66 us |

## Flicker and correctness

The Avalonia renderer still reconstructs the complete visible scene on every custom-visual callback and does not use damage-only replay. The render probe clears the surface before every iteration and compares both initial and replaced sparse frames with a visible-only SHA-256 reference. Retained replay allocates zero managed bytes. The apply probe verifies sorted order, dictionary identity, and stored indices.

## Verification

- Avalonia tests net8.0: 115 passed
- Avalonia tests net10.0: 115 passed
- Uno tests net10.0: 7 passed
- benchmark project Release build: no warnings or errors
- retained-render pixel oracle: passed
- retained-apply order oracle: passed
- git diff --check: clean