### PR TITLE
Optimize native resize presentation cadence

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -37,3 +37,62 @@ control and an Inspector-capable candidate, and fails if ordinary work initializ
 managed Inspector registry.
 
 Run with `probe` and no recognized name to list the focused probes.
+
+## Resize cadence
+
+`native-resize-cadence` drives a real Avalonia window at a configurable cadence and
+emits machine-readable engine, publication, render, CPU, and latency metrics. Its
+default local fixture exercises generic grid, flex, text, synchronous geometry reads,
+resize listeners, and animation-frame work; `--url` can qualify any external page
+without adding page-specific behavior to the engine.
+
+```bash
+WEBSCENE_NATIVE_ENGINE_PATH=/absolute/path/to/libwebscene_native_engine.dylib \
+  dotnet run --project benchmarks/WebScene.NativeEngine.Benchmarks -c Release -- \
+  probe native-resize-cadence --warmup-seconds 2 --seconds 10 --hz 60
+```
+
+Add `--composition` to exercise Avalonia's composition projection and `--enforce` to
+return a failure unless p95 resize-to-render latency is at most 16.7 ms, throughput is
+at least 58 rendered frames/second, no render interval exceeds 33.4 ms, and no input is
+dropped. `--output <file>` writes the same JSON emitted on stdout. Use repeated fresh
+control/candidate processes for performance decisions, then compare paired directories
+with `scripts/compare-native-resize-cadence.py`. The comparator uses paired bootstrap
+95% intervals, rejects supported regressions above 3%, and can require both a material
+improvement and the practical-vsync gate. It also rejects pairs that mix certification
+and production runtimes.
+
+```bash
+python3 scripts/compare-native-resize-cadence.py \
+  --control-dir artifacts/resize-control \
+  --candidate-dir artifacts/resize-candidate \
+  --minimum-samples 10 \
+  --output artifacts/resize-comparison.json
+```
+
+For a browser reference, the CDP profiler launches an isolated headed Chrome process
+and applies the same 60 Hz triangular window resize. It records rAF cadence,
+resize-to-rAF latency, long tasks, Chrome performance counters, and trace-stage totals:
+
+```bash
+node scripts/profile-chrome-resize-cadence.mjs \
+  --url https://trading-terminal.tradingview-widget.com/ \
+  --warmup-seconds 5 --seconds 10 --hz 60 \
+  --output artifacts/chrome-resize.json
+```
+
+Use `--headless` only for automation smoke tests; headed Chrome is the visual smoothness
+reference.
+
+Pass that immutable Chrome result back to the native probe to report an exact matched
+cadence comparison. Add `--enforce-chrome-reference` when the native run should fail
+unless its measured presentation throughput and p95 interval equal or beat Chrome:
+
+```bash
+WEBSCENE_NATIVE_ENGINE_PATH=/absolute/path/to/libwebscene_native_engine.dylib \
+  dotnet run --project benchmarks/WebScene.NativeEngine.Benchmarks -c Release -- \
+  probe native-resize-cadence --composition \
+  --url https://trading-terminal.tradingview-widget.com/ \
+  --warmup-seconds 5 --seconds 10 --hz 60 \
+  --chrome-reference artifacts/chrome-resize.json
+```

--- a/benchmarks/WebScene.NativeEngine.Benchmarks/NativeResizeCadenceProbe.cs
+++ b/benchmarks/WebScene.NativeEngine.Benchmarks/NativeResizeCadenceProbe.cs
@@ -1,0 +1,531 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using WebScene.Backends.Avalonia.Native;
+
+namespace WebScene.NativeEngine.Benchmarks;
+
+internal static class NativeResizeCadenceProbe
+{
+    private const string Fixture = """
+        <!doctype html>
+        <meta charset="utf-8">
+        <style>
+          * { box-sizing: border-box }
+          html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; font: 12px sans-serif }
+          #shell { display: grid; grid-template-rows: 38px 1fr 24px; width: 100vw; height: 100vh }
+          #toolbar { display: flex; gap: 6px; padding: 5px; border-bottom: 1px solid #333 }
+          #workspace { display: grid; grid-template-columns: minmax(180px, 1fr) 3fr; min-height: 0 }
+          #watchlist { overflow: hidden; border-right: 1px solid #333 }
+          #chart { position: relative; overflow: hidden; min-width: 0 }
+          .row { display: grid; grid-template-columns: 1fr 70px 70px; height: 22px; padding: 2px 5px }
+          .row:nth-child(odd) { background: #17191d }
+          .pane { position: absolute; inset: 8px; display: flex; flex-direction: column }
+          .plot { flex: 1; min-height: 0; border: 1px solid #444 }
+          #status { padding: 4px 8px; border-top: 1px solid #333 }
+        </style>
+        <div id="shell">
+          <div id="toolbar"></div>
+          <div id="workspace"><div id="watchlist"></div><div id="chart"><div class="pane"><div class="plot"></div></div></div></div>
+          <div id="status"></div>
+        </div>
+        <script>
+          const toolbar = document.querySelector('#toolbar');
+          const watchlist = document.querySelector('#watchlist');
+          for (let i = 0; i < 24; i++) {
+            const button = document.createElement('button');
+            button.textContent = `Tool ${i}`;
+            toolbar.append(button);
+          }
+          for (let i = 0; i < 180; i++) {
+            const row = document.createElement('div');
+            row.className = 'row';
+            row.innerHTML = `<span>SYMBOL-${i}</span><span>${(100 + i / 7).toFixed(2)}</span><span>${i % 2 ? '+' : '-'}0.12%</span>`;
+            watchlist.append(row);
+          }
+          const pane = document.querySelector('.pane');
+          const plot = document.querySelector('.plot');
+          const status = document.querySelector('#status');
+          addEventListener('resize', () => {
+            pane.style.height = `${Math.max(1, innerHeight - 86)}px`;
+            const width = plot.clientWidth;
+            const height = plot.getBoundingClientRect().height;
+            status.textContent = `${width} x ${height}`;
+            requestAnimationFrame(() => {
+              plot.style.transform = `translate(${width % 2}px, ${height % 2}px)`;
+              void plot.offsetHeight;
+            });
+          });
+        </script>
+        """;
+
+    internal static int Run(string[] args)
+    {
+        var library = Environment.GetEnvironmentVariable("WEBSCENE_NATIVE_ENGINE_PATH");
+        if (string.IsNullOrWhiteSpace(library))
+        {
+            throw new InvalidOperationException(
+                "Set WEBSCENE_NATIVE_ENGINE_PATH to the native V8 library.");
+        }
+
+        var seconds = ReadDoubleOption(args, "--seconds", 10);
+        var warmupSeconds = ReadDoubleOption(args, "--warmup-seconds", 2);
+        var frequency = ReadDoubleOption(args, "--hz", 60);
+        var baseWidth = ReadDoubleOption(args, "--width", 1180);
+        var baseHeight = ReadDoubleOption(args, "--height", 720);
+        var widthSpan = ReadIntOption(args, "--width-span", 24);
+        var heightSpan = ReadIntOption(args, "--height-span", 30);
+        var composition = HasOption(args, "--composition");
+        var enforce = HasOption(args, "--enforce");
+        var enforceChromeReference = HasOption(
+            args,
+            "--enforce-chrome-reference");
+        if (seconds <= 0 || warmupSeconds < 0 || frequency <= 0
+            || baseWidth <= 1 || baseHeight <= 1 || widthSpan < 1 || heightSpan < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(args), "Resize probe options are invalid.");
+        }
+
+        BenchmarkApp.EnsureInitialized();
+        NativeWebSceneApi.ConfigureLibraryPath(library);
+        var temporaryDirectory = Path.Combine(
+            Path.GetTempPath(), "webscene-native-resize-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temporaryDirectory);
+        var fixturePath = Path.Combine(temporaryDirectory, "index.html");
+        File.WriteAllText(fixturePath, Fixture);
+        var source = ReadOption(args, "--url") ?? new Uri(fixturePath).AbsoluteUri;
+        var chromeReference = ReadChromeReference(
+            ReadOption(args, "--chrome-reference"),
+            source,
+            frequency,
+            seconds);
+        if (enforceChromeReference && chromeReference is null)
+        {
+            throw new InvalidOperationException(
+                "--enforce-chrome-reference requires --chrome-reference <JSON>.");
+        }
+        var view = new NativeWebSceneView(useCompositionVisual: composition);
+        var window = new Window
+        {
+            Width = baseWidth,
+            Height = baseHeight,
+            Content = view
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        try
+        {
+            Pump(view.LoadAsync(source, library));
+            Dispatcher.UIThread.RunJobs();
+            var surface = (NativeSceneSurface)view.Content!;
+            RunCadence(window, warmupSeconds, frequency, baseWidth, baseHeight, widthSpan, heightSpan);
+            WaitForResizeDrain(view, TimeSpan.FromSeconds(2));
+
+            var baseline = view.CapturePerformanceSnapshot();
+            var submittedBaseline = surface.SubmittedResizes.Length;
+            var publishedBaseline = surface.PublishedScenes.Length;
+            var renderedBaseline = surface.RenderedScenes.Length;
+            var presentationBaseline = surface.PresentationTimestamps.Length;
+            var process = Process.GetCurrentProcess();
+            process.Refresh();
+            var cpuBefore = process.TotalProcessorTime;
+            var measurementStarted = Stopwatch.GetTimestamp();
+            var submitted = RunCadence(
+                window, seconds, frequency, baseWidth, baseHeight, widthSpan, heightSpan);
+            var measurementElapsed = Stopwatch.GetElapsedTime(measurementStarted);
+            WaitForResizeDrain(view, TimeSpan.FromSeconds(3));
+            process.Refresh();
+            var cpu = process.TotalProcessorTime - cpuBefore;
+            var snapshot = view.CapturePerformanceSnapshot();
+            var delta = snapshot.Since(baseline);
+
+            var submissions = surface.SubmittedResizes.Skip(submittedBaseline).ToArray();
+            var publications = surface.PublishedScenes.Skip(publishedBaseline).ToArray();
+            var renders = surface.RenderedScenes.Skip(renderedBaseline).ToArray();
+            var presentations = surface.PresentationTimestamps
+                .Skip(presentationBaseline)
+                .ToArray();
+            var publicationLatencies = MatchLatencies(
+                submissions,
+                publications.Select(static value =>
+                    (value.Timestamp, value.ConsumedInputSequence)).ToArray());
+            var renderLatencies = MatchLatencies(
+                submissions,
+                renders.Select(static value =>
+                    (value.Timestamp, value.ConsumedInputSequence)).ToArray());
+            var publicationToRenderLatencies = MatchSceneLatencies(publications, renders);
+            var renderIntervals = renders
+                .Zip(renders.Skip(1), static (left, right) =>
+                    (right.Timestamp - left.Timestamp) * 1000d / Stopwatch.Frequency)
+                .Where(static value => value >= 0)
+                .ToArray();
+            var presentationIntervals = presentations
+                .Zip(presentations.Skip(1), static (left, right) =>
+                    (right - left) * 1000d / Stopwatch.Frequency)
+                .Where(static value => value >= 0)
+                .ToArray();
+            var renderedFps = delta.RenderedScenes / measurementElapsed.TotalSeconds;
+            var presentationFps = presentations.Length > 1
+                ? (presentations.Length - 1) * 1000d
+                    / ((presentations[^1] - presentations[0]) * 1000d
+                        / Stopwatch.Frequency)
+                : 0;
+            var renderP95 = Percentile(renderLatencies, 0.95);
+            var presentationP95 = Percentile(presentationIntervals, 0.95);
+            var maximumInterval = renderIntervals.Length == 0 ? double.PositiveInfinity : renderIntervals.Max();
+            var compositionTiming = NativeSceneSurface.LastCompositionTiming;
+            var certificationDiagnostics = view.SceneDiagnostics;
+            var passed = renderP95 <= 16.7
+                && renderedFps >= 58
+                && maximumInterval <= 33.4
+                && delta.DroppedInputs == 0;
+            var chromeReferencePassed = chromeReference is null
+                ? (bool?)null
+                : presentationFps >= chromeReference.Value.FramesPerSecond
+                    && presentationP95
+                        <= chromeReference.Value.P95IntervalMilliseconds
+                    && delta.DroppedInputs == 0;
+
+            var json = JsonSerializer.Serialize(
+                new
+                {
+                    schema = "webscene-native-resize-cadence-v1",
+                    sourceKind = ReadOption(args, "--url") is null ? "deterministic-fixture" : "url",
+                    composition,
+                    certificationTelemetryEnabled = !certificationDiagnostics.StartsWith(
+                        "certification telemetry disabled",
+                        StringComparison.Ordinal),
+                    requestedHz = frequency,
+                    warmupSeconds,
+                    requestedSeconds = seconds,
+                    elapsedMilliseconds = measurementElapsed.TotalMilliseconds,
+                    submitted,
+                    acceptedSubmissions = submissions.Length,
+                    appliedPairs = Difference(
+                        snapshot.ResizeFrames.AppliedPairs,
+                        baseline.ResizeFrames.AppliedPairs),
+                    publishedPairs = Difference(
+                        snapshot.ResizeFrames.PublishedPairs,
+                        baseline.ResizeFrames.PublishedPairs),
+                    coalescedPairs = Difference(
+                        snapshot.ResizeFrames.SubmittedPairs - snapshot.ResizeFrames.AppliedPairs,
+                        baseline.ResizeFrames.SubmittedPairs - baseline.ResizeFrames.AppliedPairs),
+                    renderedFrames = delta.RenderedScenes,
+                    presentations = presentations.Length,
+                    renderedFramesPerSecond = renderedFps,
+                    presentationFramesPerSecond = presentationFps,
+                    layoutPasses = delta.LayoutPasses,
+                    layoutPassesPerAppliedResize = delta.LayoutPasses / (double)Math.Max(
+                        1UL,
+                        Difference(snapshot.ResizeFrames.AppliedPairs, baseline.ResizeFrames.AppliedPairs)),
+                    publishedScenes = delta.PublishedScenes,
+                    publicationAttempts = delta.PublicationAttempts,
+                    blockedPublications = delta.BlockedPublications,
+                    fullInvalidations = delta.CompositionFullInvalidations,
+                    unchangedRenderCallbacks = delta.CompositionUnchangedRenderCallbacks,
+                    droppedInputs = delta.DroppedInputs,
+                    processCpuMilliseconds = cpu.TotalMilliseconds,
+                    normalizedProcessCpuPercent =
+                        cpu.TotalMilliseconds / measurementElapsed.TotalMilliseconds * 100d,
+                    lastCompositionMilliseconds = new
+                    {
+                        diffApply = compositionTiming.DiffApplyMilliseconds,
+                        retainedDraw = compositionTiming.RetainedDrawMilliseconds,
+                        skiaSubmit = compositionTiming.SkiaSubmitMilliseconds,
+                        callback = compositionTiming.RenderCallbackMilliseconds
+                    },
+                    lastResizeStageMilliseconds = new
+                    {
+                        outerListeners = snapshot.Engine
+                            .LastResizeOuterListenersNanoseconds / 1_000_000d,
+                        frameListeners = snapshot.Engine
+                            .LastResizeFrameListenersNanoseconds / 1_000_000d,
+                        finalLayout = snapshot.Engine
+                            .LastResizeLayoutNanoseconds / 1_000_000d,
+                        observers = snapshot.Engine
+                            .LastResizeObserversNanoseconds / 1_000_000d,
+                        totalDispatch = snapshot.Engine
+                            .LastResizeDispatchNanoseconds / 1_000_000d,
+                        scenePublication = snapshot.Engine
+                            .LastScenePublicationNanoseconds / 1_000_000d
+                    },
+                    queueMilliseconds = Distribution(
+                        Difference(snapshot.ResizeFrames.TotalQueueNanoseconds, baseline.ResizeFrames.TotalQueueNanoseconds),
+                        Difference(snapshot.ResizeFrames.AppliedPairs, baseline.ResizeFrames.AppliedPairs),
+                        snapshot.ResizeFrames.MaximumQueueNanoseconds),
+                    dispatchMilliseconds = Distribution(
+                        Difference(snapshot.ResizeFrames.TotalDispatchNanoseconds, baseline.ResizeFrames.TotalDispatchNanoseconds),
+                        Difference(snapshot.ResizeFrames.AppliedPairs, baseline.ResizeFrames.AppliedPairs),
+                        snapshot.ResizeFrames.MaximumDispatchNanoseconds),
+                    publicationLatencyMilliseconds = Summary(publicationLatencies),
+                    publicationToRenderLatencyMilliseconds = Summary(
+                        publicationToRenderLatencies),
+                    renderLatencyMilliseconds = Summary(renderLatencies),
+                    renderIntervalMilliseconds = Summary(renderIntervals),
+                    presentationIntervalMilliseconds = Summary(presentationIntervals),
+                    practicalVsyncGate = new
+                    {
+                        maximumP95LatencyMilliseconds = 16.7,
+                        minimumFramesPerSecond = 58,
+                        maximumConsecutiveMissIntervalMilliseconds = 33.4,
+                        passed
+                    },
+                    chromeReferenceComparison = chromeReference is { } reference
+                        ? new
+                        {
+                            identity = reference.Identity,
+                            referenceFramesPerSecond = reference.FramesPerSecond,
+                            nativeFramesPerSecond = presentationFps,
+                            framesPerSecondDelta =
+                                presentationFps - reference.FramesPerSecond,
+                            referenceP95IntervalMilliseconds =
+                                reference.P95IntervalMilliseconds,
+                            nativeP95IntervalMilliseconds = presentationP95,
+                            p95IntervalDeltaMilliseconds =
+                                presentationP95
+                                    - reference.P95IntervalMilliseconds,
+                            passed = chromeReferencePassed
+                        }
+                        : null,
+                    certificationDiagnostics
+                },
+                new JsonSerializerOptions { WriteIndented = true });
+            Console.WriteLine(json);
+            if (ReadOption(args, "--output") is { } output)
+            {
+                var outputPath = Path.GetFullPath(output);
+                Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+                File.WriteAllText(outputPath, json);
+            }
+            return (enforce && !passed)
+                || (enforceChromeReference && chromeReferencePassed != true)
+                ? 1
+                : 0;
+        }
+        finally
+        {
+            Pump(view.DisposeAsync().AsTask());
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            try
+            {
+                Directory.Delete(temporaryDirectory, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    private readonly record struct ChromeReference(
+        string Identity,
+        double FramesPerSecond,
+        double P95IntervalMilliseconds);
+
+    private static ChromeReference? ReadChromeReference(
+        string? path,
+        string source,
+        double requestedHz,
+        double requestedSeconds)
+    {
+        if (path is null)
+        {
+            return null;
+        }
+
+        using var document = JsonDocument.Parse(File.ReadAllText(path));
+        var root = document.RootElement;
+        if (root.GetProperty("schema").GetString()
+            != "webscene-chrome-resize-cadence-v1")
+        {
+            throw new InvalidOperationException(
+                $"Chrome reference '{path}' has an unsupported schema.");
+        }
+        var referenceUrl = root.GetProperty("url").GetString();
+        var referenceHz = root.GetProperty("requestedHz").GetDouble();
+        var referenceSeconds = root.GetProperty("requestedSeconds").GetDouble();
+        if (!string.Equals(referenceUrl, source, StringComparison.Ordinal)
+            || Math.Abs(referenceHz - requestedHz) > 0.001
+            || Math.Abs(referenceSeconds - requestedSeconds) > 0.001)
+        {
+            throw new InvalidOperationException(
+                "Chrome reference URL, cadence, and duration must match the native probe.");
+        }
+        return new ChromeReference(
+            root.GetProperty("identity").GetString() ?? "Chrome",
+            root.GetProperty("renderedFramesPerSecond").GetDouble(),
+            root.GetProperty("animationFrameIntervalMilliseconds")
+                .GetProperty("p95")
+                .GetDouble());
+    }
+
+    private static int RunCadence(
+        Window window,
+        double seconds,
+        double frequency,
+        double baseWidth,
+        double baseHeight,
+        int widthSpan,
+        int heightSpan)
+    {
+        var frameCount = (int)Math.Round(seconds * frequency);
+        var started = Stopwatch.GetTimestamp();
+        for (var index = 0; index < frameCount; index++)
+        {
+            var deadline = started + (long)((index + 1) * Stopwatch.Frequency / frequency);
+            while (Stopwatch.GetTimestamp() < deadline)
+            {
+                Dispatcher.UIThread.RunJobs();
+                var remaining = deadline - Stopwatch.GetTimestamp();
+                if (remaining > Stopwatch.Frequency / 500)
+                {
+                    Thread.Sleep(1);
+                }
+                else
+                {
+                    Thread.SpinWait(32);
+                }
+            }
+            window.Width = baseWidth + index % widthSpan;
+            window.Height = baseHeight + index % heightSpan;
+            Dispatcher.UIThread.RunJobs();
+        }
+        return frameCount;
+    }
+
+    private static void WaitForResizeDrain(
+        NativeWebSceneView view,
+        TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        var stable = 0;
+        var previous = view.CapturePerformanceSnapshot().ResizeFrames.PublishedPairs;
+        while (DateTime.UtcNow < deadline && stable < 5)
+        {
+            Dispatcher.UIThread.RunJobs();
+            Thread.Sleep(5);
+            var current = view.CapturePerformanceSnapshot().ResizeFrames.PublishedPairs;
+            stable = current == previous ? stable + 1 : 0;
+            previous = current;
+        }
+    }
+
+    private static double[] MatchLatencies(
+        NativeResizeSubmissionSample[] submissions,
+        (long Timestamp, ulong ConsumedSequence)[] completions)
+    {
+        var result = new List<double>(submissions.Length);
+        var completionIndex = 0;
+        foreach (var submission in submissions)
+        {
+            while (completionIndex < completions.Length
+                && completions[completionIndex].ConsumedSequence < submission.Sequence)
+            {
+                completionIndex++;
+            }
+            if (completionIndex >= completions.Length)
+            {
+                break;
+            }
+            var elapsed = completions[completionIndex].Timestamp - submission.Timestamp;
+            if (elapsed >= 0)
+            {
+                result.Add(elapsed * 1000d / Stopwatch.Frequency);
+            }
+        }
+        return result.ToArray();
+    }
+
+    private static double[] MatchSceneLatencies(
+        NativeScenePublicationSample[] publications,
+        NativeSceneRenderSample[] renders)
+    {
+        var renderTimestamps = renders
+            .GroupBy(static sample => sample.Revision)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.Min(sample => sample.Timestamp));
+        return publications
+            .Where(publication => renderTimestamps.ContainsKey(publication.Revision))
+            .Select(publication =>
+                (renderTimestamps[publication.Revision] - publication.Timestamp)
+                    * 1000d / Stopwatch.Frequency)
+            .Where(static elapsed => elapsed >= 0)
+            .ToArray();
+    }
+
+    private static object Summary(double[] values)
+        => values.Length == 0
+            ? new { count = 0, average = 0d, p50 = 0d, p95 = 0d, maximum = 0d }
+            : new
+            {
+                count = values.Length,
+                average = values.Average(),
+                p50 = Percentile(values, 0.50),
+                p95 = Percentile(values, 0.95),
+                maximum = values.Max()
+            };
+
+    private static object Distribution(ulong totalNanoseconds, ulong count, ulong maximumNanoseconds)
+        => new
+        {
+            average = count == 0 ? 0 : totalNanoseconds / (double)count / 1_000_000d,
+            maximum = maximumNanoseconds / 1_000_000d
+        };
+
+    private static double Percentile(double[] values, double percentile)
+    {
+        if (values.Length == 0)
+        {
+            return double.PositiveInfinity;
+        }
+        var ordered = values.Order().ToArray();
+        var index = Math.Clamp(
+            (int)Math.Ceiling(percentile * ordered.Length) - 1,
+            0,
+            ordered.Length - 1);
+        return ordered[index];
+    }
+
+    private static ulong Difference(ulong current, ulong baseline)
+        => current >= baseline ? current - baseline : 0;
+
+    private static bool HasOption(IReadOnlyList<string> args, string name)
+        => args.Any(value => string.Equals(value, name, StringComparison.OrdinalIgnoreCase));
+
+    private static string? ReadOption(IReadOnlyList<string> args, string name)
+    {
+        for (var index = 0; index + 1 < args.Count; index++)
+        {
+            if (string.Equals(args[index], name, StringComparison.OrdinalIgnoreCase))
+            {
+                return args[index + 1];
+            }
+        }
+        return null;
+    }
+
+    private static int ReadIntOption(IReadOnlyList<string> args, string name, int fallback)
+        => int.TryParse(ReadOption(args, name), out var value) ? value : fallback;
+
+    private static double ReadDoubleOption(IReadOnlyList<string> args, string name, double fallback)
+        => double.TryParse(
+            ReadOption(args, name),
+            System.Globalization.NumberStyles.Float,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out var value)
+            ? value
+            : fallback;
+
+    private static void Pump(Task task)
+    {
+        while (!task.IsCompleted)
+        {
+            Dispatcher.UIThread.RunJobs();
+            Thread.Sleep(1);
+        }
+        task.GetAwaiter().GetResult();
+    }
+}

--- a/benchmarks/WebScene.NativeEngine.Benchmarks/Program.cs
+++ b/benchmarks/WebScene.NativeEngine.Benchmarks/Program.cs
@@ -20,6 +20,8 @@ if (args.Length > 0 && string.Equals(args[0], "probe", StringComparison.OrdinalI
                 return NativeContextMemoryProbe.Run(probeArgs);
             case "native-lifecycle":
                 return NativeViewLifecycleProbe.Run(probeArgs);
+            case "native-resize-cadence":
+                return NativeResizeCadenceProbe.Run(probeArgs);
             case "native-inspector-disabled-performance":
                 return NativeInspectorDisabledPerformanceProbe.Run(probeArgs);
         }
@@ -28,7 +30,7 @@ if (args.Length > 0 && string.Equals(args[0], "probe", StringComparison.OrdinalI
     Console.Error.WriteLine(
         "Unknown probe. Use one of: generated-realtime-chart, native-interop-race, " +
         "native-runtime-work, native-dom-lookup, native-context-memory, native-lifecycle, " +
-        "native-inspector-disabled-performance.");
+        "native-resize-cadence, native-inspector-disabled-performance.");
     return 2;
 }
 

--- a/experiments/WebScene.NativeEngine.Probe/README.md
+++ b/experiments/WebScene.NativeEngine.Probe/README.md
@@ -107,6 +107,14 @@ surface includes feature-use inventories, scene/canvas diagnostic snapshots,
 CSS and binding profiling maps, V8 CPU profiling, and their hot-path counters
 and timers.
 
+Certification builds also recognize two differential switches:
+
+- `WEBSCENE_DISABLE_INTRINSIC_SIZE_CACHE=1` disables the per-pass intrinsic-size cache.
+- `WEBSCENE_FORCE_LAYOUT_INVALIDATION=1` routes paint-only CSSOM changes through layout.
+
+These switches let profiling and correctness runs compare each optimized path with its
+conservative reference behavior without introducing application-specific branches.
+
 ## Canvas hot-path allocation policy
 
 Canvas commands read only the paint-state groups required by that operation.

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_native_dom.h
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_native_dom.h
@@ -1396,6 +1396,10 @@ public:
         std::vector<char>& string_bytes) const;
 
     uint64_t layout_passes() const noexcept;
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+    uint64_t intrinsic_size_cache_hits() const noexcept;
+    uint64_t intrinsic_size_cache_misses() const noexcept;
+#endif
     size_t node_count() const noexcept;
     allocation_metrics read_allocation_metrics() const noexcept;
     size_t count_tag(const std::string& tag) const noexcept;
@@ -1520,6 +1524,31 @@ private:
         }
     };
 
+    struct intrinsic_size_key final {
+        const dom_node* node{nullptr};
+        bool horizontal{false};
+
+        bool operator==(const intrinsic_size_key&) const = default;
+    };
+
+    struct intrinsic_size_key_hash final {
+        size_t operator()(const intrinsic_size_key& value) const noexcept
+        {
+            auto result = std::hash<const dom_node*>{}(value.node);
+            const auto mix = [&result](size_t next) {
+                result ^= next + 0x9e3779b9U + (result << 6U) + (result >> 2U);
+            };
+            mix(std::hash<bool>{}(value.horizontal));
+            return result;
+        }
+    };
+
+    struct intrinsic_size_cache_entry final {
+        uint64_t generation{0};
+        float available{0};
+        float size{0};
+    };
+
     webscene_text_metrics measure_text(
         std::string_view value,
         const dom_node& node) const;
@@ -1542,6 +1571,10 @@ private:
     float resolve_length(css_length value, float available, float fallback) const;
     static bool is_specified(css_length value);
     float intrinsic_size(
+        const dom_node& node,
+        bool horizontal,
+        float available);
+    float compute_intrinsic_size(
         const dom_node& node,
         bool horizontal,
         float available);
@@ -1605,6 +1638,16 @@ private:
         text_measurement_key,
         webscene_text_metrics,
         text_measurement_key_hash> text_measurement_cache_;
+    std::unique_ptr<std::unordered_map<
+        intrinsic_size_key,
+        intrinsic_size_cache_entry,
+        intrinsic_size_key_hash>> intrinsic_size_cache_;
+    uint64_t intrinsic_size_cache_generation_{0};
+    uint64_t intrinsic_size_cache_next_generation_{0};
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+    uint64_t intrinsic_size_cache_hits_{0};
+    uint64_t intrinsic_size_cache_misses_{0};
+#endif
     bool dirty_{true};
     bool globally_dirty_{true};
     uint64_t scene_generation_{1};

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_native_dom_layout.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_native_dom_layout.inc
@@ -1,5 +1,32 @@
 void native_document::layout(float viewport_width, float viewport_height)
 {
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+    const auto intrinsic_cache_disabled =
+        std::getenv("WEBSCENE_DISABLE_INTRINSIC_SIZE_CACHE") != nullptr;
+#else
+    constexpr auto intrinsic_cache_disabled = false;
+#endif
+    intrinsic_size_cache_generation_ = 0;
+    if (!intrinsic_cache_disabled) {
+        if (intrinsic_size_cache_ == nullptr) {
+            intrinsic_size_cache_ = std::make_unique<std::unordered_map<
+                intrinsic_size_key,
+                intrinsic_size_cache_entry,
+                intrinsic_size_key_hash>>();
+        }
+        // The key is bounded to two axes per stable node. This clear is only a
+        // detached-node lifetime cap, not a viewport-dependent resize cycle.
+        if (intrinsic_size_cache_->size() >= 16'384U) intrinsic_size_cache_->clear();
+        if (intrinsic_size_cache_->empty()) {
+            intrinsic_size_cache_->reserve(
+                std::min<size_t>(nodes_.size() * 2U, 16'384U));
+        }
+        if (++intrinsic_size_cache_next_generation_ == 0) {
+            intrinsic_size_cache_->clear();
+            ++intrinsic_size_cache_next_generation_;
+        }
+        intrinsic_size_cache_generation_ = intrinsic_size_cache_next_generation_;
+    }
     if (shadow_dom_storage_ != nullptr) {
         refresh_shadow_distributions();
         // Nodes omitted by slot distribution must not retain geometry from an
@@ -53,6 +80,7 @@ void native_document::layout(float viewport_width, float viewport_height)
         *body_,
         retained_canvas_seen,
         retained_canvases_remaining);
+    intrinsic_size_cache_generation_ = 0;
     ++layout_passes_;
     dirty_ = false;
     globally_dirty_ = false;
@@ -2703,6 +2731,45 @@ void native_document::layout_children(dom_node& parent)
 }
 
 float native_document::intrinsic_size(
+    const dom_node& node,
+    bool horizontal,
+    float available)
+{
+    // Only nodes owned by this document have stable identities for the whole
+    // layout pass. Pseudo-elements and list markers are represented by
+    // short-lived stack nodes that deliberately reuse their owner's native ID.
+    const auto stable_node = node.id != 0U
+        && node.id <= native_id_index_.size()
+        && native_id_index_[node.id - 1U] == &node;
+    if (intrinsic_size_cache_ == nullptr
+        || intrinsic_size_cache_generation_ == 0
+        || !stable_node) {
+        return compute_intrinsic_size(node, horizontal, available);
+    }
+    const intrinsic_size_key key{&node, horizontal};
+    if (const auto cached = intrinsic_size_cache_->find(key);
+        cached != intrinsic_size_cache_->end()
+        && cached->second.generation == intrinsic_size_cache_generation_
+        && cached->second.available == available) {
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+        ++intrinsic_size_cache_hits_;
+#endif
+        return cached->second.size;
+    }
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+    ++intrinsic_size_cache_misses_;
+#endif
+    const auto result = compute_intrinsic_size(node, horizontal, available);
+    intrinsic_size_cache_->insert_or_assign(
+        key,
+        intrinsic_size_cache_entry{
+            intrinsic_size_cache_generation_,
+            available,
+            result});
+    return result;
+}
+
+float native_document::compute_intrinsic_size(
     const dom_node& node,
     bool horizontal,
     float available)

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_native_dom_metrics.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_native_dom_metrics.inc
@@ -573,6 +573,18 @@ bool native_document::dirty() const noexcept
     return dirty_;
 }
 
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+uint64_t native_document::intrinsic_size_cache_hits() const noexcept
+{
+    return intrinsic_size_cache_hits_;
+}
+
+uint64_t native_document::intrinsic_size_cache_misses() const noexcept
+{
+    return intrinsic_size_cache_misses_;
+}
+#endif
+
 uint64_t native_document::scene_generation() const noexcept
 {
     return scene_generation_;

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime.cpp
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime.cpp
@@ -3978,6 +3978,10 @@ std::string v8_dom_runtime::event_diagnostics() const
     result << ']';
     result << ", layout-client-reuses="
         << impl_->client_geometry_layout_reuse_count;
+    result << ", intrinsic-size-cache-hits="
+        << impl_->document.intrinsic_size_cache_hits();
+    result << ", intrinsic-size-cache-misses="
+        << impl_->document.intrinsic_size_cache_misses();
     if (impl_->profile_bindings) {
         uint64_t total_nanoseconds = 0;
         result << ", resize-bindings=[";

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_dom_core.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_dom_core.inc
@@ -461,6 +461,36 @@
         dom_node& node,
         std::string_view canonical_property_name)
     {
+        // These properties affect painting or interaction, but never box
+        // measurement or flow. Publish the scene without synchronously
+        // traversing layout again.
+        constexpr std::array paint_only_properties{
+            std::string_view{"background"},
+            std::string_view{"background-color"},
+            std::string_view{"border-radius"},
+            std::string_view{"box-shadow"},
+            std::string_view{"color"},
+            std::string_view{"cursor"},
+            std::string_view{"opacity"},
+            std::string_view{"pointer-events"},
+            std::string_view{"transform"},
+            std::string_view{"transform-origin"},
+            std::string_view{"visibility"},
+            std::string_view{"-webkit-font-smoothing"}
+        };
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+        const auto force_layout_invalidation =
+            std::getenv("WEBSCENE_FORCE_LAYOUT_INVALIDATION") != nullptr;
+#else
+        constexpr auto force_layout_invalidation = false;
+#endif
+        if (!force_layout_invalidation && std::find(
+                paint_only_properties.begin(),
+                paint_only_properties.end(),
+                canonical_property_name) != paint_only_properties.end()) {
+            document.mark_scene_changed();
+            return;
+        }
         const auto isolated_out_of_flow_geometry =
             node.style.position == position_mode::absolute
             || node.style.position == position_mode::fixed;

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_lifecycle.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_lifecycle.inc
@@ -697,7 +697,7 @@
             false);
         if (match == nullptr) {
             static const std::unordered_set<std::string> known_web_api_globals{
-                "localStorage", "indexedDB", "fetch", "XMLHttpRequest",
+                "indexedDB", "fetch", "XMLHttpRequest",
                 "Worker", "SharedWorker", "ServiceWorker", "BroadcastChannel",
                 "OffscreenCanvas", "requestIdleCallback", "cancelIdleCallback"};
             if (known_web_api_globals.contains(name)) {

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_animation_cssom_tests.inc
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_animation_cssom_tests.inc
@@ -379,6 +379,58 @@ void test_rotation_keyframes_use_host_clock_and_wrap_continuously(
             + wrapped_quarter_turn);
 }
 
+void test_cssom_paint_invalidation_does_not_force_layout(
+    webscene_engine* engine)
+{
+    execute_and_wait(engine, R"JS(
+        (() => {
+          document.body.innerHTML = '<div id="invalidation" style="height: 40px; width: 80px"></div>';
+          void document.getElementById('invalidation').offsetHeight;
+        })()
+    )JS", "cssom-invalidation-setup.js");
+    webscene_engine_metrics baseline{};
+    webscene_engine_get_metrics(engine, &baseline);
+
+    execute_and_wait(engine, R"JS(
+        (() => {
+          const target = document.getElementById('invalidation');
+          target.style.transform = 'translate(2px, 3px)';
+        })()
+    )JS", "cssom-paint-only-invalidation.js");
+    static_cast<void>(evaluate(
+        engine,
+        "document.getElementById('invalidation').offsetWidth",
+        "cssom-paint-only-geometry-barrier.js"));
+    webscene_engine_metrics after_paint{};
+    webscene_engine_get_metrics(engine, &after_paint);
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+    const auto force_layout_invalidation =
+        std::getenv("WEBSCENE_FORCE_LAYOUT_INVALIDATION") != nullptr;
+#else
+    constexpr auto force_layout_invalidation = false;
+#endif
+    if (!force_layout_invalidation) {
+        require(
+            after_paint.layout_passes == baseline.layout_passes,
+            "paint-only CSSOM transform forced a document layout");
+    }
+
+    execute_and_wait(engine, R"JS(
+        (() => {
+          const target = document.getElementById('invalidation');
+          target.style.height = '41px';
+        })()
+    )JS", "cssom-changed-layout-value.js");
+    const auto changed_height = evaluate(
+        engine,
+        "document.getElementById('invalidation').offsetHeight",
+        "cssom-changed-layout-geometry-barrier.js");
+    require(
+        changed_height == "41",
+        "a changed CSSOM layout declaration did not update synchronous geometry: "
+            + changed_height);
+}
+
 void test_cssom_serializes_resolved_numbers_without_trailing_zeroes(webscene_engine* engine)
 {
     execute(engine, R"JS(

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_tests.cpp
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_tests.cpp
@@ -436,6 +436,7 @@ int main()
     test_pointer_input_precedes_following_render_opportunity();
     test_resize_and_frame_form_one_rendering_opportunity();
     test_unsupported_features_are_reported_at_native_decision_points(engine);
+    test_cssom_paint_invalidation_does_not_force_layout(engine);
     webscene_engine_destroy(engine);
     engine = webscene_engine_create(64);
     require(engine != nullptr, "transition regression engine creation failed");

--- a/scripts/compare-native-resize-cadence.py
+++ b/scripts/compare-native-resize-cadence.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Compare paired native resize-cadence control and candidate samples."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import random
+import statistics
+from typing import Any
+
+
+def read_samples(directory: pathlib.Path, minimum: int) -> list[dict[str, Any]]:
+    paths = sorted(directory.glob("*.json"))
+    if len(paths) < minimum:
+        raise RuntimeError(
+            f"{directory}: expected at least {minimum} JSON samples, found {len(paths)}")
+    samples = [json.loads(path.read_text()) for path in paths]
+    if any(sample.get("schema") != "webscene-native-resize-cadence-v1" for sample in samples):
+        raise RuntimeError(f"{directory}: contains a non-resize-cadence sample")
+    return samples
+
+
+def value_at(sample: dict[str, Any], path: str) -> float:
+    value: Any = sample
+    for part in path.split("."):
+        value = value[part]
+    return float(value)
+
+
+def paired_ratio_interval(
+    control: list[dict[str, Any]],
+    candidate: list[dict[str, Any]],
+    path: str,
+) -> list[float]:
+    controls = [value_at(sample, path) for sample in control]
+    candidates = [value_at(sample, path) for sample in candidate]
+    generator = random.Random(0x52535A45)
+    ratios: list[float] = []
+    for _ in range(10_000):
+        indices = [generator.randrange(len(controls)) for _ in controls]
+        baseline = statistics.median(controls[index] for index in indices)
+        changed = statistics.median(candidates[index] for index in indices)
+        ratios.append(changed / baseline if baseline else 1.0)
+    ratios.sort()
+    return [ratios[249], ratios[9749]]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--control-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--candidate-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    parser.add_argument("--minimum-samples", type=int, default=10)
+    parser.add_argument("--require-material-improvement", action="store_true")
+    parser.add_argument("--require-vsync", action="store_true")
+    args = parser.parse_args()
+
+    control = read_samples(args.control_dir, args.minimum_samples)
+    candidate = read_samples(args.candidate_dir, args.minimum_samples)
+    if len(control) != len(candidate):
+        raise RuntimeError("control and candidate sample counts differ")
+    option_fields = (
+        "sourceKind", "composition", "certificationTelemetryEnabled",
+        "requestedHz", "warmupSeconds",
+        "requestedSeconds", "submitted")
+    for baseline, changed in zip(control, candidate, strict=True):
+        if any(baseline.get(field) != changed.get(field) for field in option_fields):
+            raise RuntimeError("paired control and candidate options differ")
+
+    lower_is_better = (
+        "renderLatencyMilliseconds.p95",
+        "publicationLatencyMilliseconds.p95",
+        "publicationToRenderLatencyMilliseconds.p95",
+        "presentationIntervalMilliseconds.p95",
+        "presentationIntervalMilliseconds.maximum",
+        "dispatchMilliseconds.average",
+        "normalizedProcessCpuPercent",
+        "layoutPassesPerAppliedResize",
+    )
+    higher_is_better = (
+        "renderedFramesPerSecond",
+        "presentationFramesPerSecond",
+    )
+    metrics: dict[str, Any] = {}
+    failures: list[str] = []
+    material = False
+    for path in lower_is_better + higher_is_better:
+        baseline = statistics.median(value_at(sample, path) for sample in control)
+        changed = statistics.median(value_at(sample, path) for sample in candidate)
+        ratio = changed / baseline if baseline else 1.0
+        interval = paired_ratio_interval(control, candidate, path)
+        metrics[path] = {
+            "controlMedian": baseline,
+            "candidateMedian": changed,
+            "ratio": ratio,
+            "pairedBootstrap95RatioInterval": interval,
+        }
+        if path in lower_is_better:
+            if ratio > 1.03 and interval[0] > 1.03:
+                failures.append(f"{path}: statistically supported regression above 3%")
+            if ((path == "normalizedProcessCpuPercent" and ratio <= 0.90)
+                    or (path != "normalizedProcessCpuPercent" and ratio <= 0.95)):
+                material = True
+        else:
+            if ratio < 0.97 and interval[1] < 0.97:
+                failures.append(f"{path}: statistically supported regression above 3%")
+            if ratio >= 1.05:
+                material = True
+
+    if args.require_material_improvement and not material:
+        failures.append("candidate did not meet the material-improvement threshold")
+    vsync_passes = sum(
+        sample["practicalVsyncGate"]["passed"] is True for sample in candidate)
+    if args.require_vsync and vsync_passes != len(candidate):
+        failures.append(
+            f"practical vsync gate passed in {vsync_passes}/{len(candidate)} candidate runs")
+
+    report = {
+        "schema": "webscene-native-resize-comparison-v1",
+        "controlSamples": len(control),
+        "candidateSamples": len(candidate),
+        "materialImprovement": material,
+        "candidateVsyncPasses": vsync_passes,
+        "metrics": metrics,
+        "failures": failures,
+        "passed": not failures,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2) + "\n")
+    print(json.dumps(report, indent=2))
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/profile-chrome-resize-cadence.mjs
+++ b/scripts/profile-chrome-resize-cadence.mjs
@@ -1,0 +1,389 @@
+#!/usr/bin/env node
+
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { CdpClient } from "../tests/WebPlatformSubset/chrome/cdp-client.mjs";
+
+const delay = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+function parseArguments(values) {
+  const options = {
+    url: "https://trading-terminal.tradingview-widget.com/",
+    output: null,
+    seconds: 10,
+    warmupSeconds: 5,
+    hz: 60,
+    width: 1180,
+    height: 720,
+    widthSpan: 24,
+    heightSpan: 30,
+    headless: false
+  };
+  for (let index = 0; index < values.length; index++) {
+    const name = values[index];
+    if (name === "--headless") {
+      options.headless = true;
+      continue;
+    }
+    const value = values[++index];
+    if (!value) throw new Error(`Missing value after '${name}'.`);
+    if (name === "--url") options.url = value;
+    else if (name === "--output") options.output = path.resolve(value);
+    else if (name === "--seconds") options.seconds = Number(value);
+    else if (name === "--warmup-seconds") options.warmupSeconds = Number(value);
+    else if (name === "--hz") options.hz = Number(value);
+    else if (name === "--width") options.width = Number(value);
+    else if (name === "--height") options.height = Number(value);
+    else if (name === "--width-span") options.widthSpan = Number(value);
+    else if (name === "--height-span") options.heightSpan = Number(value);
+    else throw new Error(`Unknown argument '${name}'.`);
+  }
+  if (!options.output) throw new Error("Pass --output <new JSON file>.");
+  for (const name of ["seconds", "hz", "width", "height", "widthSpan", "heightSpan"]) {
+    if (!Number.isFinite(options[name]) || options[name] <= 0) {
+      throw new Error(`--${name.replace(/[A-Z]/g, match => `-${match.toLowerCase()}`)} must be positive.`);
+    }
+  }
+  if (!Number.isFinite(options.warmupSeconds) || options.warmupSeconds < 0) {
+    throw new Error("--warmup-seconds must be non-negative.");
+  }
+  if (existsSync(options.output)) {
+    throw new Error(`Output '${options.output}' already exists; evidence is never overwritten.`);
+  }
+  return options;
+}
+
+function chromeIdentity() {
+  const executable = [
+    process.env.CHROME_BIN,
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+    "/usr/bin/google-chrome",
+    "/usr/bin/chromium"
+  ].filter(Boolean).find(existsSync);
+  if (!executable) throw new Error("Chrome was not found; set CHROME_BIN.");
+  const version = spawnSync(executable, ["--version"], { encoding: "utf8" });
+  if (version.status !== 0) throw new Error(version.stderr || "Could not read Chrome version.");
+  return { executable, version: version.stdout.trim() };
+}
+
+async function launchChrome(identity, headless) {
+  const userDataDirectory = await mkdtemp(path.join(os.tmpdir(), "webscene-resize-chrome-"));
+  const arguments_ = [
+    "--disable-background-networking",
+    "--disable-component-update",
+    "--disable-default-apps",
+    "--disable-extensions",
+    "--disable-features=Translate",
+    "--disable-sync",
+    "--metrics-recording-only",
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--remote-debugging-port=0",
+    `--user-data-dir=${userDataDirectory}`,
+    "about:blank"
+  ];
+  if (headless) arguments_.unshift("--headless=new");
+  const child = spawn(identity.executable, arguments_, {
+    stdio: ["ignore", "ignore", "pipe"]
+  });
+  const endpoint = await new Promise((resolve, reject) => {
+    let stderr = "";
+    const timeout = setTimeout(
+      () => reject(new Error("Timed out waiting for Chrome DevTools.")),
+      20_000);
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", chunk => {
+      stderr += chunk;
+      const match = stderr.match(/DevTools listening on (ws:\/\/[^\s]+)/);
+      if (!match) return;
+      clearTimeout(timeout);
+      resolve(match[1]);
+    });
+    child.once("exit", code => {
+      clearTimeout(timeout);
+      reject(new Error(`Chrome exited before DevTools was ready (${code}).\n${stderr}`));
+    });
+  });
+  const endpointUrl = new URL(endpoint);
+  const origin = `http://${endpointUrl.hostname}:${endpointUrl.port}`;
+  let target = null;
+  for (let attempt = 0; attempt < 100 && !target; attempt++) {
+    try {
+      const targets = await (await fetch(`${origin}/json/list`)).json();
+      target = targets.find(item => item.type === "page" && item.webSocketDebuggerUrl);
+    } catch { /* Target publication can race the endpoint. */ }
+    if (!target) await delay(50);
+  }
+  if (!target) throw new Error("Chrome exposed no debuggable page target.");
+  const client = await CdpClient.connect(target.webSocketDebuggerUrl);
+  await client.send("Page.enable");
+  await client.send("Runtime.enable");
+  await client.send("Performance.enable");
+  return { child, client, targetId: target.id, userDataDirectory };
+}
+
+async function closeChrome(chrome) {
+  try { await chrome.client.send("Browser.close", {}, 2_000); }
+  catch { chrome.child.kill("SIGTERM"); }
+  chrome.client.close();
+  await Promise.race([
+    new Promise(resolve => chrome.child.once("exit", resolve)),
+    delay(2_000).then(() => chrome.child.kill("SIGKILL"))
+  ]);
+  await rm(chrome.userDataDirectory, { recursive: true, force: true });
+}
+
+async function evaluate(client, expression) {
+  const response = await client.send("Runtime.evaluate", {
+    expression,
+    returnByValue: true,
+    awaitPromise: true
+  });
+  if (response.exceptionDetails) {
+    throw new Error(response.exceptionDetails.exception?.description
+      || response.exceptionDetails.text
+      || "Chrome evaluation failed.");
+  }
+  return response.result.value;
+}
+
+async function waitForDocument(client, timeoutMilliseconds) {
+  const deadline = Date.now() + timeoutMilliseconds;
+  while (Date.now() < deadline) {
+    try {
+      const state = await evaluate(client, `({
+        ready: document.readyState,
+        canvases: document.querySelectorAll('canvas').length,
+        frames: document.querySelectorAll('iframe').length
+      })`);
+      if (state?.ready === "complete") return state;
+    } catch { /* Navigation replaces the execution context. */ }
+    await delay(100);
+  }
+  throw new Error("Chrome document did not finish loading.");
+}
+
+function metricsMap(response) {
+  return Object.fromEntries(response.metrics.map(metric => [metric.name, metric.value]));
+}
+
+function metricDelta(before, after, name) {
+  return (after[name] ?? 0) - (before[name] ?? 0);
+}
+
+function summary(values) {
+  if (!values.length) return { count: 0, average: 0, p50: 0, p95: 0, maximum: 0 };
+  const ordered = [...values].sort((left, right) => left - right);
+  const percentile = proportion => ordered[Math.min(
+    ordered.length - 1,
+    Math.max(0, Math.ceil(ordered.length * proportion) - 1))];
+  return {
+    count: ordered.length,
+    average: ordered.reduce((total, value) => total + value, 0) / ordered.length,
+    p50: percentile(0.5),
+    p95: percentile(0.95),
+    maximum: ordered.at(-1)
+  };
+}
+
+function traceSummary(events) {
+  const complete = events.filter(event => event.ph === "X" && Number.isFinite(event.dur));
+  const totals = new Map();
+  for (const event of complete) {
+    const value = totals.get(event.name) ?? { count: 0, microseconds: 0 };
+    value.count++;
+    value.microseconds += event.dur;
+    totals.set(event.name, value);
+  }
+  const selectedNames = [
+    "RunTask", "FunctionCall", "EventDispatch", "UpdateLayoutTree", "Layout",
+    "PrePaint", "Paint", "Commit", "CompositeLayers", "DrawFrame", "GPUTask"
+  ];
+  const selected = Object.fromEntries(selectedNames.map(name => {
+    const value = totals.get(name) ?? { count: 0, microseconds: 0 };
+    return [name, { count: value.count, totalMilliseconds: value.microseconds / 1000 }];
+  }));
+  const top = [...totals.entries()]
+    .sort((left, right) => right[1].microseconds - left[1].microseconds)
+    .slice(0, 20)
+    .map(([name, value]) => ({
+      name,
+      count: value.count,
+      totalMilliseconds: value.microseconds / 1000
+    }));
+  const counts = new Map();
+  for (const event of events) counts.set(event.name, (counts.get(event.name) ?? 0) + 1);
+  const presentation = [...counts.entries()]
+    .filter(([name]) => /(draw|swap|present|display.*frame|submit.*frame)/i.test(name))
+    .sort((left, right) => right[1] - left[1])
+    .slice(0, 40)
+    .map(([name, count]) => ({
+      name,
+      count,
+      totalMilliseconds: (totals.get(name)?.microseconds ?? 0) / 1000
+    }));
+  return { selected, top, presentation };
+}
+
+async function driveResizeCadence(client, windowId, options) {
+  const frames = Math.round(options.seconds * options.hz);
+  const started = performance.now();
+  for (let index = 0; index < frames; index++) {
+    const widthOffset = index % (options.widthSpan * 2);
+    const heightOffset = index % (options.heightSpan * 2);
+    const width = Math.round(options.width + (widthOffset < options.widthSpan
+      ? widthOffset : options.widthSpan * 2 - widthOffset));
+    const height = Math.round(options.height + (heightOffset < options.heightSpan
+      ? heightOffset : options.heightSpan * 2 - heightOffset));
+    await client.send("Browser.setWindowBounds", {
+      windowId,
+      bounds: { width, height }
+    });
+    const deadline = started + (index + 1) * 1000 / options.hz;
+    const remaining = deadline - performance.now();
+    if (remaining > 1) await delay(remaining);
+  }
+  return { submitted: frames, elapsedMilliseconds: performance.now() - started };
+}
+
+const options = parseArguments(process.argv.slice(2));
+const identity = chromeIdentity();
+const chrome = await launchChrome(identity, options.headless);
+const traceEvents = [];
+let traceComplete;
+const traceCompleted = new Promise(resolve => { traceComplete = resolve; });
+chrome.client.on("Tracing.dataCollected", event => traceEvents.push(...event.value));
+chrome.client.on("Tracing.tracingComplete", () => traceComplete());
+
+try {
+  const { windowId } = await chrome.client.send("Browser.getWindowForTarget", {
+    targetId: chrome.targetId
+  });
+  await chrome.client.send("Browser.setWindowBounds", {
+    windowId,
+    bounds: { windowState: "normal" }
+  });
+  await chrome.client.send("Browser.setWindowBounds", {
+    windowId,
+    bounds: { width: Math.round(options.width), height: Math.round(options.height) }
+  });
+  await chrome.client.send("Page.navigate", { url: options.url }, 60_000);
+  const loadedState = await waitForDocument(chrome.client, 30_000);
+  await delay(options.warmupSeconds * 1000);
+
+  await evaluate(chrome.client, `(() => {
+    const state = {
+      running: true,
+      started: performance.now(),
+      animationFrames: [],
+      resizeEvents: [],
+      resizeToAnimationFrame: [],
+      longTasks: []
+    };
+    const onResize = () => {
+      const observed = performance.now();
+      state.resizeEvents.push({ timestamp: observed, width: innerWidth, height: innerHeight });
+      requestAnimationFrame(() => state.resizeToAnimationFrame.push(performance.now() - observed));
+    };
+    addEventListener('resize', onResize);
+    const observer = typeof PerformanceObserver === 'function'
+      ? new PerformanceObserver(list => {
+          for (const entry of list.getEntries()) {
+            state.longTasks.push({ startTime: entry.startTime, duration: entry.duration });
+          }
+        })
+      : null;
+    try { observer?.observe({ type: 'longtask', buffered: false }); } catch {}
+    const frame = timestamp => {
+      if (!state.running) return;
+      state.animationFrames.push(timestamp);
+      requestAnimationFrame(frame);
+    };
+    requestAnimationFrame(frame);
+    globalThis.__webSceneChromeResize = state;
+    globalThis.__webSceneStopChromeResize = () => {
+      state.running = false;
+      state.finished = performance.now();
+      removeEventListener('resize', onResize);
+      observer?.disconnect();
+      return state;
+    };
+  })()`);
+  const beforeMetrics = metricsMap(await chrome.client.send("Performance.getMetrics"));
+  await chrome.client.send("Tracing.start", {
+    categories: [
+      "devtools.timeline",
+      "disabled-by-default-devtools.timeline",
+      "disabled-by-default-devtools.timeline.frame",
+      "benchmark",
+      "blink",
+      "cc",
+      "gpu",
+      "viz",
+      "disabled-by-default-viz",
+      "disabled-by-default-gpu.service"
+    ].join(","),
+    options: "sampling-frequency=10000",
+    transferMode: "ReportEvents"
+  });
+  const cadence = await driveResizeCadence(chrome.client, windowId, options);
+  await delay(500);
+  const pageState = await evaluate(
+    chrome.client,
+    "globalThis.__webSceneStopChromeResize()" );
+  const afterMetrics = metricsMap(await chrome.client.send("Performance.getMetrics"));
+  await chrome.client.send("Tracing.end");
+  await Promise.race([
+    traceCompleted,
+    delay(20_000).then(() => { throw new Error("Chrome trace did not complete."); })
+  ]);
+
+  const frameIntervals = pageState.animationFrames
+    .slice(1)
+    .map((value, index) => value - pageState.animationFrames[index]);
+  const longTaskDurations = pageState.longTasks.map(task => task.duration);
+  const renderedFramesPerSecond = frameIntervals.length > 0
+    ? frameIntervals.length * 1000
+      / (pageState.animationFrames.at(-1) - pageState.animationFrames[0])
+    : 0;
+  const trace = traceSummary(traceEvents);
+  const result = {
+    schema: "webscene-chrome-resize-cadence-v1",
+    engine: "chrome",
+    identity: identity.version,
+    url: options.url,
+    headless: options.headless,
+    requestedHz: options.hz,
+    warmupSeconds: options.warmupSeconds,
+    requestedSeconds: options.seconds,
+    submitted: cadence.submitted,
+    elapsedMilliseconds: cadence.elapsedMilliseconds,
+    loadedState,
+    resizeEvents: pageState.resizeEvents.length,
+    animationFrames: pageState.animationFrames.length,
+    renderedFramesPerSecond,
+    animationFrameIntervalMilliseconds: summary(frameIntervals),
+    resizeToAnimationFrameMilliseconds: summary(
+      pageState.resizeToAnimationFrame.filter(value => value >= 0)),
+    longTaskMilliseconds: summary(longTaskDurations),
+    performanceMetrics: {
+      taskMilliseconds: metricDelta(beforeMetrics, afterMetrics, "TaskDuration") * 1000,
+      scriptMilliseconds: metricDelta(beforeMetrics, afterMetrics, "ScriptDuration") * 1000,
+      layoutMilliseconds: metricDelta(beforeMetrics, afterMetrics, "LayoutDuration") * 1000,
+      styleMilliseconds: metricDelta(beforeMetrics, afterMetrics, "RecalcStyleDuration") * 1000,
+      layoutCount: metricDelta(beforeMetrics, afterMetrics, "LayoutCount"),
+      styleCount: metricDelta(beforeMetrics, afterMetrics, "RecalcStyleCount")
+    },
+    trace
+  };
+  await mkdir(path.dirname(options.output), { recursive: true });
+  await writeFile(options.output, JSON.stringify(result, null, 2) + "\n");
+  process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+} finally {
+  await closeChrome(chrome);
+}

--- a/src/WebScene.Backend.Avalonia/NativeCanvasSceneRenderer.cs
+++ b/src/WebScene.Backend.Avalonia/NativeCanvasSceneRenderer.cs
@@ -154,10 +154,11 @@ internal sealed unsafe class NativeCanvasSceneRenderer
         {
             if ((header.Flags & SceneDomReplacement) != 0)
             {
+                var compiledDom = CompileDom(view);
                 s_domBackdropPicture?.Dispose();
                 s_domOverlayPicture?.Dispose();
-                s_domBackdropPicture = CompileDom(view, foreground: false);
-                s_domOverlayPicture = CompileDom(view, foreground: true);
+                s_domBackdropPicture = compiledDom.Backdrop;
+                s_domOverlayPicture = compiledDom.Overlay;
                 s_domCommandCount = header.CommandCount;
             }
 
@@ -256,14 +257,17 @@ internal sealed unsafe class NativeCanvasSceneRenderer
             && layer.StringOffset <= view->StringCount
             && layer.StringCount <= view->StringCount - layer.StringOffset;
 
-    private SKPicture CompileDom(NativeSceneView* view, bool foreground)
+    private (SKPicture Backdrop, SKPicture Overlay) CompileDom(NativeSceneView* view)
     {
-        using var recorder = new SKPictureRecorder();
-        var canvas = recorder.BeginRecording(new SKRect(
+        using var backdropRecorder = new SKPictureRecorder();
+        using var overlayRecorder = new SKPictureRecorder();
+        var recordingBounds = new SKRect(
             0,
             0,
             Math.Max(1, view->Header.ViewportWidth),
-            Math.Max(1, view->Header.ViewportHeight)));
+            Math.Max(1, view->Header.ViewportHeight));
+        var backdrop = backdropRecorder.BeginRecording(recordingBounds);
+        var overlay = overlayRecorder.BeginRecording(recordingBounds);
         var commands = new ReadOnlySpan<SceneCommand>(
             view->Commands,
             checked((int)view->Header.CommandCount));
@@ -290,74 +294,80 @@ internal sealed unsafe class NativeCanvasSceneRenderer
                             255,
                             255,
                             (byte)(command.Rgba & 0xff));
-                        canvas.SaveLayer(opacity);
+                        backdrop.SaveLayer(opacity);
+                        overlay.SaveLayer(opacity);
                         break;
                     case 31:
-                        canvas.Restore();
+                        backdrop.Restore();
+                        overlay.Restore();
                         break;
                     case 15:
-                        canvas.Save();
-                        canvas.Translate(command.X, command.Y);
-                        canvas.Scale(command.Width, command.Height);
-                        canvas.Translate(-command.X, -command.Y);
+                        ApplyScale(backdrop, command);
+                        ApplyScale(overlay, command);
                         break;
                     case 16:
-                        canvas.Restore();
+                        backdrop.Restore();
+                        overlay.Restore();
                         break;
                     case 19:
-                        canvas.Save();
-                        canvas.Translate(command.X, command.Y);
-                        canvas.RotateDegrees(command.StrokeWidth);
-                        canvas.Translate(-command.X, -command.Y);
+                        ApplyRotation(backdrop, command);
+                        ApplyRotation(overlay, command);
                         break;
                     case 20:
-                        canvas.Restore();
+                        backdrop.Restore();
+                        overlay.Restore();
                         break;
-                    case 17 when !foreground:
-                    case 18 when foreground:
+                    case 17:
                         NativeSceneDrawOperation.RectCommandCount++;
                         DrawDomShadow(
-                            canvas,
+                            backdrop,
                             command,
                             ResolveDomCornerRadii(commands, commandIndex));
                         break;
-                    case 1 when !foreground:
+                    case 18:
+                        NativeSceneDrawOperation.RectCommandCount++;
+                        DrawDomShadow(
+                            overlay,
+                            command,
+                            ResolveDomCornerRadii(commands, commandIndex));
+                        break;
+                    case 1:
                         NativeSceneDrawOperation.RectCommandCount++;
                         fill.IsAntialias = false;
                         fill.Color = Rgba(command.Rgba);
-                        canvas.DrawRect(command.X, command.Y, command.Width, command.Height, fill);
+                        backdrop.DrawRect(command.X, command.Y, command.Width, command.Height, fill);
                         break;
-                    case 2 when !foreground:
+                    case 2:
                         NativeSceneDrawOperation.LineCommandCount++;
                         stroke.IsAntialias = true;
                         stroke.Color = Rgba(command.Rgba);
                         stroke.StrokeWidth = Math.Max(0.1f, command.Flags / 100f);
-                        canvas.DrawLine(command.X, command.Y, command.Width, command.Height, stroke);
+                        backdrop.DrawLine(command.X, command.Y, command.Width, command.Height, stroke);
                         break;
-                    case 3 when foreground:
+                    case 3:
                         NativeSceneDrawOperation.TextCommandCount++;
-                        DrawDomText(canvas, view, command, textPaint, textShapers);
+                        DrawDomText(overlay, view, command, textPaint, textShapers);
                         break;
-                    case 4 when foreground:
-                    case 5 when foreground:
+                    case 4:
+                    case 5:
                         NativeSceneDrawOperation.SvgCommandCount++;
-                        DrawDomSvgPath(canvas, view, command, command.Kind == 5);
+                        DrawDomSvgPath(overlay, view, command, command.Kind == 5);
                         break;
-                    case 6 when foreground:
+                    case 6:
                         NativeSceneDrawOperation.SvgCommandCount++;
-                        DrawDomSvg(canvas, view, command);
+                        DrawDomSvg(overlay, view, command);
                         break;
-                    case 7 when !foreground:
+                    case 7:
                         NativeSceneDrawOperation.RectCommandCount++;
                         fill.IsAntialias = true;
                         fill.Color = Rgba(command.Rgba);
                         DrawDomRoundedRect(
-                            canvas,
+                            backdrop,
                             command,
                             fill,
                             ResolveDomCornerRadii(commands, commandIndex));
                         break;
-                    case 8 when !foreground:
+                    case 8:
                         NativeSceneDrawOperation.RectCommandCount++;
                         stroke.IsAntialias = true;
                         stroke.Color = Rgba(command.Rgba);
@@ -367,28 +377,28 @@ internal sealed unsafe class NativeCanvasSceneRenderer
                                 ? command.StrokeWidth
                                 : (command.Flags & 0xffff) / 100f);
                         DrawDomRoundedBorder(
-                            canvas,
+                            backdrop,
                             command,
                             stroke,
                             ResolveDomCornerRadii(commands, commandIndex));
                         break;
-                    case 9 when foreground:
+                    case 9:
                         NativeSceneDrawOperation.RectCommandCount++;
                         fill.IsAntialias = false;
                         fill.Color = Rgba(command.Rgba);
-                        canvas.DrawRect(command.X, command.Y, command.Width, command.Height, fill);
+                        overlay.DrawRect(command.X, command.Y, command.Width, command.Height, fill);
                         break;
-                    case 10 when foreground:
+                    case 10:
                         NativeSceneDrawOperation.RectCommandCount++;
                         fill.IsAntialias = true;
                         fill.Color = Rgba(command.Rgba);
                         DrawDomRoundedRect(
-                            canvas,
+                            overlay,
                             command,
                             fill,
                             ResolveDomCornerRadii(commands, commandIndex));
                         break;
-                    case 11 when foreground:
+                    case 11:
                         NativeSceneDrawOperation.RectCommandCount++;
                         stroke.IsAntialias = true;
                         stroke.Color = Rgba(command.Rgba);
@@ -398,27 +408,33 @@ internal sealed unsafe class NativeCanvasSceneRenderer
                                 ? command.StrokeWidth
                                 : (command.Flags & 0xffff) / 100f);
                         DrawDomRoundedBorder(
-                            canvas,
+                            overlay,
                             command,
                             stroke,
                             ResolveDomCornerRadii(commands, commandIndex));
                         break;
-                    case 14 when foreground:
+                    case 14:
                         NativeSceneDrawOperation.LineCommandCount++;
                         stroke.IsAntialias = true;
                         stroke.Color = Rgba(command.Rgba);
                         stroke.StrokeWidth = Math.Max(0.1f, command.Flags / 100f);
-                        canvas.DrawLine(command.X, command.Y, command.Width, command.Height, stroke);
+                        overlay.DrawLine(command.X, command.Y, command.Width, command.Height, stroke);
                         break;
                     case 12:
-                        canvas.Save();
+                        backdrop.Save();
+                        overlay.Save();
                         ClipDomRoundedRect(
-                            canvas,
+                            backdrop,
+                            command,
+                            ResolveDomCornerRadii(commands, commandIndex));
+                        ClipDomRoundedRect(
+                            overlay,
                             command,
                             ResolveDomCornerRadii(commands, commandIndex));
                         break;
                     case 13:
-                        canvas.Restore();
+                        backdrop.Restore();
+                        overlay.Restore();
                         break;
                 }
             }
@@ -430,7 +446,23 @@ internal sealed unsafe class NativeCanvasSceneRenderer
                 shaper.Dispose();
             }
         }
-        return recorder.EndRecording();
+        return (backdropRecorder.EndRecording(), overlayRecorder.EndRecording());
+    }
+
+    private static void ApplyScale(SKCanvas canvas, in SceneCommand command)
+    {
+        canvas.Save();
+        canvas.Translate(command.X, command.Y);
+        canvas.Scale(command.Width, command.Height);
+        canvas.Translate(-command.X, -command.Y);
+    }
+
+    private static void ApplyRotation(SKCanvas canvas, in SceneCommand command)
+    {
+        canvas.Save();
+        canvas.Translate(command.X, command.Y);
+        canvas.RotateDegrees(command.StrokeWidth);
+        canvas.Translate(-command.X, -command.Y);
     }
 
     internal readonly record struct DomCornerRadii(

--- a/src/WebScene.Backend.Avalonia/NativeSceneComposition.cs
+++ b/src/WebScene.Backend.Avalonia/NativeSceneComposition.cs
@@ -103,6 +103,12 @@ internal sealed class NativeSceneUiWakeGate
         => Volatile.Write(ref _pending, 0);
 }
 
+internal enum NativeSceneUiWakePriority
+{
+    Normal,
+    Immediate
+}
+
 internal static class NativeScenePublicationWakePolicy
 {
     public static bool RequiresUiWake(
@@ -110,10 +116,10 @@ internal static class NativeScenePublicationWakePolicy
         long renderedSceneCount)
         => matchingResizePublication || renderedSceneCount == 0;
 
-    public static DispatcherPriority Priority(bool matchingResizePublication)
+    public static NativeSceneUiWakePriority Priority(bool matchingResizePublication)
         => matchingResizePublication
-            ? DispatcherPriority.Send
-            : DispatcherPriority.Normal;
+            ? NativeSceneUiWakePriority.Immediate
+            : NativeSceneUiWakePriority.Normal;
 }
 
 public readonly record struct NativeScenePublished(

--- a/src/WebScene.Backend.Avalonia/NativeSceneComposition.cs
+++ b/src/WebScene.Backend.Avalonia/NativeSceneComposition.cs
@@ -109,6 +109,11 @@ internal static class NativeScenePublicationWakePolicy
         bool matchingResizePublication,
         long renderedSceneCount)
         => matchingResizePublication || renderedSceneCount == 0;
+
+    public static DispatcherPriority Priority(bool matchingResizePublication)
+        => matchingResizePublication
+            ? DispatcherPriority.Send
+            : DispatcherPriority.Normal;
 }
 
 public readonly record struct NativeScenePublished(
@@ -772,6 +777,7 @@ internal sealed unsafe class NativeSceneCompositionHandler
             scale,
             _renderer.PresenterDeviceScaleFactor);
         skiaSubmitTicks = Stopwatch.GetTimestamp() - skiaStarted;
+        _renderObserver.RecordPresented();
 
         if (_hasPendingRenderMetrics)
         {

--- a/src/WebScene.Backend.Avalonia/NativeSceneRuntime.cs
+++ b/src/WebScene.Backend.Avalonia/NativeSceneRuntime.cs
@@ -64,6 +64,7 @@ internal sealed class NativeSceneRenderObserver
     private readonly object _viewportGate = new();
     private readonly List<int> _renderedViewportHeights = [];
     private readonly Queue<NativeSceneRenderSample> _renderedScenes = new(4096);
+    private readonly Queue<long> _presentations = new(4096);
     private long _renderedSceneCount;
     private long _firstRenderedSceneTimestamp;
     private long _firstReadySceneTimestamp;
@@ -108,6 +109,29 @@ internal sealed class NativeSceneRenderObserver
             {
                 return _renderedScenes.ToArray();
             }
+        }
+    }
+
+    public long[] Presentations
+    {
+        get
+        {
+            lock (_viewportGate)
+            {
+                return _presentations.ToArray();
+            }
+        }
+    }
+
+    public void RecordPresented()
+    {
+        lock (_viewportGate)
+        {
+            if (_presentations.Count == 4096)
+            {
+                _presentations.Dequeue();
+            }
+            _presentations.Enqueue(Stopwatch.GetTimestamp());
         }
     }
 

--- a/src/WebScene.Backend.Avalonia/NativeSceneSurface.cs
+++ b/src/WebScene.Backend.Avalonia/NativeSceneSurface.cs
@@ -347,6 +347,9 @@ public sealed class NativeSceneSurface : Control, INativeWebSceneRenderDiagnosti
     public NativeSceneRenderSample[] RenderedScenes
         => _renderObserver.RenderedScenes;
 
+    public long[] PresentationTimestamps
+        => _renderObserver.Presentations;
+
     public NativeScenePublicationSample[] PublishedScenes
     {
         get
@@ -525,13 +528,15 @@ public sealed class NativeSceneSurface : Control, INativeWebSceneRenderDiagnosti
                 DispatcherPriority.Input);
         }
 
-        NotifyResizePublicationIfReady(scene);
+        var matchingResizePublication = NotifyResizePublicationIfReady(scene);
         if (Volatile.Read(ref _compositionProjectionActive) != 0)
         {
             // Projection is demand-driven. A publication must wake an idle
             // compositor, but the gate still coalesces any producer burst into
             // one UI-to-compositor message.
-            ScheduleCompositionUiWake();
+            ScheduleCompositionUiWake(
+                NativeScenePublicationWakePolicy.Priority(
+                    matchingResizePublication));
             return;
         }
 
@@ -579,6 +584,9 @@ public sealed class NativeSceneSurface : Control, INativeWebSceneRenderDiagnosti
     }
 
     private void ScheduleCompositionUiWake()
+        => ScheduleCompositionUiWake(DispatcherPriority.Normal);
+
+    private void ScheduleCompositionUiWake(DispatcherPriority priority)
     {
         if (!_compositionUiWakeGate.TrySchedule())
         {
@@ -621,7 +629,7 @@ public sealed class NativeSceneSurface : Control, INativeWebSceneRenderDiagnosti
                     }
                 }
             },
-            DispatcherPriority.Send);
+            priority);
     }
 
     private void ApplyCursorKind(int cursorKind)

--- a/src/WebScene.Backend.Avalonia/NativeSceneSurface.cs
+++ b/src/WebScene.Backend.Avalonia/NativeSceneSurface.cs
@@ -536,7 +536,9 @@ public sealed class NativeSceneSurface : Control, INativeWebSceneRenderDiagnosti
             // one UI-to-compositor message.
             ScheduleCompositionUiWake(
                 NativeScenePublicationWakePolicy.Priority(
-                    matchingResizePublication));
+                    matchingResizePublication) == NativeSceneUiWakePriority.Immediate
+                    ? DispatcherPriority.Send
+                    : DispatcherPriority.Normal);
             return;
         }
 

--- a/tests/WebScene.Backend.Avalonia.Tests/NativeScenePublicationMailboxTests.cs
+++ b/tests/WebScene.Backend.Avalonia.Tests/NativeScenePublicationMailboxTests.cs
@@ -1,5 +1,4 @@
 using WebScene.Backends.Avalonia.Native;
-using Avalonia.Threading;
 using Xunit;
 
 namespace WebScene.Backend.Avalonia.Tests;
@@ -85,11 +84,11 @@ public sealed class NativeScenePublicationMailboxTests
     public void MatchingResizePublicationUsesImmediateUiWakePriority()
     {
         Assert.Equal(
-            DispatcherPriority.Send,
+            NativeSceneUiWakePriority.Immediate,
             NativeScenePublicationWakePolicy.Priority(
                 matchingResizePublication: true));
         Assert.Equal(
-            DispatcherPriority.Normal,
+            NativeSceneUiWakePriority.Normal,
             NativeScenePublicationWakePolicy.Priority(
                 matchingResizePublication: false));
     }

--- a/tests/WebScene.Backend.Avalonia.Tests/NativeScenePublicationMailboxTests.cs
+++ b/tests/WebScene.Backend.Avalonia.Tests/NativeScenePublicationMailboxTests.cs
@@ -1,4 +1,5 @@
 using WebScene.Backends.Avalonia.Native;
+using Avalonia.Threading;
 using Xunit;
 
 namespace WebScene.Backend.Avalonia.Tests;
@@ -78,5 +79,18 @@ public sealed class NativeScenePublicationMailboxTests
             NativeScenePublicationWakePolicy.RequiresUiWake(
                 matchingResizePublication,
                 renderedSceneCount));
+    }
+
+    [Fact]
+    public void MatchingResizePublicationUsesImmediateUiWakePriority()
+    {
+        Assert.Equal(
+            DispatcherPriority.Send,
+            NativeScenePublicationWakePolicy.Priority(
+                matchingResizePublication: true));
+        Assert.Equal(
+            DispatcherPriority.Normal,
+            NativeScenePublicationWakePolicy.Priority(
+                matchingResizePublication: false));
     }
 }


### PR DESCRIPTION
## Summary

- add deterministic native and headed-Chrome resize cadence profilers with paired statistical comparison and an exact Chrome-reference gate
- cache intrinsic measurements per layout pass and avoid full layout invalidation for paint-only CSSOM changes
- compile DOM backdrop/overlay pictures in one traversal and prioritize compositor wakes for matching resize publications
- record real presentation timestamps and resize-stage diagnostics

## TradingView comparison

Matched 3-second, 60 Hz requested resize runs against Chrome 151:

- Chrome: 30.00 presented fps, 34.00 ms p95 interval
- Native: 30.86 presented fps, 35.23 ms p95 interval

Native exceeds Chrome throughput but remains 1.23 ms slower at p95, so the strict equal-or-better reference gate intentionally remains failing.

## Testing

- `dotnet test tests/WebScene.Backend.Avalonia.Tests/WebScene.Backend.Avalonia.Tests.csproj --no-restore` — 106/106 passed on net8.0 and net10.0
- certification V8 native engine build and test suite passed
- non-certification V8 native engine build and test suite passed
- HTML, CSS, and selector parser suites passed
- Node syntax and Python comparator smoke checks passed
- `git diff --check` passed