### PR TITLE
Optimize TradingView dynamic stylesheet recascades

### DIFF
--- a/docs/architecture/tradingview-startup-style-optimization.md
+++ b/docs/architecture/tradingview-startup-style-optimization.md
@@ -1,0 +1,71 @@
+# TradingView startup style optimization
+
+## Scope
+
+This evaluation compares Chrome 151 with the compositor-backed
+`NativeTradingViewTerminal` sample. Readiness means that the TradingView chart iframe
+contains at least eight canvases and its loading indicator is hidden. Browser process
+launch is excluded from the Chrome navigation measurement; WebScene's desktop wall
+measurement starts immediately before `NativeWebSceneView.LoadAsync`.
+
+The page is served by a live CDN, so wall times and the amount of deferred UI loaded at
+the readiness boundary vary between processes. Native phase timings and node counts are
+the primary A/B evidence.
+
+## Baseline diagnosis
+
+Warm Chrome reached the chart in 1.11-1.15 seconds and spent 34-38 ms in style
+recalculation. The original warm WebScene path reached the chart in 1.42 seconds and
+spent approximately 370 ms in connected-stylesheet recascade. Its resource cache hit
+209 of 211 requests and its persistent compilation cache hit all 120 disk-cache
+lookups, ruling out broken caches as the primary cause.
+
+The original connected-link path reapplied appended rules to every existing element.
+If any appended rule defined a custom property, it then rematched every element against
+the complete accumulated stylesheet rule set to find all `var()`-dependent properties.
+
+## Implementation
+
+The optimized path:
+
+1. Indexes stylesheet rules by every custom property referenced through `var()`.
+2. Computes the transitive custom-property dependency closure once per connected
+   stylesheet.
+3. Builds one recascade plan per stylesheet, preserving source order and each link's
+   load-event boundary.
+4. Projects dependent rules through the existing tag, id, class, and attribute selector
+   indexes.
+5. Replays the complete cascade only for affected properties on candidate nodes,
+   including variable-dependent inline declarations.
+
+Certification builds retain
+`WEBSCENE_PROBE_DISABLE_CSS_VARIABLE_DEPENDENCY_FILTER=1` as an A/B control for the
+former broad scan.
+
+## Results
+
+Representative warm-cache certification runs against the same native binary and cache:
+
+| Path | Stylesheet recascade | Cumulative node visits | Variable nodes | Rules loaded at readiness |
+|---|---:|---:|---:|---:|
+| Broad-scan control | 346.7-372.8 ms | 39,310-49,962 | 22,769-28,763 | 3,926-4,289 |
+| Dependency plan | 67.1-97.0 ms | 83,949-88,921 | 469-520 | 5,704-5,843 |
+
+The optimized recascade is 72-82% faster in absolute time despite processing roughly
+twice as many cumulative node visits before the readiness boundary. Only about 0.6% of
+optimized visits require variable-dependent cascade replay, compared with roughly 58%
+under the broad control path. Normalized recascade cost falls from approximately
+7.5-8.8 microseconds per visit to 0.75-1.16 microseconds per visit.
+
+The optimized runs also have substantially more of TradingView's deferred UI stylesheet
+graph loaded by the time the chart becomes ready. This supports the reported visual
+improvement: stylesheet work no longer blocks later toolbar, sidebar, and widget chunks
+for hundreds of milliseconds.
+
+## Iframe conclusion
+
+Warm frame hydration measured about 90-105 ms. Frame resource prefetch is already
+asynchronous, although frame parsing and execution are scheduled serially. After the
+style optimization, iframe hydration is no longer large enough to justify changing its
+event-loop and lifecycle semantics without a separate deterministic workload showing a
+remaining bottleneck.

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime.cpp
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime.cpp
@@ -3822,6 +3822,8 @@ std::string v8_dom_runtime::diagnostics()
             << ",subtree-recascade=" << format(impl_->startup_subtree_recascade)
             << ",stylesheet-recascade=" << format(impl_->startup_stylesheet_recascade)
             << ",stylesheet-nodes=" << impl_->startup_stylesheet_recascade_nodes
+            << ",stylesheet-variable-nodes="
+            << impl_->startup_stylesheet_variable_nodes
             << ",css-rules=" << impl_->css_rules.size()
             << ",css-unindexed=" << impl_->unindexed_css_rules.size()
             << ",script=" << format(impl_->startup_script_execute)
@@ -4509,6 +4511,7 @@ v8_dom_runtime::memory_metrics v8_dom_runtime::read_memory_metrics() const noexc
         + indexed_rule_storage(impl_->css_rules_by_id)
         + indexed_rule_storage(impl_->css_rules_by_tag)
         + indexed_rule_storage(impl_->css_rules_by_attribute)
+        + indexed_rule_storage(impl_->css_rules_by_variable_reference)
         + impl_->css_focus_rules.capacity() * sizeof(size_t)
         + impl_->unindexed_css_rules.capacity() * sizeof(size_t)
         + impl_->hover_selector_dependencies.capacity()

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime.cpp
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime.cpp
@@ -3813,6 +3813,35 @@ std::string v8_dom_runtime::diagnostics()
             result << ']';
             return std::move(result).str();
         };
+        const auto format_phase_top = [&format](const auto& profiles) {
+            std::vector<std::pair<std::string, startup_nested_phase_stats>> ordered(
+                profiles.begin(),
+                profiles.end());
+            std::sort(ordered.begin(), ordered.end(), [](const auto& left, const auto& right) {
+                return left.second.elapsed.nanoseconds > right.second.elapsed.nanoseconds;
+            });
+            std::ostringstream result;
+            result << '[';
+            const auto count = std::min<size_t>(ordered.size(), 8U);
+            for (size_t index = 0; index < count; ++index) {
+                if (index != 0U) result << ',';
+                const auto& [name, phases] = ordered[index];
+                result << name << ":{task=" << format(phases.elapsed)
+                    << ",dirty=" << phases.clean_to_dirty_transitions
+                    << '/' << phases.tasks_left_dirty
+                    << ",layout-pass=" << phases.layout_passes
+                    << ",layout=" << format(phases.layout)
+                    << ",css-apply=" << format(phases.css_apply)
+                    << ",css-inc=" << format(phases.css_incremental_apply)
+                    << ",subtree=" << format(phases.subtree_recascade)
+                    << ",sheet=" << format(phases.stylesheet_recascade)
+                    << ",sheet-nodes=" << phases.stylesheet_nodes
+                    << ",variable-nodes=" << phases.stylesheet_variable_nodes
+                    << '}';
+            }
+            result << ']';
+            return std::move(result).str();
+        };
         description << ", startup-profile={hydrate="
             << format(impl_->startup_frame_hydrate)
             << ",io=" << format(impl_->startup_resource_read)
@@ -3822,6 +3851,8 @@ std::string v8_dom_runtime::diagnostics()
             << ",subtree-recascade=" << format(impl_->startup_subtree_recascade)
             << ",stylesheet-recascade=" << format(impl_->startup_stylesheet_recascade)
             << ",stylesheet-nodes=" << impl_->startup_stylesheet_recascade_nodes
+            << ",stylesheet-candidate-nodes="
+            << impl_->startup_stylesheet_candidate_nodes
             << ",stylesheet-variable-nodes="
             << impl_->startup_stylesheet_variable_nodes
             << ",css-rules=" << impl_->css_rules.size()
@@ -3837,7 +3868,11 @@ std::string v8_dom_runtime::diagnostics()
             << impl_->startup_max_timer_delay_ms << "ms"
             << ",task-callbacks=" << format(impl_->startup_task_callbacks)
             << ",script-top=" << format_top(impl_->startup_script_profiles)
-            << ",task-top=" << format_top(impl_->startup_task_profiles);
+            << ",task-top=" << format_top(impl_->startup_task_profiles)
+            << ",script-phase-top="
+            << format_phase_top(impl_->startup_script_phase_profiles)
+            << ",task-phase-top="
+            << format_phase_top(impl_->startup_task_phase_profiles);
         const auto profile_now = std::chrono::steady_clock::now();
         if (impl_->startup_profile_started != std::chrono::steady_clock::time_point{}) {
             description << ",total=" << std::fixed << std::setprecision(1)

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime.cpp
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime.cpp
@@ -3829,6 +3829,8 @@ std::string v8_dom_runtime::diagnostics()
                 result << name << ":{task=" << format(phases.elapsed)
                     << ",dirty=" << phases.clean_to_dirty_transitions
                     << '/' << phases.tasks_left_dirty
+                    << ",io=" << format(phases.resource_read)
+                    << ",css-parse=" << format(phases.css_parse)
                     << ",layout-pass=" << phases.layout_passes
                     << ",layout=" << format(phases.layout)
                     << ",css-apply=" << format(phases.css_apply)
@@ -3837,6 +3839,7 @@ std::string v8_dom_runtime::diagnostics()
                     << ",sheet=" << format(phases.stylesheet_recascade)
                     << ",sheet-nodes=" << phases.stylesheet_nodes
                     << ",variable-nodes=" << phases.stylesheet_variable_nodes
+                    << ",script=" << format(phases.script_execute)
                     << '}';
             }
             result << ']';
@@ -3872,7 +3875,9 @@ std::string v8_dom_runtime::diagnostics()
             << ",script-phase-top="
             << format_phase_top(impl_->startup_script_phase_profiles)
             << ",task-phase-top="
-            << format_phase_top(impl_->startup_task_phase_profiles);
+            << format_phase_top(impl_->startup_task_phase_profiles)
+            << ",frame-phase-top="
+            << format_phase_top(impl_->startup_frame_phase_profiles);
         const auto profile_now = std::chrono::steady_clock::now();
         if (impl_->startup_profile_started != std::chrono::steady_clock::time_point{}) {
             description << ",total=" << std::fixed << std::setprecision(1)
@@ -3900,7 +3905,8 @@ std::string v8_dom_runtime::diagnostics()
                     << "/ms" << std::fixed << std::setprecision(3)
                     << static_cast<double>(stats.nanoseconds) / 1'000'000.0;
             }
-            description << ']';
+            description << "],binding-top="
+                << format_top(impl_->startup_binding_profiles);
         }
     }
     description << " | html-parser={implementation="

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_browser_apis.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_browser_apis.inc
@@ -1692,7 +1692,9 @@
     static void get_inner_width(v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_geometry));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_geometry),
+            self->profile_named("Window.innerWidth.get"));
         const auto [width, height, device_scale_factor, preferred_color_scheme] =
             self->viewport_provider();
         static_cast<void>(height);
@@ -1704,7 +1706,9 @@
     static void get_inner_height(v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_geometry));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_geometry),
+            self->profile_named("Window.innerHeight.get"));
         const auto [width, height, device_scale_factor, preferred_color_scheme] =
             self->viewport_provider();
         static_cast<void>(width);
@@ -1735,7 +1739,8 @@
     {
         auto* self = current(info.GetIsolate());
         binding_callback_timer binding_timer(
-            self->profile(binding_category::dom_geometry));
+            self->profile(binding_category::dom_geometry),
+            self->profile_named("Window.scrollX.get"));
         const auto* frame = frame_owner_for_window(*self, info.Holder());
         const auto known = frame == nullptr
             ? self->frame_window_scroll_offsets.end()
@@ -1752,7 +1757,8 @@
     {
         auto* self = current(info.GetIsolate());
         binding_callback_timer binding_timer(
-            self->profile(binding_category::dom_geometry));
+            self->profile(binding_category::dom_geometry),
+            self->profile_named("Window.scrollY.get"));
         const auto* frame = frame_owner_for_window(*self, info.Holder());
         const auto known = frame == nullptr
             ? self->frame_window_scroll_offsets.end()
@@ -1767,7 +1773,8 @@
     {
         auto* self = current(info.GetIsolate());
         binding_callback_timer binding_timer(
-            self->profile(binding_category::dom_geometry));
+            self->profile(binding_category::dom_geometry),
+            self->profile_named("Window.scrollTo"));
         self->ensure_layout();
 
         auto& root = self->active_root();
@@ -1834,7 +1841,9 @@
         const v8::PropertyCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_geometry));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_geometry),
+            self->profile_named("Window.devicePixelRatio.get"));
         const auto [width, height, device_scale_factor, preferred_color_scheme] =
             self->viewport_provider();
         static_cast<void>(width);
@@ -1852,7 +1861,9 @@
         const v8::PropertyCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_geometry));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_geometry),
+            self->profile_named("Screen.width.get"));
         const auto [width, height, device_scale_factor, preferred_color_scheme] =
             self->viewport_provider();
         static_cast<void>(height);
@@ -1868,7 +1879,9 @@
         const v8::PropertyCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_geometry));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_geometry),
+            self->profile_named("Screen.height.get"));
         const auto [width, height, device_scale_factor, preferred_color_scheme] =
             self->viewport_provider();
         static_cast<void>(width);

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_cache_and_frames.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_cache_and_frames.inc
@@ -1015,6 +1015,9 @@
         const auto profile_started = profile_startup
             ? std::chrono::steady_clock::now()
             : std::chrono::steady_clock::time_point{};
+        const auto script_phase_before = profile_startup
+            ? capture_startup_phase_snapshot()
+            : startup_phase_snapshot{};
 #endif
         v8::Context::Scope context_scope(local_context);
         v8::TryCatch try_catch(isolate);
@@ -1023,8 +1026,15 @@
                 source,
                 document_name,
                 script,
-                std::move(immutable_source))
-            || script->Run(local_context).IsEmpty()) {
+                std::move(immutable_source))) {
+#if defined(WEBSCENE_NATIVE_ENGINE_WITH_V8_INSPECTOR)
+            report_inspector_exception(try_catch, local_context);
+#endif
+            error = describe_exception(try_catch, local_context);
+            return false;
+        }
+        style_recascade_batch_scope style_batch(*this);
+        if (script->Run(local_context).IsEmpty()) {
 #if defined(WEBSCENE_NATIVE_ENGINE_WITH_V8_INSPECTOR)
             report_inspector_exception(try_catch, local_context);
 #endif
@@ -1032,13 +1042,21 @@
             return false;
         }
         if (checkpoint_microtasks) perform_microtask_checkpoint();
+        style_batch.finish();
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
         if (profile_startup) {
-            auto& stats = startup_script_profiles[resource_leaf_name(document_name)];
-            ++stats.calls;
-            stats.nanoseconds += static_cast<uint64_t>(
+            const auto script_name = resource_leaf_name(document_name);
+            const auto elapsed_nanoseconds = static_cast<uint64_t>(
                 std::chrono::duration_cast<std::chrono::nanoseconds>(
                     std::chrono::steady_clock::now() - profile_started).count());
+            auto& stats = startup_script_profiles[script_name];
+            ++stats.calls;
+            stats.nanoseconds += elapsed_nanoseconds;
+            record_startup_nested_phases(
+                startup_script_phase_profiles,
+                script_name,
+                script_phase_before,
+                elapsed_nanoseconds);
         }
 #endif
         return true;

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_cache_and_frames.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_cache_and_frames.inc
@@ -1668,6 +1668,40 @@
             startup_frame_started = std::chrono::steady_clock::now();
         }
         binding_callback_timer timer(profile_startup ? &startup_frame_hydrate : nullptr);
+        auto frame_profile_name = "iframe#" + std::to_string(frame.id);
+        if (const auto source = frame.attributes.find("src");
+            source != frame.attributes.end() && !source->second.empty()) {
+            auto source_name = resource_leaf_name(source->second);
+            constexpr size_t maximum_source_name = 80U;
+            if (source_name.size() > maximum_source_name) {
+                source_name.resize(maximum_source_name);
+            }
+            frame_profile_name += ':' + source_name;
+        }
+        const auto frame_profile_started = profile_startup
+            ? std::chrono::steady_clock::now()
+            : std::chrono::steady_clock::time_point{};
+        const auto frame_phase_before = profile_startup
+            ? capture_startup_phase_snapshot()
+            : startup_phase_snapshot{};
+        const auto finish_frame_profile = [
+            this,
+            frame_profile_name,
+            frame_profile_started,
+            frame_phase_before](void*) {
+            if (!profile_startup) return;
+            const auto elapsed_nanoseconds = static_cast<uint64_t>(
+                std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::steady_clock::now() - frame_profile_started).count());
+            record_startup_nested_phases(
+                startup_frame_phase_profiles,
+                frame_profile_name,
+                frame_phase_before,
+                elapsed_nanoseconds);
+        };
+        std::unique_ptr<void, decltype(finish_frame_profile)> frame_profile_scope(
+            profile_startup ? this : nullptr,
+            finish_frame_profile);
 #endif
         const auto html_iterator = frame.attributes.find("frame-html");
         const auto object_iterator = frame.attributes.find("object-html");

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_cache_and_frames.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_cache_and_frames.inc
@@ -1714,6 +1714,7 @@
         css_rules_by_id.clear();
         css_rules_by_tag.clear();
         css_rules_by_attribute.clear();
+        css_rules_by_variable_reference.clear();
         css_focus_rules.clear();
         unindexed_css_rules.clear();
         css_attribute_dependencies.clear();

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_cache_and_frames.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_cache_and_frames.inc
@@ -1703,6 +1703,33 @@
             profile_startup ? this : nullptr,
             finish_frame_profile);
 #endif
+        if (!frame.attributes.contains("frame-html")
+            && !frame.attributes.contains("object-html")) {
+            const auto remote_result = frame.attributes.find(
+                "data-webscene-remote-result");
+            const auto source = frame.attributes.find("src");
+            if (remote_result != frame.attributes.end()
+                && remote_result->second == "pending"
+                && source != frame.attributes.end()) {
+                std::string html;
+                std::string resolved_name;
+                if (!load_text_resource(
+                        source->second,
+                        {},
+                        WEBSCENE_RESOURCE_DOCUMENT,
+                        html,
+                        resolved_name)) {
+                    frame.attributes["data-webscene-remote-result"] = "failed";
+                    frame_last_error_value = "Unable to load iframe document: "
+                        + source->second;
+                    ++frame_script_error_count;
+                    return false;
+                }
+                frame.attributes["src"] = std::move(resolved_name);
+                frame.attributes["object-html"] = std::move(html);
+                frame.attributes["data-webscene-remote-result"] = "loaded";
+            }
+        }
         const auto html_iterator = frame.attributes.find("frame-html");
         const auto object_iterator = frame.attributes.find("object-html");
         const auto& html = html_iterator != frame.attributes.end() && !html_iterator->second.empty()

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_cascade.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_cascade.inc
@@ -3371,9 +3371,15 @@
         std::string_view reason = {})
     {
         if (style_recascade_batch_depth != 0U) {
+            binding_callback_timer timer(
+                nullptr,
+                profile_named("style-recascade/subtree-scheduled"));
             schedule_style_recascade(node, true, reason);
             return;
         }
+        binding_callback_timer timer(
+            nullptr,
+            profile_named("style-recascade/subtree-immediate"));
         recascade_connected_subtree_now(node, reason);
     }
 
@@ -3381,9 +3387,15 @@
     {
         if (!is_connected(node)) return;
         if (style_recascade_batch_depth != 0U) {
+            binding_callback_timer timer(
+                nullptr,
+                profile_named("style-recascade/node-scheduled"));
             schedule_style_recascade(node, false, {});
             return;
         }
+        binding_callback_timer timer(
+            nullptr,
+            profile_named("style-recascade/node-immediate"));
         apply_css_rules(node);
     }
 

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_cascade.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_cascade.inc
@@ -2874,19 +2874,213 @@
         document.mark_dirty();
     }
 
-    bool appended_css_rules_define_custom_properties(size_t first_new_rule) const
+    std::unordered_set<std::string> appended_css_custom_properties(
+        size_t first_new_rule) const
     {
+        std::unordered_set<std::string> properties;
         for (auto index = first_new_rule; index < css_rules.size(); ++index) {
             for (const auto& declaration : css_rules[index].declarations()) {
-                if (declaration.name.starts_with("--")) return true;
+                if (declaration.name.starts_with("--")) {
+                    properties.insert(declaration.name);
+                }
             }
         }
-        return false;
+        return properties;
     }
 
-    void reapply_css_variable_dependent_rules(dom_node& node)
+    void expand_css_variable_dependencies(
+        std::unordered_set<std::string>& properties) const
     {
-        if (node.tag == "#text") return;
+        std::vector<std::string> pending(properties.begin(), properties.end());
+        for (size_t cursor = 0U; cursor < pending.size(); ++cursor) {
+            const auto indexed = css_rules_by_variable_reference.find(pending[cursor]);
+            if (indexed == css_rules_by_variable_reference.end()) continue;
+            for (const auto rule_index : indexed->second) {
+                if (rule_index >= css_rules.size()) continue;
+                for (const auto& declaration : css_rules[rule_index].declarations()) {
+                    if (!declaration.name.starts_with("--")) continue;
+                    const auto references = css_variable_references(declaration.value);
+                    if (!references.contains(pending[cursor])) continue;
+                    if (properties.insert(declaration.name).second) {
+                        pending.push_back(declaration.name);
+                    }
+                }
+            }
+        }
+    }
+
+    struct css_variable_recascade_rule final {
+        size_t index{0U};
+        std::vector<std::string> properties;
+    };
+
+    struct css_variable_recascade_plan final {
+        std::unordered_set<std::string> variables;
+        std::vector<css_variable_recascade_rule> rules;
+        std::unordered_map<std::string, std::vector<size_t>> rules_by_class;
+        std::unordered_map<std::string, std::vector<size_t>> rules_by_id;
+        std::unordered_map<std::string, std::vector<size_t>> rules_by_tag;
+        std::unordered_map<std::string, std::vector<size_t>> rules_by_attribute;
+        std::vector<size_t> focus_rules;
+        std::vector<size_t> unindexed_rules;
+    };
+
+    css_variable_recascade_plan make_css_variable_recascade_plan(
+        size_t first_new_rule) const
+    {
+        css_variable_recascade_plan plan;
+        plan.variables = appended_css_custom_properties(first_new_rule);
+        expand_css_variable_dependencies(plan.variables);
+        if (plan.variables.empty()) return plan;
+
+        std::vector<size_t> dependent_rules;
+        for (const auto& variable : plan.variables) {
+            const auto indexed = css_rules_by_variable_reference.find(variable);
+            if (indexed != css_rules_by_variable_reference.end()) {
+                dependent_rules.insert(
+                    dependent_rules.end(),
+                    indexed->second.begin(),
+                    indexed->second.end());
+            }
+        }
+        std::sort(dependent_rules.begin(), dependent_rules.end());
+        dependent_rules.erase(
+            std::unique(dependent_rules.begin(), dependent_rules.end()),
+            dependent_rules.end());
+        for (const auto index : dependent_rules) {
+            if (index >= css_rules.size()) continue;
+            css_variable_recascade_rule dependent{index, {}};
+            for (const auto& declaration : css_rules[index].declarations()) {
+                if (declaration.name.starts_with("--")) continue;
+                const auto references = css_variable_references(declaration.value);
+                if (std::any_of(
+                        references.begin(),
+                        references.end(),
+                        [&](const auto& reference) {
+                            return plan.variables.contains(reference);
+                        })) {
+                    dependent.properties.push_back(declaration.name);
+                }
+            }
+            std::sort(dependent.properties.begin(), dependent.properties.end());
+            dependent.properties.erase(
+                std::unique(
+                    dependent.properties.begin(), dependent.properties.end()),
+                dependent.properties.end());
+            if (!dependent.properties.empty()) {
+                plan.rules.push_back(std::move(dependent));
+            }
+        }
+        std::unordered_map<size_t, size_t> plan_index_by_rule;
+        for (size_t index = 0U; index < plan.rules.size(); ++index) {
+            plan_index_by_rule.emplace(plan.rules[index].index, index);
+        }
+        const auto project_index = [&](const auto& source, auto& target) {
+            for (const auto& [key, rule_indexes] : source) {
+                for (const auto rule_index : rule_indexes) {
+                    const auto found = plan_index_by_rule.find(rule_index);
+                    if (found != plan_index_by_rule.end()) {
+                        target[key].push_back(found->second);
+                    }
+                }
+            }
+        };
+        project_index(css_rules_by_class, plan.rules_by_class);
+        project_index(css_rules_by_id, plan.rules_by_id);
+        project_index(css_rules_by_tag, plan.rules_by_tag);
+        project_index(css_rules_by_attribute, plan.rules_by_attribute);
+        for (const auto rule_index : css_focus_rules) {
+            const auto found = plan_index_by_rule.find(rule_index);
+            if (found != plan_index_by_rule.end()) {
+                plan.focus_rules.push_back(found->second);
+            }
+        }
+        for (const auto rule_index : unindexed_css_rules) {
+            const auto found = plan_index_by_rule.find(rule_index);
+            if (found != plan_index_by_rule.end()) {
+                plan.unindexed_rules.push_back(found->second);
+            }
+        }
+        return plan;
+    }
+
+    void reapply_css_variable_dependent_rules(
+        dom_node& node,
+        const css_variable_recascade_plan& plan)
+    {
+        if (node.tag == "#text" || plan.variables.empty()) return;
+
+        const auto references_affected_variable = [&](std::string_view value) {
+            const auto references = css_variable_references(value);
+            return std::any_of(
+                references.begin(),
+                references.end(),
+                [&](const auto& reference) {
+                    return plan.variables.contains(reference);
+                });
+        };
+
+        auto filter_by_variable_dependency = true;
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+        filter_by_variable_dependency =
+            std::getenv("WEBSCENE_PROBE_DISABLE_CSS_VARIABLE_DEPENDENCY_FILTER")
+                == nullptr;
+#endif
+        std::unordered_set<std::string> variable_dependent_properties;
+        if (filter_by_variable_dependency) {
+            auto plan_candidates = plan.unindexed_rules;
+            const auto append_plan_candidates = [&](const auto& index, const std::string& key) {
+                const auto match = index.find(key);
+                if (match != index.end()) {
+                    plan_candidates.insert(
+                        plan_candidates.end(), match->second.begin(), match->second.end());
+                }
+            };
+            append_plan_candidates(plan.rules_by_tag, node.tag);
+            if (node.tag == "body"
+                && (node.parent == nullptr || node.parent->tag == "iframe")) {
+                append_plan_candidates(plan.rules_by_tag, "html");
+            }
+            if (!node.id_attribute.empty()) {
+                append_plan_candidates(plan.rules_by_id, node.id_attribute);
+            }
+            for (const auto& [name, value] : node.attributes) {
+                static_cast<void>(value);
+                append_plan_candidates(plan.rules_by_attribute, name);
+            }
+            if (&node == active_element) {
+                plan_candidates.insert(
+                    plan_candidates.end(),
+                    plan.focus_rules.begin(),
+                    plan.focus_rules.end());
+            }
+            std::istringstream classes(node.class_name);
+            for (std::string class_name; classes >> class_name;) {
+                append_plan_candidates(plan.rules_by_class, class_name);
+            }
+            std::sort(plan_candidates.begin(), plan_candidates.end());
+            plan_candidates.erase(
+                std::unique(plan_candidates.begin(), plan_candidates.end()),
+                plan_candidates.end());
+            for (const auto candidate : plan_candidates) {
+                const auto& dependent = plan.rules[candidate];
+                const auto& rule = css_rules[dependent.index];
+                if (!rule.media_matches || !css_rule_matches(node, rule)) continue;
+                variable_dependent_properties.insert(
+                    dependent.properties.begin(),
+                    dependent.properties.end());
+            }
+            for (const auto& [name, value] : node.authored_style().declarations) {
+                if (!name.starts_with("--") && references_affected_variable(value)) {
+                    variable_dependent_properties.insert(name);
+                }
+            }
+            if (variable_dependent_properties.empty()) return;
+        }
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+        if (profile_startup) ++startup_stylesheet_variable_nodes;
+#endif
+
         std::vector<size_t> candidates = unindexed_css_rules;
         const auto append_candidates = [&](const auto& index, const std::string& key) {
             const auto match = index.find(key);
@@ -2918,15 +3112,16 @@
         candidates.erase(std::unique(candidates.begin(), candidates.end()), candidates.end());
 
         std::vector<const css_rule*> matched_rules;
-        std::unordered_set<std::string> variable_dependent_properties;
         for (const auto index : candidates) {
             const auto& rule = css_rules[index];
             if (!rule.media_matches || !css_rule_matches(node, rule)) continue;
             matched_rules.push_back(&rule);
-            for (const auto& declaration : rule.declarations()) {
-                if (!declaration.name.starts_with("--")
-                    && declaration.value.find("var(") != std::string::npos) {
-                    variable_dependent_properties.insert(declaration.name);
+            if (!filter_by_variable_dependency) {
+                for (const auto& declaration : rule.declarations()) {
+                    if (!declaration.name.starts_with("--")
+                        && declaration.value.find("var(") != std::string::npos) {
+                        variable_dependent_properties.insert(declaration.name);
+                    }
                 }
             }
         }
@@ -2940,6 +3135,20 @@
                     apply_css_declaration(node, declaration);
                 }
             }
+        }
+        for (const auto& [name, value] : node.authored_style().declarations) {
+            if (!variable_dependent_properties.contains(name)
+                || !references_affected_variable(value)) {
+                continue;
+            }
+            const auto property_mask = inline_style_mask(name);
+            const auto retained_inline_mask = node.style.inline_property_mask;
+            node.style.inline_property_mask &= ~property_mask;
+            apply_css_declaration(
+                node,
+                {name, value,
+                    node.authored_style().important_declarations.contains(name)});
+            node.style.inline_property_mask = retained_inline_mask;
         }
         document.mark_dirty();
     }
@@ -3184,6 +3393,7 @@
         css_rules_by_id.clear();
         css_rules_by_tag.clear();
         css_rules_by_attribute.clear();
+        css_rules_by_variable_reference.clear();
         css_focus_rules.clear();
         unindexed_css_rules.clear();
         css_attribute_dependencies.clear();

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_cascade.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_cascade.inc
@@ -2776,19 +2776,74 @@
 #endif
     }
 
-    void apply_appended_css_rules(dom_node& node, size_t first_new_rule)
+    bool has_appended_css_rule_candidate(
+        const dom_node& node,
+        size_t first_new_rule) const
+    {
+        if (node.tag == "#text" || first_new_rule >= css_rules.size()) return false;
+        const auto contains_new_rule = [first_new_rule](
+            const std::vector<size_t>& indexes) {
+            return !indexes.empty() && indexes.back() >= first_new_rule;
+        };
+        const auto index_contains_new_rule = [&contains_new_rule](
+            const auto& index,
+            const std::string& key) {
+            const auto match = index.find(key);
+            return match != index.end() && contains_new_rule(match->second);
+        };
+        if (contains_new_rule(unindexed_css_rules)
+            || index_contains_new_rule(css_rules_by_tag, node.tag)
+            || (!node.id_attribute.empty()
+                && index_contains_new_rule(css_rules_by_id, node.id_attribute))) {
+            return true;
+        }
+        if (node.tag == "body"
+            && (node.parent == nullptr || node.parent->tag == "iframe")
+            && index_contains_new_rule(css_rules_by_tag, "html")) {
+            return true;
+        }
+        for (const auto& [name, value] : node.attributes) {
+            static_cast<void>(value);
+            if (index_contains_new_rule(css_rules_by_attribute, name)) return true;
+        }
+        if (&node == active_element && contains_new_rule(css_focus_rules)) return true;
+        const std::string_view classes(node.class_name);
+        size_t cursor = 0U;
+        while (cursor < classes.size()) {
+            while (cursor < classes.size()
+                && std::isspace(static_cast<unsigned char>(classes[cursor]))) ++cursor;
+            const auto start = cursor;
+            while (cursor < classes.size()
+                && !std::isspace(static_cast<unsigned char>(classes[cursor]))) ++cursor;
+            if (cursor > start
+                && index_contains_new_rule(
+                    css_rules_by_class,
+                    std::string(classes.substr(start, cursor - start)))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool apply_appended_css_rules(dom_node& node, size_t first_new_rule)
     {
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
         binding_callback_timer timer(
             profile_startup ? &startup_css_incremental_apply : nullptr);
 #endif
-        if (node.tag == "#text" || first_new_rule >= css_rules.size()) return;
+        if (node.tag == "#text" || first_new_rule >= css_rules.size()) return false;
 
-        std::vector<size_t> candidates = unindexed_css_rules;
+        std::vector<size_t> candidates;
+        const auto append_new_candidates = [&](const std::vector<size_t>& source) {
+            const auto first = std::lower_bound(
+                source.begin(), source.end(), first_new_rule);
+            candidates.insert(candidates.end(), first, source.end());
+        };
+        append_new_candidates(unindexed_css_rules);
         const auto append_candidates = [&](const auto& index, const std::string& key) {
             const auto match = index.find(key);
             if (match != index.end()) {
-                candidates.insert(candidates.end(), match->second.begin(), match->second.end());
+                append_new_candidates(match->second);
             }
         };
         append_candidates(css_rules_by_tag, node.tag);
@@ -2802,10 +2857,7 @@
             append_candidates(css_rules_by_attribute, name);
         }
         if (&node == active_element) {
-            candidates.insert(
-                candidates.end(),
-                css_focus_rules.begin(),
-                css_focus_rules.end());
+            append_new_candidates(css_focus_rules);
         }
         const std::string_view classes(node.class_name);
         size_t class_cursor = 0;
@@ -2822,11 +2874,9 @@
             }
         }
         sort_css_candidates(candidates);
-        candidates.erase(std::remove_if(
-            candidates.begin(),
-            candidates.end(),
-            [first_new_rule](size_t index) { return index < first_new_rule; }), candidates.end());
         candidates.erase(std::unique(candidates.begin(), candidates.end()), candidates.end());
+
+        if (filter_stylesheet_candidates && candidates.empty()) return false;
 
         std::vector<const css_rule*> matched_rules;
         std::vector<std::pair<int, const css_rule*>> matched_pseudo_rules;
@@ -2842,6 +2892,11 @@
                 continue;
             }
             if (css_rule_matches(node, rule)) matched_rules.push_back(&rule);
+        }
+        if (filter_stylesheet_candidates
+            && matched_rules.empty()
+            && matched_pseudo_rules.empty()) {
+            return false;
         }
         for (const auto* rule : matched_rules) {
             for (const auto& declaration : rule->declarations()) {
@@ -2872,6 +2927,7 @@
         document.update_style_animations(node);
         detect_css_compositions(node);
         document.mark_dirty();
+        return true;
     }
 
     std::unordered_set<std::string> appended_css_custom_properties(
@@ -3004,11 +3060,11 @@
         return plan;
     }
 
-    void reapply_css_variable_dependent_rules(
+    bool reapply_css_variable_dependent_rules(
         dom_node& node,
         const css_variable_recascade_plan& plan)
     {
-        if (node.tag == "#text" || plan.variables.empty()) return;
+        if (node.tag == "#text" || plan.variables.empty()) return false;
 
         const auto references_affected_variable = [&](std::string_view value) {
             const auto references = css_variable_references(value);
@@ -3075,7 +3131,7 @@
                     variable_dependent_properties.insert(name);
                 }
             }
-            if (variable_dependent_properties.empty()) return;
+            if (variable_dependent_properties.empty()) return false;
         }
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
         if (profile_startup) ++startup_stylesheet_variable_nodes;
@@ -3151,6 +3207,7 @@
             node.style.inline_property_mask = retained_inline_mask;
         }
         document.mark_dirty();
+        return true;
     }
 
     void apply_css_rules_subtree(dom_node& node)
@@ -3180,7 +3237,7 @@
         return false;
     }
 
-    void recascade_connected_subtree(
+    void recascade_connected_subtree_now(
         dom_node& node,
         std::string_view reason = {})
     {
@@ -3259,9 +3316,74 @@
 #endif
     }
 
+    void schedule_style_recascade(
+        dom_node& root,
+        bool subtree,
+        std::string_view reason)
+    {
+        if (!is_connected(root)) return;
+        retain_connected_subtree_wrappers(root);
+        for (auto& pending : pending_style_recascades) {
+            if (pending.root != &root) continue;
+            pending.subtree = pending.subtree || subtree;
+            if (pending.reason.empty() && !reason.empty()) pending.reason = reason;
+            return;
+        }
+        if (std::any_of(
+                pending_style_recascades.begin(),
+                pending_style_recascades.end(),
+                [this, &root](const pending_style_recascade& pending) {
+                    return pending.subtree
+                        && pending.root != nullptr
+                        && subtree_contains(*pending.root, &root);
+                })) {
+            return;
+        }
+        if (subtree) {
+            std::erase_if(
+                pending_style_recascades,
+                [this, &root](const pending_style_recascade& pending) {
+                    return pending.root != nullptr
+                        && subtree_contains(root, pending.root);
+                });
+        }
+        pending_style_recascades.push_back(
+            pending_style_recascade{&root, subtree, std::string(reason)});
+    }
+
+    void flush_pending_style_recascades()
+    {
+        if (pending_style_recascades.empty()) return;
+        auto pending = std::move(pending_style_recascades);
+        pending_style_recascades.clear();
+        for (const auto& recascade : pending) {
+            if (recascade.root == nullptr || !is_connected(*recascade.root)) continue;
+            if (recascade.subtree) {
+                recascade_connected_subtree_now(*recascade.root, recascade.reason);
+            } else {
+                apply_css_rules(*recascade.root);
+            }
+        }
+    }
+
+    void recascade_connected_subtree(
+        dom_node& node,
+        std::string_view reason = {})
+    {
+        if (style_recascade_batch_depth != 0U) {
+            schedule_style_recascade(node, true, reason);
+            return;
+        }
+        recascade_connected_subtree_now(node, reason);
+    }
+
     void recascade_connected_node(dom_node& node)
     {
         if (!is_connected(node)) return;
+        if (style_recascade_batch_depth != 0U) {
+            schedule_style_recascade(node, false, {});
+            return;
+        }
         apply_css_rules(node);
     }
 

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_parsing.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_parsing.inc
@@ -369,12 +369,48 @@
         }
     }
 
+    static std::unordered_set<std::string> css_variable_references(
+        std::string_view value)
+    {
+        std::unordered_set<std::string> references;
+        for (size_t search = 0U;
+             (search = value.find("var(", search)) != std::string_view::npos;) {
+            auto cursor = search + 4U;
+            while (cursor < value.size()
+                && std::isspace(static_cast<unsigned char>(value[cursor]))) {
+                ++cursor;
+            }
+            const auto start = cursor;
+            while (cursor < value.size()
+                && value[cursor] != ',' && value[cursor] != ')'
+                && !std::isspace(static_cast<unsigned char>(value[cursor]))) {
+                ++cursor;
+            }
+            if (cursor > start
+                && value.substr(start, cursor - start).starts_with("--")) {
+                references.emplace(value.substr(start, cursor - start));
+            }
+            search += 4U;
+        }
+        return references;
+    }
+
     void index_css_rule(size_t index)
     {
         const auto& rule = css_rules[index];
         const auto& selector = rule.selector();
         if (selector.find("::selection") != std::string::npos) {
             return;
+        }
+        std::unordered_set<std::string> variable_references;
+        for (const auto& declaration : rule.declarations()) {
+            auto declaration_references = css_variable_references(declaration.value);
+            variable_references.insert(
+                std::make_move_iterator(declaration_references.begin()),
+                std::make_move_iterator(declaration_references.end()));
+        }
+        for (auto& reference : variable_references) {
+            css_rules_by_variable_reference[std::move(reference)].push_back(index);
         }
         index_hover_selector_dependencies(rule);
         if (selector.find(":disabled") != std::string::npos

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_document.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_document.inc
@@ -555,7 +555,9 @@
     static void get_bounding_client_rect(const v8::FunctionCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_geometry));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_geometry),
+            self->profile_named("Element.getBoundingClientRect"));
         self->ensure_layout();
         auto* node = unwrap_node(info.This());
         if (node == nullptr) return;
@@ -595,7 +597,9 @@
     static void get_client_rects(const v8::FunctionCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_geometry));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_geometry),
+            self->profile_named("Element.getClientRects"));
         self->ensure_layout();
         auto* node = unwrap_node(info.This());
         if (node == nullptr) return;
@@ -634,7 +638,9 @@
     static void set_attribute(const v8::FunctionCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_mutation));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_mutation),
+            self->profile_named("Element.setAttribute"));
         auto* node = unwrap_node(info.This());
         if (node == nullptr || info.Length() < 2) return;
         const auto raw_name = to_utf8(info.GetIsolate(), info[0]);

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_dom_core.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_dom_core.inc
@@ -3823,7 +3823,9 @@
     static void append_child(const v8::FunctionCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_mutation));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_mutation),
+            self->profile_named("Node.appendChild"));
         auto* parent = unwrap_node(info.This());
         auto* child = info.Length() > 0 && info[0]->IsObject()
             ? unwrap_node(info[0].As<v8::Object>())
@@ -3903,7 +3905,9 @@
     static void append_nodes(const v8::FunctionCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_mutation));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_mutation),
+            self->profile_named("ParentNode.append"));
         auto* parent = unwrap_node(info.This());
         if (parent == nullptr) return;
 
@@ -3979,7 +3983,9 @@
     static void remove_child(const v8::FunctionCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_mutation));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_mutation),
+            self->profile_named("Node.removeChild"));
         auto* parent = unwrap_node(info.This());
         auto* child = info.Length() > 0 && info[0]->IsObject()
             ? unwrap_node(info[0].As<v8::Object>())
@@ -4145,7 +4151,9 @@
     static void replace_with(const v8::FunctionCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_mutation));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_mutation),
+            self->profile_named("ChildNode.replaceWith"));
         auto* replaced = unwrap_node(info.This());
         if (replaced == nullptr || replaced->parent == nullptr) return;
         auto* parent = replaced->parent;
@@ -4247,7 +4255,9 @@
     static void insert_adjacent_html(const v8::FunctionCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_mutation));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_mutation),
+            self->profile_named("Element.insertAdjacentHTML"));
         auto* reference = unwrap_node(info.This());
         if (reference == nullptr || info.Length() < 2) return;
         const auto position = lower_html_name(to_utf8(info.GetIsolate(), info[0]));
@@ -4303,7 +4313,9 @@
     static void insert_adjacent_element(const v8::FunctionCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_mutation));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_mutation),
+            self->profile_named("Element.insertAdjacentElement"));
         auto* reference = unwrap_node(info.This());
         auto* child = info.Length() > 1 && info[1]->IsObject()
             ? unwrap_node(info[1].As<v8::Object>())
@@ -4432,7 +4444,9 @@
     static void insert_before(const v8::FunctionCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_mutation));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_mutation),
+            self->profile_named("Node.insertBefore"));
         self->record_feature(
             "dom",
             "method:Node.insertBefore",

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_dom_core.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_dom_core.inc
@@ -26,6 +26,7 @@
 
     void ensure_layout(const dom_node* reusable_client_geometry_subject = nullptr)
     {
+        flush_pending_style_recascades();
         if (!document.dirty()) return;
         if (reusable_client_geometry_subject != nullptr
             && document.can_reuse_client_geometry(

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_dom_core.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_dom_core.inc
@@ -1410,25 +1410,37 @@
                 if (resolved.starts_with("http://")
                     || resolved.starts_with("https://")) {
                     node.attributes["data-webscene-remote-attempt"] = resolved;
-                    std::string html;
-                    std::string resolved_name;
-                    if (load_text_resource(
+                    node.attributes["src"] = resolved;
+                    if (prefetch_iframe_documents) {
+                        start_resource_prefetch(
                             resolved,
                             {},
-                            WEBSCENE_RESOURCE_DOCUMENT,
-                            html,
-                            resolved_name)) {
-                        node.attributes["src"] = resolved;
-                        node.attributes["object-html"] = std::move(html);
-                        node.attributes["data-webscene-remote-result"] = "loaded";
+                            WEBSCENE_RESOURCE_DOCUMENT);
+                        node.attributes["data-webscene-remote-result"] = "pending";
                     } else {
-                        node.attributes["data-webscene-remote-result"] = "failed";
+                        std::string html;
+                        std::string resolved_name;
+                        if (load_text_resource(
+                                resolved,
+                                {},
+                                WEBSCENE_RESOURCE_DOCUMENT,
+                                html,
+                                resolved_name)) {
+                            node.attributes["object-html"] = std::move(html);
+                            node.attributes["data-webscene-remote-result"] = "loaded";
+                        } else {
+                            node.attributes["data-webscene-remote-result"] = "failed";
+                        }
                     }
                 }
             }
         }
+        const auto remote_result = node.attributes.find("data-webscene-remote-result");
+        const auto remote_pending = remote_result != node.attributes.end()
+            && remote_result->second == "pending";
         if (!node.attributes.contains("object-html")
-            && !node.attributes.contains("frame-html")) return;
+            && !node.attributes.contains("frame-html")
+            && !remote_pending) return;
         if (std::find(pending_frame_hydrations.begin(), pending_frame_hydrations.end(), &node)
             == pending_frame_hydrations.end()) {
             pending_frame_hydrations.push_back(&node);

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_dom_properties.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_dom_properties.inc
@@ -788,7 +788,9 @@
         const v8::FunctionCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_mutation));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_mutation),
+            self->profile_named("DOMTokenList.value.set"));
         auto* node = class_list_node(info);
         if (node == nullptr || info.Length() < 1) return;
         self->record_feature(
@@ -851,7 +853,9 @@
     static void class_list_add(const v8::FunctionCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_mutation));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_mutation),
+            self->profile_named("DOMTokenList.add"));
         auto* node = class_list_node(info);
         if (node == nullptr) return;
         auto changed = false;
@@ -870,7 +874,9 @@
     static void class_list_remove(const v8::FunctionCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_mutation));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_mutation),
+            self->profile_named("DOMTokenList.remove"));
         auto* node = class_list_node(info);
         if (node == nullptr || info.Length() < 1) return;
         auto changed = false;
@@ -894,7 +900,9 @@
     static void class_list_toggle(const v8::FunctionCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_mutation));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_mutation),
+            self->profile_named("DOMTokenList.toggle"));
         auto* node = class_list_node(info);
         if (node == nullptr || info.Length() < 1) return;
         const auto value = to_utf8(info.GetIsolate(), info[0]);
@@ -963,7 +971,9 @@
     static void get_client_width(v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_geometry));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_geometry),
+            self->profile_named("Element.clientWidth.get"));
         auto* node = unwrap_node(info.Holder());
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
         if (self->resize_profile_active && node != nullptr) {
@@ -1039,7 +1049,8 @@
     {
         auto* self = current(info.GetIsolate());
         binding_callback_timer binding_timer(
-            self->profile(binding_category::dom_geometry));
+            self->profile(binding_category::dom_geometry),
+            self->profile_named("HTMLElement.offsetWidth.get"));
         auto* node = unwrap_node(info.Holder());
         self->ensure_layout(node);
         if (node == nullptr) return;
@@ -1061,7 +1072,9 @@
     static void get_client_height(v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_geometry));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_geometry),
+            self->profile_named("Element.clientHeight.get"));
         auto* node = unwrap_node(info.Holder());
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
         if (self->resize_profile_active && node != nullptr) {
@@ -1315,7 +1328,9 @@
     static void get_offset_left(v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_geometry));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_geometry),
+            self->profile_named("HTMLElement.offsetLeft.get"));
         self->ensure_layout();
         auto* node = unwrap_node(info.Holder());
         if (node == nullptr) return;
@@ -1336,7 +1351,9 @@
     static void get_offset_top(v8::Local<v8::Name>, const v8::PropertyCallbackInfo<v8::Value>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_geometry));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_geometry),
+            self->profile_named("HTMLElement.offsetTop.get"));
         self->ensure_layout();
         auto* node = unwrap_node(info.Holder());
         if (node == nullptr) return;

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_html.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_html.inc
@@ -733,7 +733,9 @@
         const v8::PropertyCallbackInfo<void>& info)
     {
         auto* self = current(info.GetIsolate());
-        binding_callback_timer binding_timer(self->profile(binding_category::dom_mutation));
+        binding_callback_timer binding_timer(
+            self->profile(binding_category::dom_mutation),
+            self->profile_named("Element.innerHTML.set"));
         auto* parent = unwrap_node(info.Holder());
         if (parent == nullptr) return;
         const auto html = to_utf8(info.GetIsolate(), raw_value);

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_lifecycle.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_lifecycle.inc
@@ -17,6 +17,8 @@
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
         , batch_style_recascades(
             std::getenv("WEBSCENE_PROBE_DISABLE_STYLE_RECASCADE_BATCHING") == nullptr)
+        , batch_connected_resource_style_recascades(
+            std::getenv("WEBSCENE_PROBE_DISABLE_CONNECTED_RESOURCE_STYLE_BATCHING") == nullptr)
         , filter_stylesheet_candidates(
             std::getenv("WEBSCENE_PROBE_DISABLE_STYLESHEET_CANDIDATE_FILTER") == nullptr)
         , profile_bindings(std::getenv("WEBSCENE_PROBE_PROFILE_BINDINGS") != nullptr)
@@ -745,6 +747,18 @@
             : nullptr;
 #else
         static_cast<void>(category);
+        return nullptr;
+#endif
+    }
+
+    binding_callback_stats* profile_named(std::string_view name)
+    {
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+        return profile_bindings
+            ? &startup_binding_profiles[std::string(name)]
+            : nullptr;
+#else
+        static_cast<void>(name);
         return nullptr;
 #endif
     }

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_lifecycle.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_lifecycle.inc
@@ -19,6 +19,8 @@
             std::getenv("WEBSCENE_PROBE_DISABLE_STYLE_RECASCADE_BATCHING") == nullptr)
         , batch_connected_resource_style_recascades(
             std::getenv("WEBSCENE_PROBE_DISABLE_CONNECTED_RESOURCE_STYLE_BATCHING") == nullptr)
+        , prefetch_iframe_documents(
+            std::getenv("WEBSCENE_PROBE_DISABLE_IFRAME_DOCUMENT_PREFETCH") == nullptr)
         , filter_stylesheet_candidates(
             std::getenv("WEBSCENE_PROBE_DISABLE_STYLESHEET_CANDIDATE_FILTER") == nullptr)
         , profile_bindings(std::getenv("WEBSCENE_PROBE_PROFILE_BINDINGS") != nullptr)

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_lifecycle.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_lifecycle.inc
@@ -794,6 +794,7 @@
             compact_index(css_rules_by_id);
             compact_index(css_rules_by_tag);
             compact_index(css_rules_by_attribute);
+            compact_index(css_rules_by_variable_reference);
             css_focus_rules.shrink_to_fit();
             unindexed_css_rules.shrink_to_fit();
             hover_selector_dependencies.shrink_to_fit();

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_lifecycle.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_lifecycle.inc
@@ -15,6 +15,10 @@
         , interop_callback_sink(std::move(interop_callback_sink_value))
         , compilation_cache_directory(std::move(compilation_cache_directory_value))
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+        , batch_style_recascades(
+            std::getenv("WEBSCENE_PROBE_DISABLE_STYLE_RECASCADE_BATCHING") == nullptr)
+        , filter_stylesheet_candidates(
+            std::getenv("WEBSCENE_PROBE_DISABLE_STYLESHEET_CANDIDATE_FILTER") == nullptr)
         , profile_bindings(std::getenv("WEBSCENE_PROBE_PROFILE_BINDINGS") != nullptr)
         , profile_resize_cpu(
             std::getenv("WEBSCENE_PROBE_PROFILE_RESIZE_CPU") != nullptr)

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_navigation.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_navigation.inc
@@ -225,6 +225,7 @@
         css_rules_by_id.clear();
         css_rules_by_tag.clear();
         css_rules_by_attribute.clear();
+        css_rules_by_variable_reference.clear();
         css_focus_rules.clear();
         unindexed_css_rules.clear();
         css_attribute_dependencies.clear();

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_resources.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_resources.inc
@@ -567,19 +567,38 @@
 #endif
                     const auto variable_recascade =
                         make_css_variable_recascade_plan(first_new_rule);
-                    const auto existing_nodes =
-                        document.query_selector_all(document.body(), "*");
-                    for (auto* existing : existing_nodes) {
+                    const auto apply_to_existing = [&](
+                        const auto& recurse,
+                        dom_node& existing) -> void {
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
                         if (profile_startup) ++startup_stylesheet_recascade_nodes;
 #endif
-                        apply_appended_css_rules(*existing, first_new_rule);
+                        auto applied = false;
+                        if (!filter_stylesheet_candidates
+                            || has_appended_css_rule_candidate(
+                                existing,
+                                first_new_rule)) {
+                            applied = apply_appended_css_rules(
+                                existing,
+                                first_new_rule);
+                        }
                         if (!variable_recascade.variables.empty()) {
-                            reapply_css_variable_dependent_rules(
-                                *existing,
+                            applied |= reapply_css_variable_dependent_rules(
+                                existing,
                                 variable_recascade);
                         }
-                    }
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+                        if (profile_startup && applied) {
+                            ++startup_stylesheet_candidate_nodes;
+                        }
+#else
+                        static_cast<void>(applied);
+#endif
+                        for (auto* child : existing.children) {
+                            if (child != nullptr) recurse(recurse, *child);
+                        }
+                    };
+                    apply_to_existing(apply_to_existing, document.body());
                 } else {
                     frame_last_error_value = "Unable to load connected stylesheet: " + href_iterator->second;
                     ++frame_script_error_count;

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_resources.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_resources.inc
@@ -565,19 +565,19 @@
                     binding_callback_timer recascade_timer(
                         profile_startup ? &startup_stylesheet_recascade : nullptr);
 #endif
-                    const auto custom_properties_changed =
-                        appended_css_rules_define_custom_properties(first_new_rule);
-                    for (auto* existing :
-                        document.query_selector_all(document.body(), "*")) {
+                    const auto variable_recascade =
+                        make_css_variable_recascade_plan(first_new_rule);
+                    const auto existing_nodes =
+                        document.query_selector_all(document.body(), "*");
+                    for (auto* existing : existing_nodes) {
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
                         if (profile_startup) ++startup_stylesheet_recascade_nodes;
 #endif
                         apply_appended_css_rules(*existing, first_new_rule);
-                    }
-                    if (custom_properties_changed) {
-                        for (auto* existing :
-                            document.query_selector_all(document.body(), "*")) {
-                            reapply_css_variable_dependent_rules(*existing);
+                        if (!variable_recascade.variables.empty()) {
+                            reapply_css_variable_dependent_rules(
+                                *existing,
+                                variable_recascade);
                         }
                     }
                 } else {

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state.inc
@@ -307,14 +307,17 @@
         std::string reason;
     };
     bool batch_style_recascades{true};
+    bool batch_connected_resource_style_recascades{true};
     bool filter_stylesheet_candidates{true};
     uint32_t style_recascade_batch_depth{0};
     std::vector<pending_style_recascade> pending_style_recascades;
 
     class style_recascade_batch_scope final {
     public:
-        explicit style_recascade_batch_scope(implementation& owner) noexcept
-            : owner_(owner.batch_style_recascades ? &owner : nullptr)
+        explicit style_recascade_batch_scope(
+            implementation& owner,
+            bool enabled = true) noexcept
+            : owner_(owner.batch_style_recascades && enabled ? &owner : nullptr)
         {
             if (owner_ != nullptr) ++owner_->style_recascade_batch_depth;
         }
@@ -352,6 +355,7 @@
     bool profile_css{false};
     bool resize_profile_active{false};
     std::array<binding_callback_stats, binding_category_count> binding_totals{};
+    std::unordered_map<std::string, binding_callback_stats> startup_binding_profiles;
     std::array<binding_callback_stats, binding_category_count> last_resize_binding_profile{};
     std::unordered_map<std::string, uint64_t> last_resize_style_property_counts;
     std::unordered_map<std::string, uint64_t> last_resize_style_target_counts;
@@ -383,17 +387,22 @@
         startup_script_phase_profiles;
     std::unordered_map<std::string, startup_nested_phase_stats>
         startup_task_phase_profiles;
+    std::unordered_map<std::string, startup_nested_phase_stats>
+        startup_frame_phase_profiles;
     std::chrono::steady_clock::time_point startup_profile_started{};
     std::chrono::steady_clock::time_point startup_frame_started{};
 
     startup_phase_snapshot capture_startup_phase_snapshot() const noexcept
     {
         return startup_phase_snapshot{
+            startup_resource_read,
+            startup_css_parse,
             startup_css_apply,
             startup_css_incremental_apply,
             startup_subtree_recascade,
             startup_stylesheet_recascade,
             startup_layout,
+            startup_script_execute,
             startup_stylesheet_recascade_nodes,
             startup_stylesheet_variable_nodes,
             document.layout_passes(),
@@ -409,6 +418,14 @@
         auto& profile = profiles[name];
         ++profile.elapsed.calls;
         profile.elapsed.nanoseconds += elapsed_nanoseconds;
+        accumulate_callback_delta(
+            profile.resource_read,
+            startup_resource_read,
+            before.resource_read);
+        accumulate_callback_delta(
+            profile.css_parse,
+            startup_css_parse,
+            before.css_parse);
         accumulate_callback_delta(profile.css_apply, startup_css_apply, before.css_apply);
         accumulate_callback_delta(
             profile.css_incremental_apply,
@@ -423,6 +440,10 @@
             startup_stylesheet_recascade,
             before.stylesheet_recascade);
         accumulate_callback_delta(profile.layout, startup_layout, before.layout);
+        accumulate_callback_delta(
+            profile.script_execute,
+            startup_script_execute,
+            before.script_execute);
         profile.stylesheet_nodes +=
             startup_stylesheet_recascade_nodes - before.stylesheet_nodes;
         profile.stylesheet_variable_nodes +=

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state.inc
@@ -308,6 +308,7 @@
     };
     bool batch_style_recascades{true};
     bool batch_connected_resource_style_recascades{true};
+    bool prefetch_iframe_documents{true};
     bool filter_stylesheet_candidates{true};
     uint32_t style_recascade_batch_depth{0};
     std::vector<pending_style_recascade> pending_style_recascades;

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state.inc
@@ -160,6 +160,8 @@
     std::unordered_map<std::string, std::vector<size_t>> css_rules_by_id;
     std::unordered_map<std::string, std::vector<size_t>> css_rules_by_tag;
     std::unordered_map<std::string, std::vector<size_t>> css_rules_by_attribute;
+    std::unordered_map<std::string, std::vector<size_t>>
+        css_rules_by_variable_reference;
     std::vector<size_t> css_focus_rules;
     std::vector<size_t> unindexed_css_rules;
     std::unordered_set<std::string> css_attribute_dependencies;
@@ -330,6 +332,7 @@
     binding_callback_stats startup_layout{};
     binding_callback_stats startup_frame_hydrate{};
     uint64_t startup_stylesheet_recascade_nodes{0};
+    uint64_t startup_stylesheet_variable_nodes{0};
     uint64_t startup_connected_resources{0};
     uint64_t startup_raf_scheduled{0};
     uint64_t startup_raf_executed{0};

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state.inc
@@ -301,6 +301,42 @@
     double caret_blink_epoch_ms{0};
     std::string frame_last_error_value;
     const std::string empty_string;
+    struct pending_style_recascade final {
+        dom_node* root{nullptr};
+        bool subtree{false};
+        std::string reason;
+    };
+    bool batch_style_recascades{true};
+    bool filter_stylesheet_candidates{true};
+    uint32_t style_recascade_batch_depth{0};
+    std::vector<pending_style_recascade> pending_style_recascades;
+
+    class style_recascade_batch_scope final {
+    public:
+        explicit style_recascade_batch_scope(implementation& owner) noexcept
+            : owner_(owner.batch_style_recascades ? &owner : nullptr)
+        {
+            if (owner_ != nullptr) ++owner_->style_recascade_batch_depth;
+        }
+
+        ~style_recascade_batch_scope()
+        {
+            finish();
+        }
+
+        void finish()
+        {
+            if (owner_ == nullptr) return;
+            auto* owner = owner_;
+            owner_ = nullptr;
+            if (--owner->style_recascade_batch_depth == 0U) {
+                owner->flush_pending_style_recascades();
+            }
+        }
+
+    private:
+        implementation* owner_;
+    };
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
     uint64_t last_resize_outer_listeners_ns{0};
     uint64_t last_resize_frame_listeners_ns{0};
@@ -332,6 +368,7 @@
     binding_callback_stats startup_layout{};
     binding_callback_stats startup_frame_hydrate{};
     uint64_t startup_stylesheet_recascade_nodes{0};
+    uint64_t startup_stylesheet_candidate_nodes{0};
     uint64_t startup_stylesheet_variable_nodes{0};
     uint64_t startup_connected_resources{0};
     uint64_t startup_raf_scheduled{0};
@@ -342,6 +379,57 @@
     binding_callback_stats startup_task_callbacks{};
     std::unordered_map<std::string, binding_callback_stats> startup_script_profiles;
     std::unordered_map<std::string, binding_callback_stats> startup_task_profiles;
+    std::unordered_map<std::string, startup_nested_phase_stats>
+        startup_script_phase_profiles;
+    std::unordered_map<std::string, startup_nested_phase_stats>
+        startup_task_phase_profiles;
     std::chrono::steady_clock::time_point startup_profile_started{};
     std::chrono::steady_clock::time_point startup_frame_started{};
+
+    startup_phase_snapshot capture_startup_phase_snapshot() const noexcept
+    {
+        return startup_phase_snapshot{
+            startup_css_apply,
+            startup_css_incremental_apply,
+            startup_subtree_recascade,
+            startup_stylesheet_recascade,
+            startup_layout,
+            startup_stylesheet_recascade_nodes,
+            startup_stylesheet_variable_nodes,
+            document.layout_passes(),
+            document.dirty()};
+    }
+
+    void record_startup_nested_phases(
+        std::unordered_map<std::string, startup_nested_phase_stats>& profiles,
+        const std::string& name,
+        const startup_phase_snapshot& before,
+        uint64_t elapsed_nanoseconds)
+    {
+        auto& profile = profiles[name];
+        ++profile.elapsed.calls;
+        profile.elapsed.nanoseconds += elapsed_nanoseconds;
+        accumulate_callback_delta(profile.css_apply, startup_css_apply, before.css_apply);
+        accumulate_callback_delta(
+            profile.css_incremental_apply,
+            startup_css_incremental_apply,
+            before.css_incremental_apply);
+        accumulate_callback_delta(
+            profile.subtree_recascade,
+            startup_subtree_recascade,
+            before.subtree_recascade);
+        accumulate_callback_delta(
+            profile.stylesheet_recascade,
+            startup_stylesheet_recascade,
+            before.stylesheet_recascade);
+        accumulate_callback_delta(profile.layout, startup_layout, before.layout);
+        profile.stylesheet_nodes +=
+            startup_stylesheet_recascade_nodes - before.stylesheet_nodes;
+        profile.stylesheet_variable_nodes +=
+            startup_stylesheet_variable_nodes - before.stylesheet_variable_nodes;
+        profile.layout_passes += document.layout_passes() - before.layout_passes;
+        const auto dirty = document.dirty();
+        if (!before.document_dirty && dirty) ++profile.clean_to_dirty_transitions;
+        if (dirty) ++profile.tasks_left_dirty;
+    }
 #endif

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_support.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_support.inc
@@ -32,6 +32,43 @@ struct binding_callback_stats final {
     uint64_t nanoseconds{0};
 };
 
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+struct startup_phase_snapshot final {
+    binding_callback_stats css_apply{};
+    binding_callback_stats css_incremental_apply{};
+    binding_callback_stats subtree_recascade{};
+    binding_callback_stats stylesheet_recascade{};
+    binding_callback_stats layout{};
+    uint64_t stylesheet_nodes{0};
+    uint64_t stylesheet_variable_nodes{0};
+    uint64_t layout_passes{0};
+    bool document_dirty{false};
+};
+
+struct startup_nested_phase_stats final {
+    binding_callback_stats elapsed{};
+    binding_callback_stats css_apply{};
+    binding_callback_stats css_incremental_apply{};
+    binding_callback_stats subtree_recascade{};
+    binding_callback_stats stylesheet_recascade{};
+    binding_callback_stats layout{};
+    uint64_t stylesheet_nodes{0};
+    uint64_t stylesheet_variable_nodes{0};
+    uint64_t layout_passes{0};
+    uint64_t clean_to_dirty_transitions{0};
+    uint64_t tasks_left_dirty{0};
+};
+
+void accumulate_callback_delta(
+    binding_callback_stats& target,
+    const binding_callback_stats& current,
+    const binding_callback_stats& before) noexcept
+{
+    target.calls += current.calls - before.calls;
+    target.nanoseconds += current.nanoseconds - before.nanoseconds;
+}
+#endif
+
 std::filesystem::path runtime_file_path(const std::filesystem::path& path)
 {
 #if defined(_WIN32)

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_support.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_support.inc
@@ -34,11 +34,14 @@ struct binding_callback_stats final {
 
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
 struct startup_phase_snapshot final {
+    binding_callback_stats resource_read{};
+    binding_callback_stats css_parse{};
     binding_callback_stats css_apply{};
     binding_callback_stats css_incremental_apply{};
     binding_callback_stats subtree_recascade{};
     binding_callback_stats stylesheet_recascade{};
     binding_callback_stats layout{};
+    binding_callback_stats script_execute{};
     uint64_t stylesheet_nodes{0};
     uint64_t stylesheet_variable_nodes{0};
     uint64_t layout_passes{0};
@@ -47,11 +50,14 @@ struct startup_phase_snapshot final {
 
 struct startup_nested_phase_stats final {
     binding_callback_stats elapsed{};
+    binding_callback_stats resource_read{};
+    binding_callback_stats css_parse{};
     binding_callback_stats css_apply{};
     binding_callback_stats css_incremental_apply{};
     binding_callback_stats subtree_recascade{};
     binding_callback_stats stylesheet_recascade{};
     binding_callback_stats layout{};
+    binding_callback_stats script_execute{};
     uint64_t stylesheet_nodes{0};
     uint64_t stylesheet_variable_nodes{0};
     uint64_t layout_passes{0};
@@ -88,23 +94,35 @@ std::filesystem::path runtime_file_path(const std::filesystem::path& path)
 
 class binding_callback_timer final {
 public:
-    explicit binding_callback_timer(binding_callback_stats* stats) noexcept
-        : stats_(stats)
+    explicit binding_callback_timer(
+        binding_callback_stats* stats,
+        binding_callback_stats* named_stats = nullptr) noexcept
+        : stats_(stats), named_stats_(named_stats)
     {
-        if (stats_ != nullptr) started_ = std::chrono::steady_clock::now();
+        if (stats_ != nullptr || named_stats_ != nullptr) {
+            started_ = std::chrono::steady_clock::now();
+        }
     }
 
     ~binding_callback_timer()
     {
-        if (stats_ == nullptr) return;
-        ++stats_->calls;
-        stats_->nanoseconds += static_cast<uint64_t>(
+        if (stats_ == nullptr && named_stats_ == nullptr) return;
+        const auto elapsed = static_cast<uint64_t>(
             std::chrono::duration_cast<std::chrono::nanoseconds>(
                 std::chrono::steady_clock::now() - started_).count());
+        if (stats_ != nullptr) {
+            ++stats_->calls;
+            stats_->nanoseconds += elapsed;
+        }
+        if (named_stats_ != nullptr) {
+            ++named_stats_->calls;
+            named_stats_->nanoseconds += elapsed;
+        }
     }
 
 private:
     binding_callback_stats* stats_;
+    binding_callback_stats* named_stats_;
     std::chrono::steady_clock::time_point started_{};
 };
 

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_tasks.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_tasks.inc
@@ -73,6 +73,7 @@
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
         auto task_profile_name = std::string{};
         auto task_profile_started = std::chrono::steady_clock::time_point{};
+        auto task_phase_before = startup_phase_snapshot{};
         std::array<binding_callback_stats, binding_category_count>
             task_binding_profile_before{};
         if (profile_startup) {
@@ -94,6 +95,7 @@
                 }
             }
             task_profile_started = std::chrono::steady_clock::now();
+            task_phase_before = capture_startup_phase_snapshot();
         }
         if (profile_bindings) {
             task_binding_profile_before = binding_totals;
@@ -115,6 +117,7 @@
         }
         active_timer_id = task.id;
         active_timer_cancelled = false;
+        style_recascade_batch_scope style_batch(*this);
 #if defined(WEBSCENE_NATIVE_ENGINE_WITH_V8_INSPECTOR)
         inspector_async_task_started(task.id);
 #endif
@@ -187,16 +190,23 @@
             }
         }
         perform_microtask_checkpoint();
+        style_batch.finish();
 #if defined(WEBSCENE_NATIVE_ENGINE_WITH_V8_INSPECTOR)
         inspector_async_task_finished(task.id);
 #endif
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
         if (profile_startup) {
-            auto& stats = startup_task_profiles[task_profile_name];
-            ++stats.calls;
-            stats.nanoseconds += static_cast<uint64_t>(
+            const auto task_elapsed_nanoseconds = static_cast<uint64_t>(
                 std::chrono::duration_cast<std::chrono::nanoseconds>(
                     std::chrono::steady_clock::now() - task_profile_started).count());
+            auto& stats = startup_task_profiles[task_profile_name];
+            ++stats.calls;
+            stats.nanoseconds += task_elapsed_nanoseconds;
+            record_startup_nested_phases(
+                startup_task_phase_profiles,
+                task_profile_name,
+                task_phase_before,
+                task_elapsed_nanoseconds);
             if (std::getenv("WEBSCENE_PROBE_TRACE_STARTUP_TASKS") != nullptr) {
                 std::cerr << "[Native Engine Probe] startup-task t=" << std::fixed
                     << std::setprecision(1)

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_tasks.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_tasks.inc
@@ -282,6 +282,13 @@
             return true;
         }
         v8::Context::Scope resource_scope(resource_context);
+        // A dynamically loaded script, its load event, and the resulting
+        // microtasks form one browser task. Keep style invalidations pending
+        // across that entire boundary so Webpack/React DOM construction does
+        // not recascade synchronously between those phases.
+        style_recascade_batch_scope style_batch(
+            *this,
+            batch_connected_resource_style_recascades);
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
         const auto trace_resource = profile_startup
             && std::getenv("WEBSCENE_PROBE_TRACE_STARTUP_TASKS") != nullptr;
@@ -322,6 +329,7 @@
 #endif
         }
         perform_microtask_checkpoint();
+        style_batch.finish();
         return true;
     }
 

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_resource_tests.inc
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_resource_tests.inc
@@ -1859,10 +1859,15 @@ void test_dynamic_stylesheet_custom_properties_preserve_cascade_order()
         return std::stoull(profile.substr(value_start));
     };
     const auto visited_nodes = read_metric("stylesheet-nodes=");
+    const auto candidate_nodes = read_metric("stylesheet-candidate-nodes=");
     const auto variable_nodes = read_metric("stylesheet-variable-nodes=");
     require(
         visited_nodes >= 256U,
         "dynamic stylesheet benchmark did not visit its irrelevant-node corpus");
+    require(
+        candidate_nodes <= 5U,
+        "dynamic stylesheet candidate filtering finalized irrelevant nodes: "
+            + std::to_string(candidate_nodes));
     require(
         variable_nodes <= 4U,
         "custom-property dependency filtering revisited irrelevant nodes: "

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_resource_tests.inc
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_resource_tests.inc
@@ -1770,22 +1770,51 @@ void test_dynamic_stylesheet_custom_properties_preserve_cascade_order()
                   volume.className = 'cell volume hidden';
                   symbol.appendChild(volume);
                   document.body.appendChild(symbol);
+                  const direct = document.createElement('div');
+                  direct.className = 'direct-variable';
+                  document.body.appendChild(direct);
+                  const indirect = document.createElement('div');
+                  indirect.className = 'indirect-variable';
+                  document.body.appendChild(indirect);
+                  const inline = document.createElement('div');
+                  inline.style.display = 'var(--watchlist-volume-display)';
+                  document.body.appendChild(inline);
+                  for (let index = 0; index < 256; ++index) {
+                    const irrelevant = document.createElement('div');
+                    irrelevant.className = 'irrelevant-' + index;
+                    document.body.appendChild(irrelevant);
+                  }
                   globalThis.__dynamicCascadeDisplay = 'loading';
                   const link = document.createElement('link');
                   link.rel = 'stylesheet';
                   link.href = 'watchlist.css';
                   link.onload = () => {
-                    globalThis.__dynamicCascadeDisplay =
-                      getComputedStyle(volume).display;
+                    globalThis.__dynamicCascadeDisplay = [
+                      getComputedStyle(volume).display,
+                      getComputedStyle(direct).display,
+                      getComputedStyle(indirect).display,
+                      getComputedStyle(inline).display
+                    ];
+                    globalThis.__webSceneComponentReady = true;
                   };
                   document.head.appendChild(link);
                 </script></body></html>)"},
             {"https://dynamic-cascade.test/watchlist.css", R"(
                 :root { --watchlist-volume-display: flex; }
+                :root {
+                  --watchlist-indirect-display:
+                    var(--watchlist-volume-display);
+                }
                 .symbol .cell.volume {
                   display: var(--watchlist-volume-display, flex);
                 }
                 .symbol .cell.hidden { display: none; }
+                .direct-variable {
+                  display: var(--watchlist-volume-display);
+                }
+                .indirect-variable {
+                  display: var(--watchlist-indirect-display);
+                }
             )"}
         }};
     const webscene_engine_options options{
@@ -1808,13 +1837,37 @@ void test_dynamic_stylesheet_custom_properties_preserve_cascade_order()
             engine,
             "globalThis.__dynamicCascadeDisplay",
             "dynamic-cascade-result.js");
-        if (display == R"("none")") break;
+        if (display == R"(["none","flex","flex","flex"])") break;
         std::this_thread::sleep_for(std::chrono::milliseconds(2));
     }
     require(
-        display == R"("none")",
+        display == R"(["none","flex","flex","flex"])",
         "custom-property recascade overrode a later display declaration: "
             + display);
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+    auto profile = std::string{};
+    for (auto attempt = 0; attempt < 100; ++attempt) {
+        profile = diagnostics(engine);
+        if (profile.find("stylesheet-variable-nodes=") != std::string::npos) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    const auto read_metric = [&](std::string_view name) {
+        const auto start = profile.find(name);
+        require(start != std::string::npos, "missing startup profile metric: "
+            + std::string(name) + " in " + profile);
+        const auto value_start = start + name.size();
+        return std::stoull(profile.substr(value_start));
+    };
+    const auto visited_nodes = read_metric("stylesheet-nodes=");
+    const auto variable_nodes = read_metric("stylesheet-variable-nodes=");
+    require(
+        visited_nodes >= 256U,
+        "dynamic stylesheet benchmark did not visit its irrelevant-node corpus");
+    require(
+        variable_nodes <= 4U,
+        "custom-property dependency filtering revisited irrelevant nodes: "
+            + std::to_string(variable_nodes));
+#endif
     webscene_engine_destroy(engine);
 }
 

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_resource_tests.inc
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_resource_tests.inc
@@ -2,12 +2,14 @@ struct resource_server final {
     std::unordered_map<std::string, std::string> content;
     std::atomic<int> active{0};
     std::atomic<int> peak{0};
+    std::atomic<int> active_documents{0};
+    std::atomic<int> peak_documents{0};
     std::atomic<int> requests{0};
 };
 
 size_t load_test_resource(
     void* user_data,
-    uint32_t,
+    uint32_t kind,
     const char* url,
     size_t url_length,
     const char*,
@@ -31,7 +33,21 @@ size_t load_test_resource(
                 active,
                 std::memory_order_relaxed)) {
         }
+        if (kind == WEBSCENE_RESOURCE_DOCUMENT) {
+            const auto active_documents =
+                server.active_documents.fetch_add(1, std::memory_order_relaxed) + 1;
+            auto peak_documents = server.peak_documents.load(std::memory_order_relaxed);
+            while (active_documents > peak_documents
+                && !server.peak_documents.compare_exchange_weak(
+                    peak_documents,
+                    active_documents,
+                    std::memory_order_relaxed)) {
+            }
+        }
         std::this_thread::sleep_for(std::chrono::milliseconds(60));
+        if (kind == WEBSCENE_RESOURCE_DOCUMENT) {
+            server.active_documents.fetch_sub(1, std::memory_order_relaxed);
+        }
         server.active.fetch_sub(1, std::memory_order_relaxed);
     }
     else if (destination == nullptr) {
@@ -1665,6 +1681,9 @@ void test_dynamic_frame_resources_use_each_document_base_url()
         origins == R"(["first-load","first-script","second-load","second-script"])",
         "dynamic frame resources did not resolve against their owning documents: "
             + origins);
+    require(
+        server.peak_documents.load(std::memory_order_relaxed) >= 2,
+        "dynamic iframe documents were not prefetched concurrently");
     execute(engine, R"JS(
         (() => {
           const children = Array.from(document.querySelectorAll('iframe'));

--- a/samples/NativeTradingViewTerminal/MainWindow.axaml.cs
+++ b/samples/NativeTradingViewTerminal/MainWindow.axaml.cs
@@ -56,6 +56,10 @@ public sealed partial class MainWindow : Window
                 ResourceReplayDirectory = paths.ResourceReplayDirectory
             };
             var startupTimer = Stopwatch.StartNew();
+            var replayPreparationTimer = Stopwatch.StartNew();
+            _resourceLoader.PrepareResourceReplay();
+            replayPreparationTimer.Stop();
+            Stopwatch? navigationTimer = null;
             StatusText.Text = "Loading hosted TradingView terminal…";
             DiagnosticsText.Text = paths.DocumentUrl;
             await TerminalHost.LoadAsync(
@@ -65,6 +69,11 @@ public sealed partial class MainWindow : Window
                     NativeLibraryPath = paths.NativeLibraryPath,
                     CompilationCacheDirectory = paths.CompilationCacheDirectory,
                     ResourceLoader = _resourceLoader
+                },
+                (_, _) =>
+                {
+                    navigationTimer = Stopwatch.StartNew();
+                    return ValueTask.CompletedTask;
                 });
             StatusText.Text = "TradingView terminal loaded";
             if (_arguments.Contains("--startup-profile", StringComparer.Ordinal))
@@ -105,12 +114,19 @@ public sealed partial class MainWindow : Window
                 _resourceLoader.FlushResourceCapture();
                 Console.WriteLine(FormattableString.Invariant(
                     $"TradingView desktop chart ready wall: {startupTimer.Elapsed.TotalMilliseconds:F3} ms"));
+                Console.WriteLine(FormattableString.Invariant(
+                    $"TradingView desktop replay preparation: {replayPreparationTimer.Elapsed.TotalMilliseconds:F3} ms"));
+                Console.WriteLine(FormattableString.Invariant(
+                    $"TradingView desktop chart ready navigation: {navigationTimer?.Elapsed.TotalMilliseconds ?? double.NaN:F3} ms"));
                 await TerminalHost.EvaluateTextAsync("""
                     globalThis.__webSceneComponentReady = true;
                     document.body.setAttribute('data-webscene-profile-ready', 'true');
                     true
                     """);
-                await Task.Delay(500);
+                // Conditional chunks can be requested shortly after the visual
+                // readiness gate. Give capture runs a longer observation window
+                // so later strict replays do not depend on lucky task ordering.
+                await Task.Delay(paths.ResourceCaptureDirectory is null ? 500 : 2_000);
                 var startupMetrics = TerminalHost.CapturePerformanceSnapshot();
                 Console.WriteLine(
                     "TradingView desktop startup metrics: "

--- a/samples/NativeTradingViewTerminal/MainWindow.axaml.cs
+++ b/samples/NativeTradingViewTerminal/MainWindow.axaml.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using Avalonia.Controls;
 using Avalonia.Threading;
@@ -46,6 +47,7 @@ public sealed partial class MainWindow : Window
         try
         {
             var paths = SamplePaths.Resolve(_arguments);
+            var startupTimer = Stopwatch.StartNew();
             StatusText.Text = "Loading hosted TradingView terminal…";
             DiagnosticsText.Text = paths.DocumentUrl;
             await TerminalHost.LoadAsync(
@@ -53,6 +55,76 @@ public sealed partial class MainWindow : Window
                 paths.NativeLibraryPath,
                 paths.CompilationCacheDirectory);
             StatusText.Text = "TradingView terminal loaded";
+            if (_arguments.Contains("--startup-profile", StringComparer.Ordinal))
+            {
+                var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+                var chartReady = false;
+                while (DateTime.UtcNow < deadline)
+                {
+                    var ready = await TerminalHost.EvaluateTextAsync("""
+                        (() => {
+                          for (const frame of document.querySelectorAll('iframe')) {
+                            try {
+                              const chart = frame.contentDocument;
+                              const loading = chart?.querySelector('.loading-indicator');
+                              if ((chart?.querySelectorAll('canvas').length ?? 0) >= 8
+                                  && loading && getComputedStyle(loading).display === 'none') {
+                                return true;
+                              }
+                            } catch {}
+                          }
+                          return false;
+                        })()
+                        """);
+                    if (ready == "true")
+                    {
+                        chartReady = true;
+                        break;
+                    }
+                    await Task.Delay(25);
+                }
+                if (!chartReady)
+                {
+                    throw new TimeoutException(
+                        "TradingView chart did not reach the startup-profile readiness gate.");
+                }
+                Console.WriteLine(FormattableString.Invariant(
+                    $"TradingView desktop chart ready wall: {startupTimer.Elapsed.TotalMilliseconds:F3} ms"));
+                await TerminalHost.EvaluateTextAsync("""
+                    globalThis.__webSceneComponentReady = true;
+                    document.body.setAttribute('data-webscene-profile-ready', 'true');
+                    true
+                    """);
+                await Task.Delay(500);
+                var startupMetrics = TerminalHost.CapturePerformanceSnapshot();
+                Console.WriteLine(
+                    "TradingView desktop startup metrics: "
+                    + JsonSerializer.Serialize(new
+                    {
+                        startupMetrics.Engine.CompilationRequests,
+                        startupMetrics.Engine.CompilationMemoryHits,
+                        startupMetrics.Engine.CompilationPersistentHits,
+                        startupMetrics.Engine.CompilationPersistentMisses,
+                        CompilationTimeMilliseconds =
+                            startupMetrics.Engine.CompilationTimeNanoseconds / 1_000_000d,
+                        startupMetrics.ResourceCache.Requests,
+                        startupMetrics.ResourceCache.Hits,
+                        startupMetrics.ResourceCache.Misses,
+                        startupMetrics.ResourceCache.BytesRead
+                    }));
+                var diagnostics = TerminalHost.SceneDiagnostics;
+                var profileStart = diagnostics.IndexOf(
+                    "startup-profile=", StringComparison.Ordinal);
+                var profileEnd = profileStart < 0
+                    ? -1
+                    : diagnostics.IndexOf(" | ", profileStart, StringComparison.Ordinal);
+                Console.WriteLine(profileStart < 0
+                    ? "TradingView desktop startup profile unavailable"
+                    : "TradingView desktop " + diagnostics[profileStart..(
+                        profileEnd < 0 ? diagnostics.Length : profileEnd)]);
+                Close();
+                return;
+            }
             _diagnosticsTimer.Start();
             await RefreshDiagnosticsAsync();
         }

--- a/samples/NativeTradingViewTerminal/MainWindow.axaml.cs
+++ b/samples/NativeTradingViewTerminal/MainWindow.axaml.cs
@@ -2,6 +2,8 @@ using System.Diagnostics;
 using System.Text.Json;
 using Avalonia.Controls;
 using Avalonia.Threading;
+using WebScene.Backends.Avalonia;
+using WebScene.Backends.Native;
 
 namespace NativeTradingViewTerminal;
 
@@ -9,6 +11,7 @@ public sealed partial class MainWindow : Window
 {
     private readonly IReadOnlyList<string> _arguments;
     private readonly DispatcherTimer _diagnosticsTimer;
+    private AvaloniaResourceLoader? _resourceLoader;
 
     public MainWindow()
         : this(Environment.GetCommandLineArgs())
@@ -47,13 +50,22 @@ public sealed partial class MainWindow : Window
         try
         {
             var paths = SamplePaths.Resolve(_arguments);
+            _resourceLoader = new AvaloniaResourceLoader
+            {
+                ResourceCaptureDirectory = paths.ResourceCaptureDirectory,
+                ResourceReplayDirectory = paths.ResourceReplayDirectory
+            };
             var startupTimer = Stopwatch.StartNew();
             StatusText.Text = "Loading hosted TradingView terminal…";
             DiagnosticsText.Text = paths.DocumentUrl;
             await TerminalHost.LoadAsync(
-                paths.DocumentUrl,
-                paths.NativeLibraryPath,
-                paths.CompilationCacheDirectory);
+                new NativeWebSceneLoadOptions
+                {
+                    Source = paths.DocumentUrl,
+                    NativeLibraryPath = paths.NativeLibraryPath,
+                    CompilationCacheDirectory = paths.CompilationCacheDirectory,
+                    ResourceLoader = _resourceLoader
+                });
             StatusText.Text = "TradingView terminal loaded";
             if (_arguments.Contains("--startup-profile", StringComparer.Ordinal))
             {
@@ -81,13 +93,16 @@ public sealed partial class MainWindow : Window
                         chartReady = true;
                         break;
                     }
+                    _resourceLoader.ThrowIfResourceReplayFailed();
                     await Task.Delay(25);
                 }
+                _resourceLoader.ThrowIfResourceReplayFailed();
                 if (!chartReady)
                 {
                     throw new TimeoutException(
                         "TradingView chart did not reach the startup-profile readiness gate.");
                 }
+                _resourceLoader.FlushResourceCapture();
                 Console.WriteLine(FormattableString.Invariant(
                     $"TradingView desktop chart ready wall: {startupTimer.Elapsed.TotalMilliseconds:F3} ms"));
                 await TerminalHost.EvaluateTextAsync("""
@@ -110,7 +125,22 @@ public sealed partial class MainWindow : Window
                         startupMetrics.ResourceCache.Requests,
                         startupMetrics.ResourceCache.Hits,
                         startupMetrics.ResourceCache.Misses,
-                        startupMetrics.ResourceCache.BytesRead
+                        startupMetrics.ResourceCache.BytesRead,
+                        startupMetrics.Engine.DomNodes,
+                        startupMetrics.Engine.LayoutPasses,
+                        startupMetrics.Engine.PublishedScenes,
+                        startupMetrics.Engine.AcquiredScenes,
+                        LastLayoutMilliseconds =
+                            startupMetrics.Engine.LastLayoutNanoseconds / 1_000_000d,
+                        LastSceneBuildMilliseconds =
+                            startupMetrics.Engine.LastSceneBuildNanoseconds / 1_000_000d,
+                        LastScenePublicationMilliseconds =
+                            startupMetrics.Engine.LastScenePublicationNanoseconds / 1_000_000d,
+                        MaximumScenePublicationMilliseconds =
+                            startupMetrics.Engine.MaximumScenePublicationNanoseconds / 1_000_000d,
+                        startupMetrics.SceneFlow.PublicationAttempts,
+                        startupMetrics.SceneFlow.BlockedPublications,
+                        startupMetrics.SceneFlow.AcknowledgedScenes
                     }));
                 var diagnostics = TerminalHost.SceneDiagnostics;
                 var profileStart = diagnostics.IndexOf(
@@ -180,6 +210,7 @@ public sealed partial class MainWindow : Window
     private async void OnClosed(object? sender, EventArgs args)
     {
         _diagnosticsTimer.Stop();
+        _resourceLoader?.FlushResourceCapture();
         await TerminalHost.DisposeAsync();
     }
 }

--- a/samples/NativeTradingViewTerminal/README.md
+++ b/samples/NativeTradingViewTerminal/README.md
@@ -69,11 +69,80 @@ WEBSCENE_PROBE_PROFILE_STARTUP=1 dotnet run \
   --cache /tmp/webscene-tradingview-profile-cache
 ```
 
+Capture the resolved HTTP(S) text resources and web-font bytes after starting with
+an empty WebScene cache, then replay them without any network fallback:
+
+```bash
+WEBSCENE_PROBE_PROFILE_STARTUP=1 dotnet run \
+  --project samples/NativeTradingViewTerminal -c Release -- \
+  --startup-profile \
+  --native-library /absolute/path/to/libwebscene_native_engine.dylib \
+  --cache /tmp/webscene-tradingview-capture-cache \
+  --capture-resources /tmp/webscene-tradingview-resources
+
+WEBSCENE_PROBE_PROFILE_STARTUP=1 dotnet run \
+  --project samples/NativeTradingViewTerminal -c Release -- \
+  --startup-profile \
+  --native-library /absolute/path/to/libwebscene_native_engine.dylib \
+  --cache /tmp/webscene-tradingview-replay-cache \
+  --replay-resources /tmp/webscene-tradingview-resources
+```
+
+Resource capture and replay are mutually exclusive. Replay fails immediately when
+the application requests an uncaptured HTTP(S) resource; it never silently reaches
+the origin. Use a separate compilation/resource cache directory for each cold run,
+or intentionally reuse one when measuring the warm-cache case.
+
+Compare Chrome against the same response bodies without installing an extension.
+The runner starts a temporary headless Chrome profile and fulfills requests directly
+through the Chrome DevTools Protocol:
+
+```bash
+node scripts/benchmark-tradingview-replay.mjs \
+  --archive /tmp/webscene-tradingview-resources \
+  --capture-misses
+
+node scripts/benchmark-tradingview-replay.mjs \
+  --archive /tmp/webscene-tradingview-resources
+```
+
+`--capture-misses` is a one-time preparation pass that adds Chrome-only responses
+to the shared archive. Omit it for every measured run. The JSON result reports the
+chart-ready wall time, Chrome task/script/style/layout
+durations, served bytes, and every blocked archive miss. Any miss makes the command
+fail so a changed resource graph cannot silently contaminate the comparison.
+
 Certification builds can reproduce the former broad custom-property recascade as an
 A/B control by additionally setting
 `WEBSCENE_PROBE_DISABLE_CSS_VARIABLE_DEPENDENCY_FILTER=1`. Run the optimized and
 control processes against the same warm cache; compare `stylesheet-recascade`,
 `stylesheet-nodes`, and `stylesheet-variable-nodes` in the compact profile output.
+
+Use `WEBSCENE_PROBE_DISABLE_STYLE_RECASCADE_BATCHING=1` as the control for immediate
+DOM-mutation recascades. Certification profiles report `script-phase-top` and
+`task-phase-top`, including nested CSS work, forced layout passes, and dirty-state
+transitions for the hottest scripts and timer/animation-frame callbacks.
+
+Use `WEBSCENE_PROBE_DISABLE_STYLESHEET_CANDIDATE_FILTER=1` to restore the legacy
+connected-stylesheet path that finalizes and dirties every existing element, even
+when no appended selector can match it. The optimized profile additionally reports
+`stylesheet-candidate-nodes` beside the total number of visited stylesheet nodes.
+
+### August 2026 startup results
+
+Five cold runs against one captured HTTP response archive initially measured a
+1,505.7 ms WebScene median and a 1,253.2 ms Chrome median. The archive fixes HTTP
+response bodies, but TradingView's WebSocket data remains live, so use medians and
+nested CPU counters instead of treating individual wall-time runs as paired samples.
+
+Per-task mutation batching reduced the WebScene median from 1,034.2 ms with immediate
+recascade to 1,004.2 ms, while median CSS-application CPU fell from 145.1 ms to
+86.8 ms. In a later five-run candidate-filter A/B, median incremental stylesheet CPU
+fell from 27.9 ms to 8.2 ms and total stylesheet recascade fell from 53.3 ms to
+48.1 ms. That pass did not yet produce a statistically useful wall-time improvement
+(1,509.2 ms control versus 1,529.9 ms optimized) because live-data scheduling noise
+was larger than the saved CPU interval. A representative optimized run finalized
+280 of 56,521 visited nodes (0.50%).
 
 Run the Sandwich Trading Platform multi-chart geometry proof with a
 deterministic in-process market-data bridge:

--- a/samples/NativeTradingViewTerminal/README.md
+++ b/samples/NativeTradingViewTerminal/README.md
@@ -90,8 +90,16 @@ WEBSCENE_PROBE_PROFILE_STARTUP=1 dotnet run \
 
 Resource capture and replay are mutually exclusive. Replay fails immediately when
 the application requests an uncaptured HTTP(S) resource; it never silently reaches
-the origin. Use a separate compilation/resource cache directory for each cold run,
-or intentionally reuse one when measuring the warm-cache case.
+the origin. Reusing a capture directory merges newly observed responses into its
+existing valid manifest, which is useful for stabilizing conditional resource paths.
+Capture runs observe the page for two seconds after visual readiness so nearby lazy
+chunks are included before the manifest is flushed.
+Use a separate compilation/resource cache directory for each cold run, or
+intentionally reuse one when measuring the warm-cache case.
+The startup sample reports archive preparation, cold host-to-ready, and
+navigation-to-ready separately. Compare Chrome's `readyMilliseconds` with the
+navigation interval; the cold interval intentionally includes fixture preparation
+and native-engine initialization.
 
 Compare Chrome against the same response bodies without installing an extension.
 The runner starts a temporary headless Chrome profile and fulfills requests directly
@@ -101,6 +109,11 @@ through the Chrome DevTools Protocol:
 node scripts/benchmark-tradingview-replay.mjs \
   --archive /tmp/webscene-tradingview-resources \
   --capture-misses
+
+# Add a WebScene-only conditional URL reported by a strict replay miss.
+node scripts/benchmark-tradingview-replay.mjs \
+  --archive /tmp/webscene-tradingview-resources \
+  --capture-url https://example.test/conditional-chunk.js
 
 node scripts/benchmark-tradingview-replay.mjs \
   --archive /tmp/webscene-tradingview-resources
@@ -122,6 +135,12 @@ Use `WEBSCENE_PROBE_DISABLE_STYLE_RECASCADE_BATCHING=1` as the control for immed
 DOM-mutation recascades. Certification profiles report `script-phase-top` and
 `task-phase-top`, including nested CSS work, forced layout passes, and dirty-state
 transitions for the hottest scripts and timer/animation-frame callbacks.
+`frame-phase-top` applies the same attribution to each hydrated iframe.
+Set `WEBSCENE_PROBE_PROFILE_BINDINGS=1` to add per-category binding totals and the
+eight hottest named DOM mutation/geometry APIs. Use
+`WEBSCENE_PROBE_DISABLE_CONNECTED_RESOURCE_STYLE_BATCHING=1` to isolate the legacy
+dynamic-resource boundary, which flushed after script evaluation and then ran its
+`load` event and microtasks with immediate recascades.
 
 Use `WEBSCENE_PROBE_DISABLE_STYLESHEET_CANDIDATE_FILTER=1` to restore the legacy
 connected-stylesheet path that finalizes and dirties every existing element, even
@@ -130,10 +149,22 @@ when no appended selector can match it. The optimized profile additionally repor
 
 ### August 2026 startup results
 
-Five cold runs against one captured HTTP response archive initially measured a
-1,505.7 ms WebScene median and a 1,253.2 ms Chrome median. The archive fixes HTTP
-response bodies, but TradingView's WebSocket data remains live, so use medians and
-nested CPU counters instead of treating individual wall-time runs as paired samples.
+An initial five-run comparison measured a 1,505.7 ms WebScene median and a
+1,253.2 ms Chrome median, but that result included archive reads and native-engine
+creation in WebScene while Chrome's archive and browser were already initialized.
+It is retained here only as the benchmark asymmetry that motivated the separate
+preparation, cold-host, and navigation clocks.
+
+With both sides timed from navigation to the same eight-canvas/loading-hidden gate,
+five strict-replay runs measured a 983.3 ms WebScene navigation median and a
+1,140.6 ms Chrome median. WebScene was 157.3 ms (13.8%) faster at that shared gate.
+Its full cold host-to-ready median, including archive preparation and engine
+creation, was 1,068.4 ms; archive preparation itself was 28.1 ms. Chrome task/script
+metrics overlap and use different semantics from WebScene's nested buckets, so they
+are reported for within-engine attribution rather than subtracted across engines.
+The archive fixes HTTP response bodies, but TradingView's WebSocket data remains
+live, so use medians and CPU counters instead of treating individual wall-time runs
+as paired samples.
 
 Per-task mutation batching reduced the WebScene median from 1,034.2 ms with immediate
 recascade to 1,004.2 ms, while median CSS-application CPU fell from 145.1 ms to
@@ -143,6 +174,21 @@ fell from 27.9 ms to 8.2 ms and total stylesheet recascade fell from 53.3 ms to
 (1,509.2 ms control versus 1,529.9 ms optimized) because live-data scheduling noise
 was larger than the saved CPU interval. A representative optimized run finalized
 280 of 56,521 visited nodes (0.50%).
+
+Named binding attribution then found that dynamically connected resource tasks
+were flushing style work after script evaluation, before dispatching `load` and its
+microtasks. Extending the batch across that complete browser-task boundary reduced
+immediate subtree recascades from 1,743 to 101 in representative diagnostic runs;
+DOM-mutation binding CPU fell from 90.5 ms to 22.2 ms and `Node.appendChild` from
+42.1 ms to 5.7 ms. In a five-pair cold A/B, median CSS-application CPU fell from
+101.7 ms to 70.8 ms (-30.4%) and subtree-recascade CPU from 65.9 ms to 44.8 ms
+(-32.1%). Navigation medians were 1,016.6 ms control and 1,044.8 ms optimized, so
+no wall-time improvement is claimed for that pass.
+
+The iframe attribution also shows why iframe scheduling remains later work: a
+representative main frame spent 80.7 ms of its 105.5 ms hydration interval executing
+application scripts, 11.8 ms reading resources, and only about 3 ms parsing/applying
+CSS and laying out. The secondary frame similarly spent 17.5 ms of 22.4 ms in script.
 
 Run the Sandwich Trading Platform multi-chart geometry proof with a
 deterministic in-process market-data bridge:

--- a/samples/NativeTradingViewTerminal/README.md
+++ b/samples/NativeTradingViewTerminal/README.md
@@ -141,6 +141,9 @@ eight hottest named DOM mutation/geometry APIs. Use
 `WEBSCENE_PROBE_DISABLE_CONNECTED_RESOURCE_STYLE_BATCHING=1` to isolate the legacy
 dynamic-resource boundary, which flushed after script evaluation and then ran its
 `load` event and microtasks with immediate recascades.
+Use `WEBSCENE_PROBE_DISABLE_IFRAME_DOCUMENT_PREFETCH=1` to restore synchronous
+remote iframe-document acquisition at `appendChild`; CSS/script execution order is
+unchanged by this control.
 
 Use `WEBSCENE_PROBE_DISABLE_STYLESHEET_CANDIDATE_FILTER=1` to restore the legacy
 connected-stylesheet path that finalizes and dirties every existing element, even
@@ -185,10 +188,16 @@ DOM-mutation binding CPU fell from 90.5 ms to 22.2 ms and `Node.appendChild` fro
 (-32.1%). Navigation medians were 1,016.6 ms control and 1,044.8 ms optimized, so
 no wall-time improvement is claimed for that pass.
 
-The iframe attribution also shows why iframe scheduling remains later work: a
+The iframe attribution shows why parallel script execution is not the first lever: a
 representative main frame spent 80.7 ms of its 105.5 ms hydration interval executing
 application scripts, 11.8 ms reading resources, and only about 3 ms parsing/applying
 CSS and laying out. The secondary frame similarly spent 17.5 ms of 22.4 ms in script.
+Remote iframe documents were nevertheless still fetched synchronously before they
+entered that hydration path. Starting sibling document requests concurrently while
+preserving ordered single-isolate hydration improved all five interleaved strict-replay
+pairs: median navigation fell from 953.4 ms to 934.4 ms (-19.0 ms, -2.0%), and cold
+host-to-ready from 1,038.5 ms to 1,016.2 ms (-22.3 ms, -2.1%). A delayed native host
+loader regression also requires two remote iframe document requests to overlap.
 
 Run the Sandwich Trading Platform multi-chart geometry proof with a
 deterministic in-process market-data bridge:

--- a/samples/NativeTradingViewTerminal/README.md
+++ b/samples/NativeTradingViewTerminal/README.md
@@ -58,6 +58,23 @@ dotnet run --project samples/NativeTradingViewTerminal -c Release -- \
   --output artifacts/native-tradingview-terminal
 ```
 
+Profile desktop startup until the chart iframe has rendered at least eight canvases
+and hidden its loading indicator:
+
+```bash
+WEBSCENE_PROBE_PROFILE_STARTUP=1 dotnet run \
+  --project samples/NativeTradingViewTerminal -c Release -- \
+  --startup-profile \
+  --native-library /absolute/path/to/libwebscene_native_engine.dylib \
+  --cache /tmp/webscene-tradingview-profile-cache
+```
+
+Certification builds can reproduce the former broad custom-property recascade as an
+A/B control by additionally setting
+`WEBSCENE_PROBE_DISABLE_CSS_VARIABLE_DEPENDENCY_FILTER=1`. Run the optimized and
+control processes against the same warm cache; compare `stylesheet-recascade`,
+`stylesheet-nodes`, and `stylesheet-variable-nodes` in the compact profile output.
+
 Run the Sandwich Trading Platform multi-chart geometry proof with a
 deterministic in-process market-data bridge:
 

--- a/samples/NativeTradingViewTerminal/SamplePaths.cs
+++ b/samples/NativeTradingViewTerminal/SamplePaths.cs
@@ -5,7 +5,9 @@ namespace NativeTradingViewTerminal;
 internal sealed record SamplePaths(
     string NativeLibraryPath,
     string CompilationCacheDirectory,
-    string DocumentUrl)
+    string DocumentUrl,
+    string? ResourceCaptureDirectory,
+    string? ResourceReplayDirectory)
 {
     internal const string TerminalUrl =
         "https://trading-terminal.tradingview-widget.com/";
@@ -15,6 +17,8 @@ internal sealed record SamplePaths(
         string? configuredLibrary = null;
         string? configuredCache = null;
         string? configuredUrl = null;
+        string? resourceCaptureDirectory = null;
+        string? resourceReplayDirectory = null;
         for (var index = 0; index < arguments.Count; index++)
         {
             switch (arguments[index])
@@ -28,7 +32,19 @@ internal sealed record SamplePaths(
                 case "--url" when index + 1 < arguments.Count:
                     configuredUrl = arguments[++index];
                     break;
+                case "--capture-resources" when index + 1 < arguments.Count:
+                    resourceCaptureDirectory = Path.GetFullPath(arguments[++index]);
+                    break;
+                case "--replay-resources" when index + 1 < arguments.Count:
+                    resourceReplayDirectory = Path.GetFullPath(arguments[++index]);
+                    break;
             }
+        }
+
+        if (resourceCaptureDirectory is not null && resourceReplayDirectory is not null)
+        {
+            throw new ArgumentException(
+                "--capture-resources and --replay-resources are mutually exclusive.");
         }
 
         configuredLibrary ??=
@@ -56,7 +72,9 @@ internal sealed record SamplePaths(
             cache,
             string.IsNullOrWhiteSpace(configuredUrl)
                 ? TerminalUrl
-                : configuredUrl);
+                : configuredUrl,
+            resourceCaptureDirectory,
+            resourceReplayDirectory);
     }
 
     internal static string NativeLibraryFileName()

--- a/scripts/benchmark-tradingview-replay.mjs
+++ b/scripts/benchmark-tradingview-replay.mjs
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const DEFAULT_URL = "https://trading-terminal.tradingview-widget.com/";
+const READY_EXPRESSION = `(() => {
+  const loading = document.querySelector('.loading-indicator');
+  return document.querySelectorAll('canvas').length >= 8
+    && loading
+    && getComputedStyle(loading).display === 'none';
+})()`;
+
+class CdpClient {
+  #nextId = 0;
+  #pending = new Map();
+  #listeners = new Map();
+
+  constructor(address) {
+    this.socket = new WebSocket(address);
+    this.opened = new Promise((resolve, reject) => {
+      this.socket.addEventListener("open", resolve, { once: true });
+      this.socket.addEventListener("error", reject, { once: true });
+    });
+    this.socket.addEventListener("message", event => {
+      const message = JSON.parse(event.data);
+      if (message.id) {
+        const pending = this.#pending.get(message.id);
+        if (!pending) return;
+        this.#pending.delete(message.id);
+        if (message.error) pending.reject(new Error(message.error.message));
+        else pending.resolve(message.result ?? {});
+        return;
+      }
+      for (const listener of this.#listeners.get(message.method) ?? []) {
+        listener(message.params ?? {});
+      }
+    });
+  }
+
+  async send(method, params = {}) {
+    await this.opened;
+    const id = ++this.#nextId;
+    const result = new Promise((resolve, reject) => {
+      this.#pending.set(id, { resolve, reject });
+    });
+    this.socket.send(JSON.stringify({ id, method, params }));
+    return result;
+  }
+
+  on(method, listener) {
+    const listeners = this.#listeners.get(method) ?? [];
+    listeners.push(listener);
+    this.#listeners.set(method, listeners);
+  }
+
+  close() {
+    this.socket.close();
+  }
+}
+
+function parseArguments(arguments_) {
+  const options = { url: DEFAULT_URL, timeout: 30_000 };
+  for (let index = 0; index < arguments_.length; index++) {
+    switch (arguments_[index]) {
+      case "--archive":
+        options.archive = path.resolve(arguments_[++index]);
+        break;
+      case "--chrome":
+        options.chrome = path.resolve(arguments_[++index]);
+        break;
+      case "--url":
+        options.url = arguments_[++index];
+        break;
+      case "--timeout-ms":
+        options.timeout = Number(arguments_[++index]);
+        break;
+      case "--capture-misses":
+        options.captureMisses = true;
+        break;
+      default:
+        throw new Error(`Unknown or incomplete argument '${arguments_[index]}'.`);
+    }
+  }
+  if (!options.archive) {
+    throw new Error("Pass --archive /path/to/a/WebScene/resource/archive.");
+  }
+  if (!Number.isFinite(options.timeout) || options.timeout <= 0) {
+    throw new Error("--timeout-ms must be a positive number.");
+  }
+  return options;
+}
+
+function defaultChromePath() {
+  const candidates = process.platform === "darwin"
+    ? ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"]
+    : process.platform === "win32"
+      ? [
+          path.join(process.env.PROGRAMFILES ?? "", "Google/Chrome/Application/chrome.exe"),
+          path.join(process.env["PROGRAMFILES(X86)"] ?? "", "Google/Chrome/Application/chrome.exe")
+        ]
+      : ["/usr/bin/google-chrome", "/usr/bin/chromium", "/usr/bin/chromium-browser"];
+  const executable = candidates.find(candidate => candidate && existsSync(candidate));
+  if (!executable) {
+    throw new Error("Chrome was not found; pass --chrome /path/to/chrome.");
+  }
+  return executable;
+}
+
+async function loadArchive(directory) {
+  const manifestPath = path.join(directory, "manifest.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  if (manifest.SchemaVersion !== 1 || !Array.isArray(manifest.Entries)) {
+    throw new Error(`Unsupported WebScene resource archive '${manifestPath}'.`);
+  }
+
+  const entriesByAddress = new Map();
+  for (const entry of manifest.Entries) {
+    const address = withoutFragment(entry.Address);
+    const entries = entriesByAddress.get(address) ?? [];
+    entries.push({
+      ...entry,
+      body: (await readFile(path.join(directory, entry.ContentFile))).toString("base64")
+    });
+    entriesByAddress.set(address, entries);
+  }
+  return { directory, manifest, entriesByAddress };
+}
+
+function withoutFragment(address) {
+  const url = new URL(address);
+  url.hash = "";
+  return url.href;
+}
+
+function chooseEntry(entries, resourceType) {
+  if (!entries?.length) return undefined;
+  const expectedKind = {
+    Script: 0,
+    Stylesheet: 1,
+    Document: 2,
+    Image: 3
+  }[resourceType];
+  if (resourceType === "Font") {
+    return entries.find(entry => entry.ResourceType === "binary");
+  }
+  return entries.find(entry => entry.Kind === expectedKind)
+    ?? entries.find(entry => entry.ResourceType === "text")
+    ?? entries[0];
+}
+
+function contentType(entry, resourceType) {
+  if (entry.MimeType) return entry.MimeType;
+  if (resourceType === "Font" || entry.ResourceType === "binary") return "font/woff2";
+  if (entry.Kind === 0) return "application/javascript; charset=utf-8";
+  if (entry.Kind === 1) return "text/css; charset=utf-8";
+  if (entry.Kind === 3 || /\.svg(?:$|\?)/i.test(entry.Address)) return "image/svg+xml";
+  if (resourceType === "Document" || /\.(?:html?|xhtml)(?:$|\?)/i.test(entry.Address)) {
+    return "text/html; charset=utf-8";
+  }
+  return "application/json; charset=utf-8";
+}
+
+function resourceKind(resourceType) {
+  return {
+    Script: 0,
+    Stylesheet: 1,
+    Document: 2,
+    Image: 3
+  }[resourceType] ?? 2;
+}
+
+async function captureResponse(archive, candidate, response, body) {
+  const content = Buffer.from(body.body, body.base64Encoded ? "base64" : "utf8");
+  const hash = createHash("sha256").update(content).digest("hex");
+  const contentFile = `objects/${hash}.bin`;
+  await mkdir(path.join(archive.directory, "objects"), { recursive: true });
+  await writeFile(path.join(archive.directory, contentFile), content, { flag: "wx" })
+    .catch(error => {
+      if (error.code !== "EEXIST") throw error;
+    });
+
+  const type = candidate.resourceType === "Font" ? "binary" : "text";
+  const kind = type === "text" ? resourceKind(candidate.resourceType) : null;
+  const key = type === "binary"
+    ? `binary:${candidate.url}`
+    : `text:${kind}:${candidate.url}`;
+  if (archive.manifest.Entries.some(entry => entry.Key === key)) return false;
+  const entry = {
+    Key: key,
+    Address: candidate.url,
+    ResourceType: type,
+    Kind: kind,
+    ContentFile: contentFile,
+    ContentLength: content.length,
+    CacheKey: candidate.url,
+    DisplayName: candidate.url,
+    Directory: null,
+    EntityTag: null,
+    LastModified: null,
+    FreshUntil: null,
+    IsCacheable: true,
+    MimeType: response.mimeType || undefined
+  };
+  archive.manifest.Entries.push(entry);
+  const address = withoutFragment(candidate.url);
+  const entries = archive.entriesByAddress.get(address) ?? [];
+  entries.push({ ...entry, body: content.toString("base64") });
+  archive.entriesByAddress.set(address, entries);
+  return true;
+}
+
+async function captureFromOrigin(archive, candidate) {
+  const response = await fetch(candidate.url);
+  if (!response.ok) {
+    throw new Error(`origin returned HTTP ${response.status}`);
+  }
+  const content = Buffer.from(await response.arrayBuffer());
+  const captured = await captureResponse(
+    archive,
+    candidate,
+    { mimeType: response.headers.get("content-type") ?? "" },
+    { body: content.toString("base64"), base64Encoded: true });
+  return {
+    captured,
+    entry: chooseEntry(
+      archive.entriesByAddress.get(withoutFragment(candidate.url)),
+      candidate.resourceType)
+  };
+}
+
+async function writeArchiveManifest(archive) {
+  archive.manifest.Entries.sort((left, right) => left.Key.localeCompare(right.Key));
+  await writeFile(
+    path.join(archive.directory, "manifest.json"),
+    JSON.stringify(archive.manifest, null, 2) + "\n");
+}
+
+async function waitForDevToolsPort(userDataDirectory, child, timeout) {
+  const portFile = path.join(userDataDirectory, "DevToolsActivePort");
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Chrome exited before exposing DevTools (code ${child.exitCode}).`);
+    }
+    if (existsSync(portFile)) {
+      const [port] = (await readFile(portFile, "utf8")).trim().split(/\r?\n/);
+      if (port) return Number(port);
+    }
+    await delay(20);
+  }
+  throw new Error("Timed out waiting for Chrome's DevTools port.");
+}
+
+async function waitForPageTarget(port, timeout) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const targets = await fetch(`http://127.0.0.1:${port}/json/list`).then(response => response.json());
+    const page = targets.find(target => target.type === "page");
+    if (page) return page.webSocketDebuggerUrl;
+    await delay(20);
+  }
+  throw new Error("Timed out waiting for Chrome's page target.");
+}
+
+async function waitForChart(client, executionContexts, timeout) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    for (const contextId of [...executionContexts]) {
+      try {
+        const evaluation = await client.send("Runtime.evaluate", {
+          expression: READY_EXPRESSION,
+          contextId,
+          returnByValue: true
+        });
+        if (evaluation.result?.value === true) return;
+      } catch {
+        executionContexts.delete(contextId);
+      }
+    }
+    await delay(25);
+  }
+  throw new Error("Chrome chart did not reach the startup readiness gate.");
+}
+
+function delay(milliseconds) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const archive = await loadArchive(options.archive);
+  const chrome = options.chrome ?? defaultChromePath();
+  const userDataDirectory = await mkdtemp(path.join(os.tmpdir(), "webscene-chrome-replay-"));
+  const child = spawn(chrome, [
+    "--headless=new",
+    "--remote-debugging-port=0",
+    `--user-data-dir=${userDataDirectory}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--disable-background-networking",
+    "--disable-component-update",
+    "--disable-sync",
+    "about:blank"
+  ], { stdio: "ignore" });
+
+  let client;
+  try {
+    const port = await waitForDevToolsPort(userDataDirectory, child, options.timeout);
+    client = new CdpClient(await waitForPageTarget(port, options.timeout));
+    const executionContexts = new Set();
+    const misses = new Set();
+    const captureTasks = new Set();
+    let capturedRequests = 0;
+    let servedRequests = 0;
+    let servedBytes = 0;
+
+    client.on("Runtime.executionContextCreated", event => {
+      if (event.context.auxData?.isDefault) executionContexts.add(event.context.id);
+    });
+    client.on("Runtime.executionContextDestroyed", event => {
+      executionContexts.delete(event.executionContextId);
+    });
+    client.on("Runtime.executionContextsCleared", () => executionContexts.clear());
+    const handlePausedRequest = async event => {
+      try {
+        if (event.request.url === new URL("/favicon.ico", options.url).href) {
+          await client.send("Fetch.fulfillRequest", {
+            requestId: event.requestId,
+            responseCode: 204
+          });
+          return;
+        }
+        const entries = archive.entriesByAddress.get(withoutFragment(event.request.url));
+        const entry = chooseEntry(entries, event.resourceType);
+        if (!entry || event.request.method !== "GET") {
+          if (options.captureMisses && event.request.method === "GET") {
+            const captured = await captureFromOrigin(archive, {
+              url: event.request.url,
+              resourceType: event.resourceType
+            });
+            if (captured.captured) capturedRequests++;
+            if (!captured.entry) {
+              throw new Error("The captured response was not added to the archive.");
+            }
+            await client.send("Fetch.fulfillRequest", {
+              requestId: event.requestId,
+              responseCode: 200,
+              responseHeaders: [
+                { name: "Content-Type", value: contentType(captured.entry, event.resourceType) },
+                { name: "Cache-Control", value: "no-store" },
+                { name: "Access-Control-Allow-Origin", value: "*" },
+                { name: "Cross-Origin-Resource-Policy", value: "cross-origin" }
+              ],
+              body: captured.entry.body
+            });
+            return;
+          }
+          misses.add(`${event.request.method} ${event.resourceType} ${event.request.url}`);
+          await client.send("Fetch.failRequest", {
+            requestId: event.requestId,
+            errorReason: "BlockedByClient"
+          });
+          return;
+        }
+        servedRequests++;
+        servedBytes += entry.ContentLength;
+        await client.send("Fetch.fulfillRequest", {
+          requestId: event.requestId,
+          responseCode: 200,
+          responseHeaders: [
+            { name: "Content-Type", value: contentType(entry, event.resourceType) },
+            { name: "Cache-Control", value: "no-store" },
+            { name: "Access-Control-Allow-Origin", value: "*" },
+            { name: "Cross-Origin-Resource-Policy", value: "cross-origin" }
+          ],
+          body: entry.body
+        });
+      } catch (error) {
+        misses.add(`interception-error ${event.request.url}: ${error.message}`);
+        try {
+          await client.send("Fetch.failRequest", {
+            requestId: event.requestId,
+            errorReason: "Failed"
+          });
+        } catch {}
+      }
+    };
+    client.on("Fetch.requestPaused", event => {
+      const task = handlePausedRequest(event)
+        .finally(() => captureTasks.delete(task));
+      captureTasks.add(task);
+    });
+
+    await Promise.all([
+      client.send("Page.enable"),
+      client.send("Runtime.enable"),
+      client.send("Performance.enable"),
+      client.send("Fetch.enable", {
+        patterns: [{ urlPattern: "http*", requestStage: "Request" }]
+      })
+    ]);
+    const version = await client.send("Browser.getVersion");
+    const startedAt = performance.now();
+    await client.send("Page.navigate", { url: options.url });
+    await waitForChart(client, executionContexts, options.timeout);
+    const readyMilliseconds = performance.now() - startedAt;
+    await delay(500);
+    await Promise.all([...captureTasks]);
+    if (options.captureMisses && capturedRequests) {
+      await writeArchiveManifest(archive);
+    }
+    const performanceMetrics = await client.send("Performance.getMetrics");
+    const selectedMetrics = Object.fromEntries(
+      performanceMetrics.metrics
+        .filter(metric => [
+          "TaskDuration",
+          "ScriptDuration",
+          "LayoutDuration",
+          "RecalcStyleDuration",
+          "LayoutCount",
+          "RecalcStyleCount",
+          "JSHeapUsedSize"
+        ].includes(metric.name))
+        .map(metric => [metric.name, metric.value]));
+
+    console.log(JSON.stringify({
+      browser: version.product,
+      readyMilliseconds,
+      servedRequests,
+      servedBytes,
+      capturedRequests,
+      misses: [...misses].sort(),
+      metrics: selectedMetrics
+    }, null, 2));
+    if (misses.size) process.exitCode = 2;
+  } finally {
+    client?.close();
+    child.kill("SIGTERM");
+    if (child.exitCode === null) {
+      await Promise.race([
+        new Promise(resolve => child.once("exit", resolve)),
+        delay(2_000)
+      ]);
+    }
+    for (let attempt = 0; attempt < 5; attempt++) {
+      try {
+        await rm(userDataDirectory, { recursive: true, force: true });
+        break;
+      } catch (error) {
+        if (attempt === 4) throw error;
+        await delay(100);
+      }
+    }
+  }
+}
+
+main().catch(error => {
+  console.error(error.stack ?? error.message);
+  process.exitCode = 1;
+});

--- a/scripts/benchmark-tradingview-replay.mjs
+++ b/scripts/benchmark-tradingview-replay.mjs
@@ -64,7 +64,7 @@ class CdpClient {
 }
 
 function parseArguments(arguments_) {
-  const options = { url: DEFAULT_URL, timeout: 30_000 };
+  const options = { url: DEFAULT_URL, timeout: 30_000, captureUrls: [] };
   for (let index = 0; index < arguments_.length; index++) {
     switch (arguments_[index]) {
       case "--archive":
@@ -82,6 +82,9 @@ function parseArguments(arguments_) {
       case "--capture-misses":
         options.captureMisses = true;
         break;
+      case "--capture-url":
+        options.captureUrls.push(new URL(arguments_[++index]).href);
+        break;
       default:
         throw new Error(`Unknown or incomplete argument '${arguments_[index]}'.`);
     }
@@ -93,6 +96,15 @@ function parseArguments(arguments_) {
     throw new Error("--timeout-ms must be a positive number.");
   }
   return options;
+}
+
+function inferResourceType(address) {
+  const pathname = new URL(address).pathname.toLowerCase();
+  if (/\.(?:woff2?|ttf|otf)$/.test(pathname)) return "Font";
+  if (/\.css$/.test(pathname)) return "Stylesheet";
+  if (/\.(?:js|mjs)$/.test(pathname)) return "Script";
+  if (/\.(?:svg|png|jpe?g|gif|webp|avif|ico)$/.test(pathname)) return "Image";
+  return "Document";
 }
 
 function defaultChromePath() {
@@ -294,6 +306,15 @@ function delay(milliseconds) {
 async function main() {
   const options = parseArguments(process.argv.slice(2));
   const archive = await loadArchive(options.archive);
+  let explicitCapturedRequests = 0;
+  for (const url of options.captureUrls) {
+    const captured = await captureFromOrigin(archive, {
+      url,
+      resourceType: inferResourceType(url)
+    });
+    if (captured.captured) explicitCapturedRequests++;
+  }
+  if (explicitCapturedRequests) await writeArchiveManifest(archive);
   const chrome = options.chrome ?? defaultChromePath();
   const userDataDirectory = await mkdtemp(path.join(os.tmpdir(), "webscene-chrome-replay-"));
   const child = spawn(chrome, [
@@ -315,7 +336,7 @@ async function main() {
     const executionContexts = new Set();
     const misses = new Set();
     const captureTasks = new Set();
-    let capturedRequests = 0;
+    let capturedRequests = explicitCapturedRequests;
     let servedRequests = 0;
     let servedBytes = 0;
 

--- a/src/WebScene.Backend.Avalonia/AvaloniaHostServices.cs
+++ b/src/WebScene.Backend.Avalonia/AvaloniaHostServices.cs
@@ -318,8 +318,25 @@ public sealed class AvaloniaResourceLoader : IWebSceneResourceLoader
     private static readonly HttpClient s_httpClient = new();
     private readonly List<string> _resourceSearchDirectories = new();
     private readonly List<MountedResourceDirectory> _mountedDirectories = new();
+    private readonly object _archiveGate = new();
+    private AvaloniaResourceArchive? _captureArchive;
+    private AvaloniaResourceArchive? _replayArchive;
+    private Exception? _resourceReplayFailure;
 
     public string ScriptBaseDirectory { get; set; } = AppContext.BaseDirectory;
+
+    /// <summary>
+    /// Gets the directory to which resolved HTTP(S) text and binary responses
+    /// are captured. Call <see cref="FlushResourceCapture"/> after the final
+    /// resource has loaded.
+    /// </summary>
+    public string? ResourceCaptureDirectory { get; init; }
+
+    /// <summary>
+    /// Gets an existing deterministic HTTP(S) resource archive. Missing
+    /// resources fail closed and never fall back to the network.
+    /// </summary>
+    public string? ResourceReplayDirectory { get; init; }
 
     public WebSceneTextResource LoadText(in WebSceneResourceRequest request)
     {
@@ -349,64 +366,85 @@ public sealed class AvaloniaResourceLoader : IWebSceneResourceLoader
 
         if (resolved.Scheme is "http" or "https")
         {
+            if (GetReplayArchiveTracked() is { } replayArchive)
+            {
+                try
+                {
+                    return replayArchive.ReplayText(resolved, request.Kind);
+                }
+                catch (Exception error)
+                {
+                    RememberReplayFailure(error);
+                    throw;
+                }
+            }
+
+            WebSceneTextResource resource;
             if (TryResolveMountedResource(resolved, out var mountedPath))
             {
-                return LoadFile(mountedPath);
+                resource = LoadFile(mountedPath);
             }
-
-            if (TryResolvePackagedResource(resolved.AbsolutePath, out var packagedPath))
+            else if (TryResolvePackagedResource(resolved.AbsolutePath, out var packagedPath))
             {
-                return LoadFile(packagedPath);
+                resource = LoadFile(packagedPath);
             }
-
-            using var message = new HttpRequestMessage(HttpMethod.Get, resolved);
-            message.Version = HttpVersion.Version20;
-            message.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
-            if (!string.IsNullOrWhiteSpace(request.IfNoneMatch)
-                && EntityTagHeaderValue.TryParse(request.IfNoneMatch, out var entityTag))
+            else
             {
-                message.Headers.IfNoneMatch.Add(entityTag);
-            }
-            if (request.IfModifiedSince is { } modifiedSince)
-            {
-                message.Headers.IfModifiedSince = modifiedSince;
-            }
-            using var response = s_httpClient.SendAsync(
-                    message,
-                    HttpCompletionOption.ResponseHeadersRead)
-                .GetAwaiter()
-                .GetResult();
-            var responseEntityTag = response.Headers.ETag?.ToString() ?? request.IfNoneMatch;
-            var responseLastModified = response.Content.Headers.LastModified
-                                       ?? request.IfModifiedSince;
-            var cachePolicy = ReadHttpCachePolicy(response, responseLastModified);
-            if (response.StatusCode == HttpStatusCode.NotModified)
-            {
-                return new WebSceneTextResource(
-                    resolved.ToString(),
-                    string.Empty,
-                    resolved.ToString(),
-                    null)
+                using var message = new HttpRequestMessage(HttpMethod.Get, resolved);
+                message.Version = HttpVersion.Version20;
+                message.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
+                if (!string.IsNullOrWhiteSpace(request.IfNoneMatch)
+                    && EntityTagHeaderValue.TryParse(request.IfNoneMatch, out var entityTag))
                 {
-                    EntityTag = responseEntityTag,
-                    LastModified = responseLastModified,
-                    FreshUntil = cachePolicy.FreshUntil,
-                    IsCacheable = cachePolicy.IsCacheable,
-                    NotModified = true
-                };
+                    message.Headers.IfNoneMatch.Add(entityTag);
+                }
+                if (request.IfModifiedSince is { } modifiedSince)
+                {
+                    message.Headers.IfModifiedSince = modifiedSince;
+                }
+                using var response = s_httpClient.SendAsync(
+                        message,
+                        HttpCompletionOption.ResponseHeadersRead)
+                    .GetAwaiter()
+                    .GetResult();
+                var responseEntityTag = response.Headers.ETag?.ToString() ?? request.IfNoneMatch;
+                var responseLastModified = response.Content.Headers.LastModified
+                                           ?? request.IfModifiedSince;
+                var cachePolicy = ReadHttpCachePolicy(response, responseLastModified);
+                if (response.StatusCode == HttpStatusCode.NotModified)
+                {
+                    resource = new WebSceneTextResource(
+                        resolved.ToString(),
+                        string.Empty,
+                        resolved.ToString(),
+                        null)
+                    {
+                        EntityTag = responseEntityTag,
+                        LastModified = responseLastModified,
+                        FreshUntil = cachePolicy.FreshUntil,
+                        IsCacheable = cachePolicy.IsCacheable,
+                        NotModified = true
+                    };
+                }
+                else
+                {
+                    response.EnsureSuccessStatusCode();
+                    resource = new WebSceneTextResource(
+                        resolved.ToString(),
+                        response.Content.ReadAsStringAsync().GetAwaiter().GetResult(),
+                        resolved.ToString(),
+                        null)
+                    {
+                        EntityTag = responseEntityTag,
+                        LastModified = responseLastModified,
+                        FreshUntil = cachePolicy.FreshUntil,
+                        IsCacheable = cachePolicy.IsCacheable
+                    };
+                }
             }
-            response.EnsureSuccessStatusCode();
-            return new WebSceneTextResource(
-                resolved.ToString(),
-                response.Content.ReadAsStringAsync().GetAwaiter().GetResult(),
-                resolved.ToString(),
-                null)
-            {
-                EntityTag = responseEntityTag,
-                LastModified = responseLastModified,
-                FreshUntil = cachePolicy.FreshUntil,
-                IsCacheable = cachePolicy.IsCacheable
-            };
+
+            GetCaptureArchive()?.CaptureText(resolved, request.Kind, resource);
+            return resource;
         }
 
         throw new NotSupportedException($"Unsupported resource scheme '{resolved.Scheme}'.");
@@ -497,32 +535,77 @@ public sealed class AvaloniaResourceLoader : IWebSceneResourceLoader
 
         if (resolved.Scheme is "http" or "https")
         {
+            if (GetReplayArchiveTracked() is { } replayArchive)
+            {
+                try
+                {
+                    return replayArchive.ReplayBinary(resolved);
+                }
+                catch (Exception error)
+                {
+                    RememberReplayFailure(error);
+                    throw;
+                }
+            }
+
+            AvaloniaBinaryResource resource;
             if (TryResolveMountedResource(resolved, out var mountedPath))
             {
-                return new AvaloniaBinaryResource(
+                resource = new AvaloniaBinaryResource(
                     mountedPath,
                     await File.ReadAllBytesAsync(mountedPath, cancellationToken).ConfigureAwait(false),
                     new Uri(mountedPath).AbsoluteUri);
             }
-
-            if (TryResolvePackagedResource(resolved.AbsolutePath, out var packagedPath))
+            else if (TryResolvePackagedResource(resolved.AbsolutePath, out var packagedPath))
             {
-                return new AvaloniaBinaryResource(
+                resource = new AvaloniaBinaryResource(
                     packagedPath,
                     await File.ReadAllBytesAsync(packagedPath, cancellationToken).ConfigureAwait(false),
                     new Uri(packagedPath).AbsoluteUri);
             }
+            else
+            {
+                resource = new AvaloniaBinaryResource(
+                    resolved.ToString(),
+                    await s_httpClient.GetByteArrayAsync(resolved, cancellationToken).ConfigureAwait(false),
+                    resolved.ToString());
+            }
 
-            return new AvaloniaBinaryResource(
-                resolved.ToString(),
-                await s_httpClient.GetByteArrayAsync(resolved, cancellationToken).ConfigureAwait(false),
-                resolved.ToString());
+            GetCaptureArchive()?.CaptureBinary(resolved, resource);
+            return resource;
         }
 
         throw new NotSupportedException($"Unsupported resource scheme '{resolved.Scheme}'.");
     }
 
     public void ClearSearchDirectories() => _resourceSearchDirectories.Clear();
+
+    /// <summary>Writes a pending deterministic resource-capture manifest.</summary>
+    public void FlushResourceCapture()
+    {
+        lock (_archiveGate)
+        {
+            _captureArchive?.Flush();
+        }
+    }
+
+    /// <summary>
+    /// Throws when the native callback boundary observed an archive miss or
+    /// corrupt replay object. Native resource callbacks cannot propagate
+    /// managed exceptions directly, so deterministic benchmark hosts should
+    /// call this while waiting for readiness and once after the readiness gate.
+    /// </summary>
+    public void ThrowIfResourceReplayFailed()
+    {
+        if (Volatile.Read(ref _resourceReplayFailure) is not { } error)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "Deterministic WebScene resource replay failed. The origin was not contacted.",
+            error);
+    }
 
     public void MountDirectory(string addressPrefix, string directory)
     {
@@ -665,6 +748,60 @@ public sealed class AvaloniaResourceLoader : IWebSceneResourceLoader
     }
 
     private sealed record MountedResourceDirectory(Uri Prefix, string Directory);
+
+    private AvaloniaResourceArchive? GetCaptureArchive()
+    {
+        ValidateArchiveConfiguration();
+        if (string.IsNullOrWhiteSpace(ResourceCaptureDirectory))
+        {
+            return null;
+        }
+
+        lock (_archiveGate)
+        {
+            return _captureArchive ??= AvaloniaResourceArchive.CreateCapture(ResourceCaptureDirectory);
+        }
+    }
+
+    private AvaloniaResourceArchive? GetReplayArchive()
+    {
+        ValidateArchiveConfiguration();
+        if (string.IsNullOrWhiteSpace(ResourceReplayDirectory))
+        {
+            return null;
+        }
+
+        lock (_archiveGate)
+        {
+            return _replayArchive ??= AvaloniaResourceArchive.OpenReplay(ResourceReplayDirectory);
+        }
+    }
+
+    private AvaloniaResourceArchive? GetReplayArchiveTracked()
+    {
+        try
+        {
+            return GetReplayArchive();
+        }
+        catch (Exception error)
+        {
+            RememberReplayFailure(error);
+            throw;
+        }
+    }
+
+    private void ValidateArchiveConfiguration()
+    {
+        if (!string.IsNullOrWhiteSpace(ResourceCaptureDirectory)
+            && !string.IsNullOrWhiteSpace(ResourceReplayDirectory))
+        {
+            throw new InvalidOperationException(
+                "Resource capture and replay directories are mutually exclusive.");
+        }
+    }
+
+    private void RememberReplayFailure(Exception error)
+        => Interlocked.CompareExchange(ref _resourceReplayFailure, error, null);
 
     private static string DecodeDataUri(string value)
     {

--- a/src/WebScene.Backend.Avalonia/AvaloniaHostServices.cs
+++ b/src/WebScene.Backend.Avalonia/AvaloniaHostServices.cs
@@ -607,6 +607,24 @@ public sealed class AvaloniaResourceLoader : IWebSceneResourceLoader
             error);
     }
 
+    /// <summary>
+    /// Validates and preloads every replay object. Benchmark hosts can call
+    /// this before starting their navigation timer, matching a browser whose
+    /// interception fixture is already resident in memory.
+    /// </summary>
+    public void PrepareResourceReplay()
+    {
+        try
+        {
+            GetReplayArchiveTracked()?.Preload();
+        }
+        catch (Exception error)
+        {
+            RememberReplayFailure(error);
+            throw;
+        }
+    }
+
     public void MountDirectory(string addressPrefix, string directory)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(addressPrefix);

--- a/src/WebScene.Backend.Avalonia/AvaloniaResourceArchive.cs
+++ b/src/WebScene.Backend.Avalonia/AvaloniaResourceArchive.cs
@@ -1,0 +1,278 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using WebScene.Core;
+
+namespace WebScene.Backends.Avalonia;
+
+internal sealed class AvaloniaResourceArchive
+{
+    private const int CurrentSchemaVersion = 1;
+    private const string ManifestFileName = "manifest.json";
+    private readonly object _gate = new();
+    private readonly string _rootDirectory;
+    private readonly string _objectsDirectory;
+    private readonly Dictionary<string, ResourceArchiveEntry> _entries;
+    private bool _dirty;
+
+    private AvaloniaResourceArchive(
+        string directory,
+        Dictionary<string, ResourceArchiveEntry> entries)
+    {
+        _rootDirectory = Path.GetFullPath(directory);
+        _objectsDirectory = Path.Combine(_rootDirectory, "objects");
+        _entries = entries;
+    }
+
+    internal static AvaloniaResourceArchive CreateCapture(string directory)
+    {
+        var archive = new AvaloniaResourceArchive(
+            directory,
+            new Dictionary<string, ResourceArchiveEntry>(StringComparer.Ordinal));
+        Directory.CreateDirectory(archive._objectsDirectory);
+        return archive;
+    }
+
+    internal static AvaloniaResourceArchive OpenReplay(string directory)
+    {
+        var root = Path.GetFullPath(directory);
+        var manifestPath = Path.Combine(root, ManifestFileName);
+        if (!File.Exists(manifestPath))
+        {
+            throw new FileNotFoundException(
+                $"WebScene resource replay manifest '{manifestPath}' was not found.",
+                manifestPath);
+        }
+
+        var manifest = JsonSerializer.Deserialize<ResourceArchiveManifest>(
+                           File.ReadAllText(manifestPath))
+                       ?? throw new InvalidDataException(
+                           $"WebScene resource replay manifest '{manifestPath}' is empty.");
+        if (manifest.SchemaVersion != CurrentSchemaVersion)
+        {
+            throw new InvalidDataException(
+                $"WebScene resource replay manifest schema {manifest.SchemaVersion} is not supported; "
+                + $"expected {CurrentSchemaVersion}.");
+        }
+
+        var entries = new Dictionary<string, ResourceArchiveEntry>(StringComparer.Ordinal);
+        foreach (var entry in manifest.Entries)
+        {
+            if (string.IsNullOrWhiteSpace(entry.Key)
+                || string.IsNullOrWhiteSpace(entry.ContentFile)
+                || !entries.TryAdd(entry.Key, entry))
+            {
+                throw new InvalidDataException(
+                    $"WebScene resource replay manifest '{manifestPath}' contains an invalid or duplicate entry.");
+            }
+        }
+
+        return new AvaloniaResourceArchive(root, entries);
+    }
+
+    internal void CaptureText(
+        Uri address,
+        WebSceneResourceKind kind,
+        in WebSceneTextResource resource)
+    {
+        if (resource.NotModified)
+        {
+            throw new InvalidOperationException(
+                $"Cannot capture the 304 response for '{address}' without its cached body. "
+                + "Use an empty WebScene resource cache for the capture run.");
+        }
+
+        var content = Encoding.UTF8.GetBytes(resource.Content);
+        lock (_gate)
+        {
+            _entries[TextKey(address, kind)] = new ResourceArchiveEntry
+            {
+                Key = TextKey(address, kind),
+                Address = address.ToString(),
+                ResourceType = "text",
+                Kind = kind,
+                ContentFile = StoreContent(content),
+                ContentLength = content.LongLength,
+                CacheKey = resource.CacheKey,
+                DisplayName = resource.DisplayName,
+                Directory = resource.Directory,
+                EntityTag = resource.EntityTag,
+                LastModified = resource.LastModified,
+                FreshUntil = resource.FreshUntil,
+                IsCacheable = resource.IsCacheable
+            };
+            _dirty = true;
+        }
+    }
+
+    internal WebSceneTextResource ReplayText(Uri address, WebSceneResourceKind kind)
+    {
+        ResourceArchiveEntry entry;
+        lock (_gate)
+        {
+            if (!_entries.TryGetValue(TextKey(address, kind), out entry!))
+            {
+                throw MissingResource(address, $"text/{kind}");
+            }
+        }
+
+        var content = ReadContent(entry);
+        return new WebSceneTextResource(
+            entry.CacheKey ?? entry.Address,
+            Encoding.UTF8.GetString(content),
+            entry.DisplayName ?? entry.Address,
+            entry.Directory)
+        {
+            EntityTag = entry.EntityTag,
+            LastModified = entry.LastModified,
+            FreshUntil = entry.FreshUntil,
+            IsCacheable = entry.IsCacheable
+        };
+    }
+
+    internal void CaptureBinary(Uri address, in AvaloniaBinaryResource resource)
+    {
+        lock (_gate)
+        {
+            _entries[BinaryKey(address)] = new ResourceArchiveEntry
+            {
+                Key = BinaryKey(address),
+                Address = address.ToString(),
+                ResourceType = "binary",
+                ContentFile = StoreContent(resource.Content),
+                ContentLength = resource.Content.LongLength,
+                CacheKey = resource.CacheKey,
+                DisplayName = resource.DisplayName
+            };
+            _dirty = true;
+        }
+    }
+
+    internal AvaloniaBinaryResource ReplayBinary(Uri address)
+    {
+        ResourceArchiveEntry entry;
+        lock (_gate)
+        {
+            if (!_entries.TryGetValue(BinaryKey(address), out entry!))
+            {
+                throw MissingResource(address, "binary");
+            }
+        }
+
+        return new AvaloniaBinaryResource(
+            entry.CacheKey ?? entry.Address,
+            ReadContent(entry),
+            entry.DisplayName ?? entry.Address);
+    }
+
+    internal void Flush()
+    {
+        lock (_gate)
+        {
+            if (!_dirty)
+            {
+                return;
+            }
+
+            Directory.CreateDirectory(_rootDirectory);
+            var manifest = new ResourceArchiveManifest
+            {
+                SchemaVersion = CurrentSchemaVersion,
+                Entries = _entries.Values
+                    .OrderBy(entry => entry.Key, StringComparer.Ordinal)
+                    .ToArray()
+            };
+            var manifestPath = Path.Combine(_rootDirectory, ManifestFileName);
+            var temporaryPath = Path.Combine(_rootDirectory, $".{ManifestFileName}.{Guid.NewGuid():N}.tmp");
+            File.WriteAllText(
+                temporaryPath,
+                JsonSerializer.Serialize(
+                    manifest,
+                    new JsonSerializerOptions { WriteIndented = true }));
+            File.Move(temporaryPath, manifestPath, overwrite: true);
+            _dirty = false;
+        }
+    }
+
+    private string StoreContent(ReadOnlySpan<byte> content)
+    {
+        var hash = Convert.ToHexString(SHA256.HashData(content)).ToLowerInvariant();
+        var relativePath = Path.Combine("objects", hash + ".bin");
+        var fullPath = Path.Combine(_rootDirectory, relativePath);
+        if (!File.Exists(fullPath))
+        {
+            File.WriteAllBytes(fullPath, content.ToArray());
+        }
+        return relativePath.Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    private byte[] ReadContent(ResourceArchiveEntry entry)
+    {
+        var relativePath = entry.ContentFile.Replace('/', Path.DirectorySeparatorChar);
+        var fullPath = Path.GetFullPath(Path.Combine(_rootDirectory, relativePath));
+        var rootPrefix = _rootDirectory.EndsWith(Path.DirectorySeparatorChar)
+            ? _rootDirectory
+            : _rootDirectory + Path.DirectorySeparatorChar;
+        if (!fullPath.StartsWith(rootPrefix, StringComparison.Ordinal)
+            || !File.Exists(fullPath))
+        {
+            throw new InvalidDataException(
+                $"WebScene resource replay object '{entry.ContentFile}' is missing or outside the archive.");
+        }
+
+        var content = File.ReadAllBytes(fullPath);
+        if (content.LongLength != entry.ContentLength)
+        {
+            throw new InvalidDataException(
+                $"WebScene resource replay object '{entry.ContentFile}' has length {content.LongLength}; "
+                + $"expected {entry.ContentLength}.");
+        }
+        return content;
+    }
+
+    private static FileNotFoundException MissingResource(Uri address, string type)
+        => new(
+            $"Resource '{address}' ({type}) is not present in the deterministic WebScene replay archive. "
+            + "Replay never falls back to the network.");
+
+    private static string TextKey(Uri address, WebSceneResourceKind kind)
+        => $"text:{(int)kind}:{address}";
+
+    private static string BinaryKey(Uri address) => $"binary:{address}";
+
+    private sealed class ResourceArchiveManifest
+    {
+        public int SchemaVersion { get; set; }
+
+        public ResourceArchiveEntry[] Entries { get; set; } = [];
+    }
+
+    private sealed class ResourceArchiveEntry
+    {
+        public string Key { get; set; } = string.Empty;
+
+        public string Address { get; set; } = string.Empty;
+
+        public string ResourceType { get; set; } = string.Empty;
+
+        public WebSceneResourceKind? Kind { get; set; }
+
+        public string ContentFile { get; set; } = string.Empty;
+
+        public long ContentLength { get; set; }
+
+        public string? CacheKey { get; set; }
+
+        public string? DisplayName { get; set; }
+
+        public string? Directory { get; set; }
+
+        public string? EntityTag { get; set; }
+
+        public DateTimeOffset? LastModified { get; set; }
+
+        public DateTimeOffset? FreshUntil { get; set; }
+
+        public bool IsCacheable { get; set; } = true;
+    }
+}

--- a/src/WebScene.Backend.Avalonia/AvaloniaResourceArchive.cs
+++ b/src/WebScene.Backend.Avalonia/AvaloniaResourceArchive.cs
@@ -13,6 +13,7 @@ internal sealed class AvaloniaResourceArchive
     private readonly string _rootDirectory;
     private readonly string _objectsDirectory;
     private readonly Dictionary<string, ResourceArchiveEntry> _entries;
+    private readonly Dictionary<string, byte[]> _contentByFile = new(StringComparer.Ordinal);
     private bool _dirty;
 
     private AvaloniaResourceArchive(
@@ -26,6 +27,12 @@ internal sealed class AvaloniaResourceArchive
 
     internal static AvaloniaResourceArchive CreateCapture(string directory)
     {
+        var manifestPath = Path.Combine(Path.GetFullPath(directory), ManifestFileName);
+        if (File.Exists(manifestPath))
+        {
+            return OpenReplay(directory);
+        }
+
         var archive = new AvaloniaResourceArchive(
             directory,
             new Dictionary<string, ResourceArchiveEntry>(StringComparer.Ordinal));
@@ -165,6 +172,20 @@ internal sealed class AvaloniaResourceArchive
             entry.DisplayName ?? entry.Address);
     }
 
+    internal void Preload()
+    {
+        lock (_gate)
+        {
+            foreach (var entry in _entries.Values)
+            {
+                if (!_contentByFile.ContainsKey(entry.ContentFile))
+                {
+                    _contentByFile.Add(entry.ContentFile, ReadContentFromDisk(entry));
+                }
+            }
+        }
+    }
+
     internal void Flush()
     {
         lock (_gate)
@@ -207,6 +228,21 @@ internal sealed class AvaloniaResourceArchive
     }
 
     private byte[] ReadContent(ResourceArchiveEntry entry)
+    {
+        lock (_gate)
+        {
+            if (_contentByFile.TryGetValue(entry.ContentFile, out var content))
+            {
+                return content;
+            }
+
+            content = ReadContentFromDisk(entry);
+            _contentByFile.Add(entry.ContentFile, content);
+            return content;
+        }
+    }
+
+    private byte[] ReadContentFromDisk(ResourceArchiveEntry entry)
     {
         var relativePath = entry.ContentFile.Replace('/', Path.DirectorySeparatorChar);
         var fullPath = Path.GetFullPath(Path.Combine(_rootDirectory, relativePath));

--- a/tests/WebScene.Backend.Avalonia.Tests/AvaloniaResourceLoaderTests.cs
+++ b/tests/WebScene.Backend.Avalonia.Tests/AvaloniaResourceLoaderTests.cs
@@ -9,6 +9,114 @@ namespace WebScene.Backend.Avalonia.Tests;
 public sealed class AvaloniaResourceLoaderTests
 {
     [Fact]
+    public async Task HttpCaptureReplaysTextAndBinaryWithoutOriginFallback()
+    {
+        var fixtureDirectory = Path.Combine(AppContext.BaseDirectory, "Fixtures");
+        var archiveDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "webscene-resource-archive-tests",
+            Guid.NewGuid().ToString("N"));
+        try
+        {
+            var capture = new AvaloniaResourceLoader
+            {
+                ResourceCaptureDirectory = archiveDirectory
+            };
+            capture.MountDirectory("https://fixtures.webscene.test/", fixtureDirectory);
+            var address = "https://fixtures.webscene.test/module-mutation-observer.js";
+            var request = new WebSceneResourceRequest(
+                address,
+                null,
+                WebSceneResourceKind.Script);
+
+            var capturedText = capture.LoadText(request);
+            var capturedBinary = await capture.LoadBytesAsync(
+                address,
+                null,
+                CancellationToken.None);
+            capture.FlushResourceCapture();
+
+            var replay = new AvaloniaResourceLoader
+            {
+                ResourceReplayDirectory = archiveDirectory
+            };
+            var replayedText = replay.LoadText(request);
+            var replayedBinary = await replay.LoadBytesAsync(
+                address,
+                null,
+                CancellationToken.None);
+
+            Assert.Equal(capturedText.Content, replayedText.Content);
+            Assert.Equal(capturedText.CacheKey, replayedText.CacheKey);
+            Assert.Equal(capturedBinary.Content, replayedBinary.Content);
+            Assert.Equal(capturedBinary.CacheKey, replayedBinary.CacheKey);
+            Assert.Throws<FileNotFoundException>(() => replay.LoadText(
+                new WebSceneResourceRequest(
+                    "https://fixtures.webscene.test/not-captured.js",
+                    null,
+                    WebSceneResourceKind.Script)));
+            var replayFailure = Assert.Throws<InvalidOperationException>(
+                replay.ThrowIfResourceReplayFailed);
+            Assert.IsType<FileNotFoundException>(replayFailure.InnerException);
+        }
+        finally
+        {
+            if (Directory.Exists(archiveDirectory))
+            {
+                Directory.Delete(archiveDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void ResourceCaptureAndReplayAreMutuallyExclusive()
+    {
+        var loader = new AvaloniaResourceLoader
+        {
+            ResourceCaptureDirectory = "capture",
+            ResourceReplayDirectory = "replay"
+        };
+
+        var error = Assert.Throws<InvalidOperationException>(() => loader.LoadText(
+            new WebSceneResourceRequest(
+                "https://fixtures.webscene.test/app.js",
+                null,
+                WebSceneResourceKind.Script)));
+
+        Assert.Contains("mutually exclusive", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MissingReplayManifestIsRememberedAcrossNativeCallbackBoundary()
+    {
+        var archiveDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "webscene-resource-archive-tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(archiveDirectory);
+        try
+        {
+            var replay = new AvaloniaResourceLoader
+            {
+                ResourceReplayDirectory = archiveDirectory
+            };
+
+            Assert.Throws<FileNotFoundException>(() => replay.LoadText(
+                new WebSceneResourceRequest(
+                    "https://fixtures.webscene.test/app.js",
+                    null,
+                    WebSceneResourceKind.Script)));
+            var replayFailure = Assert.Throws<InvalidOperationException>(
+                replay.ThrowIfResourceReplayFailed);
+            Assert.IsType<FileNotFoundException>(replayFailure.InnerException);
+        }
+        finally
+        {
+            Directory.Delete(archiveDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
     public void HttpResourceFreshnessHonorsOriginPolicyAndBoundedValidatorHeuristics()
     {
         var now = DateTimeOffset.UtcNow;

--- a/tests/WebScene.Backend.Avalonia.Tests/AvaloniaResourceLoaderTests.cs
+++ b/tests/WebScene.Backend.Avalonia.Tests/AvaloniaResourceLoaderTests.cs
@@ -36,17 +36,40 @@ public sealed class AvaloniaResourceLoaderTests
                 CancellationToken.None);
             capture.FlushResourceCapture();
 
+            var incrementalCapture = new AvaloniaResourceLoader
+            {
+                ResourceCaptureDirectory = archiveDirectory
+            };
+            incrementalCapture.MountDirectory(
+                "https://incremental.fixtures.webscene.test/",
+                fixtureDirectory);
+            var incrementalAddress =
+                "https://incremental.fixtures.webscene.test/module-mutation-observer.js";
+            var incrementalResource = incrementalCapture.LoadText(
+                new WebSceneResourceRequest(
+                    incrementalAddress,
+                    null,
+                    WebSceneResourceKind.Script));
+            incrementalCapture.FlushResourceCapture();
+
             var replay = new AvaloniaResourceLoader
             {
                 ResourceReplayDirectory = archiveDirectory
             };
+            replay.PrepareResourceReplay();
             var replayedText = replay.LoadText(request);
+            var replayedIncremental = replay.LoadText(
+                new WebSceneResourceRequest(
+                    incrementalAddress,
+                    null,
+                    WebSceneResourceKind.Script));
             var replayedBinary = await replay.LoadBytesAsync(
                 address,
                 null,
                 CancellationToken.None);
 
             Assert.Equal(capturedText.Content, replayedText.Content);
+            Assert.Equal(incrementalResource.Content, replayedIncremental.Content);
             Assert.Equal(capturedText.CacheKey, replayedText.CacheKey);
             Assert.Equal(capturedBinary.Content, replayedBinary.Content);
             Assert.Equal(capturedBinary.CacheKey, replayedBinary.CacheKey);
@@ -101,6 +124,7 @@ public sealed class AvaloniaResourceLoaderTests
                 ResourceReplayDirectory = archiveDirectory
             };
 
+            Assert.Throws<FileNotFoundException>(replay.PrepareResourceReplay);
             Assert.Throws<FileNotFoundException>(() => replay.LoadText(
                 new WebSceneResourceRequest(
                     "https://fixtures.webscene.test/app.js",


### PR DESCRIPTION
## Summary

- index CSS rules by referenced custom properties and build one dependency plan per connected stylesheet
- filter variable-dependent recascade work through the existing selector indexes while preserving source order and link load-event boundaries
- cover direct, transitive, and inline variable dependencies with a focused regression corpus
- add a reproducible TradingView desktop startup profiler and benchmark documentation

## Performance

Warm-cache certification A/B runs reduced connected-stylesheet recascade from 346.7-372.8 ms to 67.1-97.0 ms. The optimized path processed roughly twice as many cumulative node visits before readiness while reducing nodes requiring variable replay from 22,769-28,763 to 469-520.

Chrome 151 measured 34-38 ms for warm style recalculation; this moves WebScene from roughly a 10x discrepancy to approximately 2x.

## Verification

- production webscene_native_engine_tests passes
- certification regression passes and the broader suite reaches the existing structured feature-inventory gate
- NativeTradingViewTerminal Release build succeeds with zero warnings and errors
- git diff --check passes

## Follow-up

Warm iframe hydration is now approximately 90-105 ms. It remains a secondary candidate for a separately benchmarked scheduling change, but this PR intentionally avoids changing iframe lifecycle semantics.