### PR TITLE
Improve iframe preparation and cooperative hydration

### DIFF
--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime.cpp
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime.cpp
@@ -3785,7 +3785,7 @@ std::string v8_dom_runtime::diagnostics()
         description << impl_->loaded_resource_names[index];
     }
     description << "] | resource-memory-hits="
-        << impl_->resource_cache_memory_hit_count
+        << impl_->resource_cache_memory_hit_count.load(std::memory_order_relaxed)
         << ", detached-dom={pending-roots=" << impl_->detached_dom_roots.size()
         << ",pending-nodes=" << impl_->detached_nodes_since_gc
         << ",released=" << impl_->released_detached_dom_nodes << '}';
@@ -3847,6 +3847,16 @@ std::string v8_dom_runtime::diagnostics()
         };
         description << ", startup-profile={hydrate="
             << format(impl_->startup_frame_hydrate)
+            << ",frame-prepare=" << format(impl_->startup_frame_prepare)
+            << ",frame-prepare-wait=" << format(impl_->startup_frame_prepare_wait)
+            << ",frame-prepare-lead=" << std::fixed << std::setprecision(3)
+            << impl_->startup_frame_prepare_lead_nanoseconds / 1'000'000.0
+            << "ms"
+            << ",frame-slices=" << impl_->startup_frame_hydration_slices
+            << ",frame-yields=" << impl_->startup_frame_hydration_yields
+            << ",frame-max-slice=" << std::fixed << std::setprecision(3)
+            << impl_->startup_frame_hydration_max_slice_nanoseconds / 1'000'000.0
+            << "ms"
             << ",io=" << format(impl_->startup_resource_read)
             << ",css-parse=" << format(impl_->startup_css_parse)
             << ",css-apply=" << format(impl_->startup_css_apply)
@@ -3861,6 +3871,8 @@ std::string v8_dom_runtime::diagnostics()
             << ",css-rules=" << impl_->css_rules.size()
             << ",css-unindexed=" << impl_->unindexed_css_rules.size()
             << ",script=" << format(impl_->startup_script_execute)
+            << ",script-compile=" << format(impl_->startup_script_compile)
+            << ",script-run=" << format(impl_->startup_script_run)
             << ",layout=" << format(impl_->startup_layout)
             << ",resources=" << impl_->startup_connected_resources
             << ",raf=" << impl_->startup_raf_executed << '/'
@@ -4233,32 +4245,32 @@ uint64_t v8_dom_runtime::shared_isolate_peak_contexts() const noexcept
 
 uint64_t v8_dom_runtime::resource_cache_requests() const noexcept
 {
-    return impl_->resource_cache_request_count;
+    return impl_->resource_cache_request_count.load(std::memory_order_relaxed);
 }
 
 uint64_t v8_dom_runtime::resource_cache_hits() const noexcept
 {
-    return impl_->resource_cache_hit_count;
+    return impl_->resource_cache_hit_count.load(std::memory_order_relaxed);
 }
 
 uint64_t v8_dom_runtime::resource_cache_misses() const noexcept
 {
-    return impl_->resource_cache_miss_count;
+    return impl_->resource_cache_miss_count.load(std::memory_order_relaxed);
 }
 
 uint64_t v8_dom_runtime::resource_cache_rejections() const noexcept
 {
-    return impl_->resource_cache_rejection_count;
+    return impl_->resource_cache_rejection_count.load(std::memory_order_relaxed);
 }
 
 uint64_t v8_dom_runtime::resource_cache_bytes_read() const noexcept
 {
-    return impl_->resource_cache_bytes_read_count;
+    return impl_->resource_cache_bytes_read_count.load(std::memory_order_relaxed);
 }
 
 uint64_t v8_dom_runtime::resource_cache_bytes_written() const noexcept
 {
-    return impl_->resource_cache_bytes_written_count;
+    return impl_->resource_cache_bytes_written_count.load(std::memory_order_relaxed);
 }
 
 uint64_t v8_dom_runtime::input_events_dispatched() const noexcept
@@ -4490,6 +4502,12 @@ v8_dom_runtime::memory_metrics v8_dom_runtime::read_memory_metrics() const noexc
     result.native_css_rule_count = impl_->css_rules.size();
     result.native_css_rule_storage_bytes =
         impl_->css_rules.capacity() * sizeof(implementation::css_rule);
+    for (const auto& [root, cascade] : impl_->inactive_css_cascades) {
+        static_cast<void>(root);
+        result.native_css_rule_count += cascade.rules.size();
+        result.native_css_rule_storage_bytes +=
+            cascade.rules.capacity() * sizeof(implementation::css_rule);
+    }
     const auto string_bytes = [](const std::string& value) {
         return value.capacity() + 1U;
     };
@@ -4500,6 +4518,17 @@ v8_dom_runtime::memory_metrics v8_dom_runtime::read_memory_metrics() const noexc
                 * sizeof(node_style::opacity_keyframe)
             + keyframes.rotation_stops.capacity()
                 * sizeof(node_style::rotation_keyframe);
+    }
+    for (const auto& [root, cascade] : impl_->inactive_css_cascades) {
+        static_cast<void>(root);
+        for (const auto& [name, keyframes] : cascade.opacity_keyframes) {
+            result.native_css_rule_storage_bytes += string_bytes(name)
+                + sizeof(decltype(cascade.opacity_keyframes)::value_type)
+                + keyframes.opacity_stops.capacity()
+                    * sizeof(node_style::opacity_keyframe)
+                + keyframes.rotation_stops.capacity()
+                    * sizeof(node_style::rotation_keyframe);
+        }
     }
     {
         std::lock_guard lock(
@@ -4563,6 +4592,19 @@ v8_dom_runtime::memory_metrics v8_dom_runtime::read_memory_metrics() const noexc
         + impl_->unindexed_css_rules.capacity() * sizeof(size_t)
         + impl_->hover_selector_dependencies.capacity()
             * sizeof(implementation::hover_selector_dependency);
+    for (const auto& [root, cascade] : impl_->inactive_css_cascades) {
+        static_cast<void>(root);
+        result.native_css_index_storage_bytes +=
+            indexed_rule_storage(cascade.rules_by_class)
+            + indexed_rule_storage(cascade.rules_by_id)
+            + indexed_rule_storage(cascade.rules_by_tag)
+            + indexed_rule_storage(cascade.rules_by_attribute)
+            + indexed_rule_storage(cascade.rules_by_variable_reference)
+            + cascade.focus_rules.capacity() * sizeof(size_t)
+            + cascade.unindexed_rules.capacity() * sizeof(size_t)
+            + cascade.hover_dependencies.capacity()
+                * sizeof(implementation::hover_selector_dependency);
+    }
     return result;
 }
 

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_cache_and_frames.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_cache_and_frames.inc
@@ -390,7 +390,10 @@
             std::error_code metadata_error;
             const auto size = std::filesystem::file_size(path, metadata_error);
             if (metadata_error) continue;
-            const auto last_write = std::filesystem::last_write_time(path, metadata_error);
+            const auto last_write = pending_compilation_cache_touches.contains(
+                    path.string())
+                ? std::filesystem::file_time_type::clock::now()
+                : std::filesystem::last_write_time(path, metadata_error);
             if (metadata_error) continue;
             files.push_back(cache_file{path, last_write, size});
             total_bytes += size;
@@ -408,6 +411,20 @@
             }
             ++first_retained;
         }
+    }
+
+    void flush_compilation_cache_touches()
+    {
+        if (pending_compilation_cache_touches.empty()) return;
+        const auto now = std::filesystem::file_time_type::clock::now();
+        for (const auto& value : pending_compilation_cache_touches) {
+            std::error_code error;
+            std::filesystem::last_write_time(
+                runtime_file_path(value),
+                now,
+                error);
+        }
+        pending_compilation_cache_touches.clear();
     }
 
     std::shared_ptr<const immutable_byte_buffer> read_compilation_cache(
@@ -489,11 +506,15 @@
         }
         if (record_access) {
             compilation_cache_bytes_read_count += payload->size();
-            std::error_code access_error;
-            std::filesystem::last_write_time(
-                path,
-                std::filesystem::file_time_type::clock::now(),
-                access_error);
+            if (defer_compilation_cache_touches) {
+                pending_compilation_cache_touches.insert(path.string());
+            } else {
+                std::error_code access_error;
+                std::filesystem::last_write_time(
+                    path,
+                    std::filesystem::file_time_type::clock::now(),
+                    access_error);
+            }
         }
         return payload;
     }
@@ -1022,11 +1043,19 @@
         v8::Context::Scope context_scope(local_context);
         v8::TryCatch try_catch(isolate);
         v8::Local<v8::Script> script;
-        if (!compile_script(
+        auto compiled = false;
+        {
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+            binding_callback_timer compile_timer(
+                profile_startup ? &startup_script_compile : nullptr);
+#endif
+            compiled = compile_script(
                 source,
                 document_name,
                 script,
-                std::move(immutable_source))) {
+                std::move(immutable_source));
+        }
+        if (!compiled) {
 #if defined(WEBSCENE_NATIVE_ENGINE_WITH_V8_INSPECTOR)
             report_inspector_exception(try_catch, local_context);
 #endif
@@ -1034,7 +1063,15 @@
             return false;
         }
         style_recascade_batch_scope style_batch(*this);
-        if (script->Run(local_context).IsEmpty()) {
+        auto ran = false;
+        {
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+            binding_callback_timer run_timer(
+                profile_startup ? &startup_script_run : nullptr);
+#endif
+            ran = !script->Run(local_context).IsEmpty();
+        }
+        if (!ran) {
 #if defined(WEBSCENE_NATIVE_ENGINE_WITH_V8_INSPECTOR)
             report_inspector_exception(try_catch, local_context);
 #endif
@@ -1661,7 +1698,380 @@
         static_cast<void>(frame_body);
     }
 
-    bool hydrate_frame(dom_node& frame)
+    void start_frame_preparation(dom_node& frame, const std::string& source)
+    {
+        for (auto iterator = pending_frame_preparations.begin();
+             iterator != pending_frame_preparations.end();) {
+            auto* candidate = document.find_by_native_id(iterator->first);
+            auto stale = candidate == nullptr || !is_connected(*candidate);
+            if (!stale) {
+                const auto candidate_source = candidate->attributes.find("src");
+                stale = candidate_source == candidate->attributes.end()
+                    || candidate_source->second != iterator->second.source;
+            }
+            if (stale
+                && iterator->second.future.valid()
+                && iterator->second.future.wait_for(std::chrono::seconds(0))
+                    == std::future_status::ready) {
+                iterator = pending_frame_preparations.erase(iterator);
+            } else {
+                ++iterator;
+            }
+        }
+        if (!prepare_iframe_subresources
+            || !prefetch_iframe_documents
+            || source.empty()
+            || pending_frame_preparations.size() >= maximum_frame_preparations
+            || pending_frame_preparations.contains(frame.id)) {
+            return;
+        }
+        const auto document_key = resource_prefetch_key(
+            WEBSCENE_RESOURCE_DOCUMENT,
+            source);
+        std::shared_future<prefetched_resource> document_future;
+        {
+            std::lock_guard lock(resource_prefetch_mutex);
+            const auto known = prefetched_resources.find(document_key);
+            if (known == prefetched_resources.end()) return;
+            document_future = known->second;
+        }
+        if (!document_future.valid()) return;
+        const auto outer_base_address = document_base_address;
+
+        pending_frame_preparation preparation;
+        preparation.source = source;
+        preparation.future = std::async(
+            std::launch::async,
+            [this, source, outer_base_address, document_future]()
+                -> std::shared_ptr<const prepared_frame> {
+                const auto started = std::chrono::steady_clock::now();
+                try {
+                    const auto& document = document_future.get();
+                    const immutable_text_source* content = nullptr;
+                    if (document.from_fresh_cache && document.cached.content != nullptr) {
+                        content = document.cached.content.get();
+                    } else if (document.loaded && document.response != nullptr
+                        && !document.response->not_modified) {
+                        auto result = std::make_shared<prepared_frame>();
+                        result->source = source;
+                        result->html = document.response->content;
+                        result->started = started;
+                        prepare_frame_resource_plan(*result, outer_base_address);
+                        result->completed = std::chrono::steady_clock::now();
+                        return result;
+                    } else if (document.has_cached && document.cached.content != nullptr) {
+                        content = document.cached.content.get();
+                    }
+                    if (content == nullptr) return {};
+                    auto result = std::make_shared<prepared_frame>();
+                    result->source = source;
+                    result->html.assign(content->data(), content->size());
+                    result->started = started;
+                    prepare_frame_resource_plan(*result, outer_base_address);
+                    result->completed = std::chrono::steady_clock::now();
+                    return result;
+                } catch (...) {
+                    return {};
+                }
+            }).share();
+        pending_frame_preparations.emplace(frame.id, std::move(preparation));
+    }
+
+    void prepare_frame_resource_plan(
+        prepared_frame& result,
+        const std::string& outer_base_address)
+    {
+        const auto normalized_html = lower_html_name(result.html);
+        const auto opening_tag = [&](std::string_view name) {
+            const auto open = normalized_html.find("<" + std::string(name));
+            const auto close = open == std::string::npos
+                ? std::string::npos : normalized_html.find('>', open);
+            return open == std::string::npos || close == std::string::npos
+                ? std::string{}
+                : result.html.substr(open, close - open + 1U);
+        };
+        result.base_address = resolve_resource_url(result.source, outer_base_address);
+        const auto base_opening = opening_tag("base");
+        if (!base_opening.empty()) {
+            for (const auto& [name, value] : parse_html_attributes(base_opening, 5U)) {
+                if (lower_html_name(name) == "href" && !value.empty()) {
+                    result.base_address = resolve_resource_url(value, outer_base_address);
+                    break;
+                }
+            }
+        }
+        result.html_opening = opening_tag("html");
+        result.body_opening = opening_tag("body");
+        result.stylesheets = parse_frame_stylesheets(result.html);
+        result.scripts = parse_frame_scripts(result.html);
+        for (const auto& href : result.stylesheets) {
+            start_resource_prefetch(
+                href,
+                result.base_address,
+                WEBSCENE_RESOURCE_STYLESHEET);
+        }
+        for (const auto& script : result.scripts) {
+            if (!script.source.empty()) {
+                start_resource_prefetch(
+                    script.source,
+                    result.base_address,
+                    WEBSCENE_RESOURCE_SCRIPT);
+            }
+        }
+    }
+
+    std::shared_ptr<const prepared_frame> take_frame_preparation(
+        const dom_node& frame,
+        const std::string& html)
+    {
+        const auto known = pending_frame_preparations.find(frame.id);
+        if (known == pending_frame_preparations.end()) return {};
+        const auto source = frame.attributes.find("src");
+        if (source == frame.attributes.end()
+            || source->second != known->second.source
+            || !known->second.future.valid()) {
+            if (known->second.future.valid()
+                && known->second.future.wait_for(std::chrono::seconds(0))
+                    == std::future_status::ready) {
+                pending_frame_preparations.erase(known);
+            }
+            return {};
+        }
+        auto preparation = std::move(known->second);
+        pending_frame_preparations.erase(known);
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+        const auto wait_started = std::chrono::steady_clock::now();
+#endif
+        std::shared_ptr<const prepared_frame> result;
+        try {
+            result = preparation.future.get();
+        } catch (...) {
+            return {};
+        }
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+        const auto consumed = std::chrono::steady_clock::now();
+        if (profile_startup) {
+            ++startup_frame_prepare_wait.calls;
+            startup_frame_prepare_wait.nanoseconds += static_cast<uint64_t>(
+                std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    consumed - wait_started).count());
+            if (result != nullptr) {
+                ++startup_frame_prepare.calls;
+                startup_frame_prepare.nanoseconds += static_cast<uint64_t>(
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        result->completed - result->started).count());
+                if (consumed > result->completed) {
+                    startup_frame_prepare_lead_nanoseconds += static_cast<uint64_t>(
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            consumed - result->completed).count());
+                }
+            }
+        }
+#endif
+        return result != nullptr && result->html == html ? result : nullptr;
+    }
+
+    bool execute_frame_hydration_script(
+        frame_hydration_state& hydration,
+        const frame_script& script)
+    {
+        auto local_frame_context = hydration.context.Get(isolate);
+        if (local_frame_context.IsEmpty()) {
+            frame_last_error_value = "Iframe context was discarded during hydration";
+            ++frame_script_error_count;
+            return false;
+        }
+        std::string source = script.code;
+        std::shared_ptr<const immutable_text_source> immutable_source;
+        auto name = "webscene-frame-inline-" + std::to_string(script.index) + ".js";
+        if (!script.source.empty()) {
+            if (!load_text_resource(
+                    script.source,
+                    hydration.base_address,
+                    WEBSCENE_RESOURCE_SCRIPT,
+                    source,
+                    name,
+                    &immutable_source)) {
+                frame_last_error_value = "Unable to load iframe script: " + script.source;
+                ++frame_script_error_count;
+                return false;
+            }
+        }
+        {
+            v8::Context::Scope context_scope(local_frame_context);
+            auto document_value = local_frame_context->Global()->Get(
+                local_frame_context,
+                js_string(isolate, "document")).ToLocalChecked().As<v8::Object>();
+            set_current_script(local_frame_context, document_value, name);
+        }
+        std::string error;
+        const auto script_source = immutable_source != nullptr
+            ? immutable_source->view()
+            : std::string_view(source);
+        if (!execute_in_context(
+                local_frame_context,
+                script_source,
+                name,
+                error,
+                true,
+                std::move(immutable_source))) {
+            frame_last_error_value = "Iframe script #" + std::to_string(script.index)
+                + " failed: " + error;
+            ++frame_script_error_count;
+            return false;
+        }
+        ++frame_script_execution_count;
+        return true;
+    }
+
+    frame_hydration_result continue_frame_hydration(
+        dom_node& frame,
+        frame_hydration_state& hydration,
+        bool cooperative)
+    {
+        if (hydration.body == nullptr || hydration.context.IsEmpty()) {
+            frame_last_error_value = "Iframe hydration state was discarded";
+            ++frame_script_error_count;
+            return frame_hydration_result::failed;
+        }
+        activate_css_cascade(hydration.body);
+        const auto restore_outer = [&](frame_hydration_result result) {
+            activate_css_cascade(context.Get(isolate));
+            return result;
+        };
+        const auto slice_started = std::chrono::steady_clock::now();
+        constexpr auto slice_budget = std::chrono::milliseconds(8);
+
+        while (hydration.phase != frame_hydration_phase::lifecycle) {
+            const auto defer =
+                hydration.phase == frame_hydration_phase::deferred_scripts;
+            auto executed_script = false;
+            while (hydration.next_script < hydration.scripts.size()) {
+                const auto& script = hydration.scripts[hydration.next_script++];
+                if (script.defer != defer) continue;
+                if (!execute_frame_hydration_script(hydration, script)) {
+                    return restore_outer(frame_hydration_result::failed);
+                }
+                executed_script = true;
+                if (cooperative
+                    && std::chrono::steady_clock::now() - slice_started >= slice_budget) {
+                    return restore_outer(frame_hydration_result::pending);
+                }
+            }
+
+            hydration.next_script = 0U;
+            if (hydration.phase == frame_hydration_phase::blocking_scripts) {
+                auto local_frame_context = hydration.context.Get(isolate);
+                v8::Context::Scope context_scope(local_frame_context);
+                auto document_value = local_frame_context->Global()->Get(
+                    local_frame_context,
+                    js_string(isolate, "document")).ToLocalChecked().As<v8::Object>();
+                document_value->Set(
+                    local_frame_context,
+                    js_string(isolate, "readyState"),
+                    js_string(isolate, "interactive")).Check();
+                hydration.phase = frame_hydration_phase::deferred_scripts;
+                if (cooperative && executed_script) {
+                    return restore_outer(frame_hydration_result::pending);
+                }
+            } else {
+                hydration.phase = frame_hydration_phase::lifecycle;
+                if (cooperative && executed_script) {
+                    return restore_outer(frame_hydration_result::pending);
+                }
+            }
+        }
+
+        auto local_frame_context = hydration.context.Get(isolate);
+        v8::Context::Scope lifecycle_context_scope(local_frame_context);
+        const auto dispatch_lifecycle_event = [&](v8::Local<v8::Object> target, const char* type) {
+            auto event = create_event_instance(local_frame_context);
+            event->Set(
+                local_frame_context,
+                js_string(isolate, "type"),
+                js_string(isolate, type)).Check();
+            event->Set(
+                local_frame_context,
+                js_string(isolate, "bubbles"),
+                v8::Boolean::New(
+                    isolate,
+                    std::string_view(type) == "DOMContentLoaded")).Check();
+            event->Set(
+                local_frame_context,
+                js_string(isolate, "cancelable"),
+                v8::False(isolate)).Check();
+            event->Set(
+                local_frame_context,
+                js_string(isolate, "defaultPrevented"),
+                v8::False(isolate)).Check();
+            v8::Local<v8::Value> dispatcher;
+            if (!target->Get(
+                    local_frame_context,
+                    js_string(isolate, "dispatchEvent")).ToLocal(&dispatcher)
+                || !dispatcher->IsFunction()) {
+                frame_last_error_value =
+                    std::string("Iframe ") + type + " dispatcher is unavailable";
+                ++frame_script_error_count;
+                return false;
+            }
+            v8::TryCatch try_catch(isolate);
+            v8::Local<v8::Value> arguments[] = {event};
+            if (dispatcher.As<v8::Function>()->Call(
+                    local_frame_context,
+                    target,
+                    1,
+                    arguments).IsEmpty()) {
+                frame_last_error_value = std::string("Iframe ") + type
+                    + " dispatch failed: "
+                    + describe_exception(try_catch, local_frame_context);
+                ++frame_script_error_count;
+                return false;
+            }
+            perform_microtask_checkpoint();
+            return true;
+        };
+        auto frame_global = local_frame_context->Global();
+        auto document_value = frame_global->Get(
+            local_frame_context,
+            js_string(isolate, "document")).ToLocalChecked().As<v8::Object>();
+        if (!dispatch_lifecycle_event(document_value, "DOMContentLoaded")) {
+            return restore_outer(frame_hydration_result::failed);
+        }
+        document_value->Set(
+            local_frame_context,
+            js_string(isolate, "readyState"),
+            js_string(isolate, "complete")).Check();
+        auto body_onload = std::string{};
+        for (auto [name, value] : parse_html_attributes(hydration.body_opening, 5U)) {
+            if (lower_html_name(name) != "onload") continue;
+            body_onload = std::move(value);
+            break;
+        }
+        if (!body_onload.empty()) {
+            std::string error;
+            const auto handler_source = "(function(event){" + body_onload
+                + "\n}).call(document.body, { type: 'load' });";
+            if (!execute_in_context(
+                    local_frame_context,
+                    handler_source,
+                    hydration.base_address + "#body-onload",
+                    error,
+                    true)) {
+                frame_last_error_value = "Iframe body load handler failed: " + error;
+                ++frame_script_error_count;
+                return restore_outer(frame_hydration_result::failed);
+            }
+        }
+        if (!dispatch_lifecycle_event(frame_global, "load")) {
+            return restore_outer(frame_hydration_result::failed);
+        }
+        perform_microtask_checkpoint();
+        frame_last_error_value.clear();
+        static_cast<void>(frame);
+        return restore_outer(frame_hydration_result::complete);
+    }
+
+    frame_hydration_result hydrate_frame(dom_node& frame)
     {
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
         if (profile_startup && startup_frame_started == std::chrono::steady_clock::time_point{}) {
@@ -1703,6 +2113,22 @@
             profile_startup ? this : nullptr,
             finish_frame_profile);
 #endif
+        if (auto existing = frame_hydration_states.find(frame.id);
+            existing != frame_hydration_states.end()) {
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+            const auto cooperative = cooperative_iframe_hydration;
+#else
+            constexpr auto cooperative = true;
+#endif
+            const auto result = continue_frame_hydration(
+                frame,
+                existing->second,
+                cooperative);
+            if (result != frame_hydration_result::pending) {
+                frame_hydration_states.erase(existing);
+            }
+            return result;
+        }
         if (!frame.attributes.contains("frame-html")
             && !frame.attributes.contains("object-html")) {
             const auto remote_result = frame.attributes.find(
@@ -1723,7 +2149,7 @@
                     frame_last_error_value = "Unable to load iframe document: "
                         + source->second;
                     ++frame_script_error_count;
-                    return false;
+                    return frame_hydration_result::failed;
                 }
                 frame.attributes["src"] = std::move(resolved_name);
                 frame.attributes["object-html"] = std::move(html);
@@ -1738,34 +2164,49 @@
         if (html.empty()) {
             frame_last_error_value = "Iframe document.close() received no HTML";
             ++frame_script_error_count;
-            return false;
+            return frame_hydration_result::failed;
         }
-        const auto normalized_html = lower_html_name(html);
-        const auto opening_tag = [&](std::string_view name) {
-            const auto open = normalized_html.find("<" + std::string(name));
-            const auto close = open == std::string::npos
-                ? std::string::npos : normalized_html.find('>', open);
-            return open == std::string::npos || close == std::string::npos
-                ? std::string{}
-                : html.substr(open, close - open + 1U);
-        };
-        const auto frame_source = frame.attributes.find("src");
-        frame_base_address = frame_source != frame.attributes.end()
-            && (frame_source->second.starts_with("http://")
-                || frame_source->second.starts_with("https://"))
-            ? resolve_resource_url(frame_source->second, document_base_address)
-            : document_base_address;
-        const auto base_opening = opening_tag("base");
-        if (!base_opening.empty()) {
-            for (const auto& [name, value] : parse_html_attributes(base_opening, 5U)) {
-                if (lower_html_name(name) == "href" && !value.empty()) {
-                    frame_base_address = resolve_resource_url(value, document_base_address);
-                    break;
+        const auto preparation = take_frame_preparation(frame, html);
+        std::vector<std::string> stylesheets;
+        std::vector<frame_script> scripts;
+        std::string html_opening;
+        std::string body_opening;
+        if (preparation != nullptr) {
+            frame_base_address = preparation->base_address;
+            stylesheets = preparation->stylesheets;
+            scripts = preparation->scripts;
+            html_opening = preparation->html_opening;
+            body_opening = preparation->body_opening;
+        } else {
+            const auto normalized_html = lower_html_name(html);
+            const auto opening_tag = [&](std::string_view name) {
+                const auto open = normalized_html.find("<" + std::string(name));
+                const auto close = open == std::string::npos
+                    ? std::string::npos : normalized_html.find('>', open);
+                return open == std::string::npos || close == std::string::npos
+                    ? std::string{}
+                    : html.substr(open, close - open + 1U);
+            };
+            const auto frame_source = frame.attributes.find("src");
+            frame_base_address = frame_source != frame.attributes.end()
+                && (frame_source->second.starts_with("http://")
+                    || frame_source->second.starts_with("https://"))
+                ? resolve_resource_url(frame_source->second, document_base_address)
+                : document_base_address;
+            const auto base_opening = opening_tag("base");
+            if (!base_opening.empty()) {
+                for (const auto& [name, value] : parse_html_attributes(base_opening, 5U)) {
+                    if (lower_html_name(name) == "href" && !value.empty()) {
+                        frame_base_address = resolve_resource_url(value, document_base_address);
+                        break;
+                    }
                 }
             }
+            html_opening = opening_tag("html");
+            body_opening = opening_tag("body");
+            stylesheets = parse_frame_stylesheets(html);
+            scripts = parse_frame_scripts(html);
         }
-        const auto stylesheets = parse_frame_stylesheets(html);
-        const auto scripts = parse_frame_scripts(html);
         const auto requires_resource_loader = !stylesheets.empty()
             || std::any_of(scripts.begin(), scripts.end(), [](const auto& script) {
                 return !script.source.empty();
@@ -1773,7 +2214,7 @@
         if (requires_resource_loader && resource_root.empty() && !load_resource_callback) {
             frame_last_error_value = "The connected component resource root was not configured";
             ++frame_script_error_count;
-            return false;
+            return frame_hydration_result::failed;
         }
         for (const auto& href : stylesheets) {
             start_resource_prefetch(href, frame_base_address, WEBSCENE_RESOURCE_STYLESHEET);
@@ -1787,6 +2228,9 @@
             }
         }
 
+        auto& frame_body = document.create_element("body");
+        frame_base_addresses[&frame_body] = frame_base_address;
+        activate_css_cascade(&frame_body);
         css_rules.clear();
         opacity_keyframes.clear();
         css_rules_by_class.clear();
@@ -1815,16 +2259,12 @@
                     stylesheet_name)) {
                 frame_last_error_value = "Unable to load iframe stylesheet: " + href;
                 ++frame_script_error_count;
-                return false;
+                activate_css_cascade(context.Get(isolate));
+                return frame_hydration_result::failed;
             }
             add_stylesheet(std::move(stylesheet), stylesheet_name);
         }
 
-        const auto html_opening = opening_tag("html");
-        const auto body_opening = opening_tag("body");
-
-        auto& frame_body = document.create_element("body");
-        frame_base_addresses[&frame_body] = frame_base_address;
         record_feature(
             "html",
             "element:body",
@@ -1880,7 +2320,8 @@
                 ? "html5ever iframe parsing failed"
                 : parsed_frame.error;
             ++frame_script_error_count;
-            return false;
+            activate_css_cascade(context.Get(isolate));
+            return frame_hydration_result::failed;
         }
         dom_node* parsed_html = nullptr;
         dom_node* parsed_body = nullptr;
@@ -1895,7 +2336,8 @@
         if (parsed_body == nullptr) {
             frame_last_error_value = "html5ever iframe parse produced no body";
             ++frame_script_error_count;
-            return false;
+            activate_css_cascade(context.Get(isolate));
+            return frame_hydration_result::failed;
         }
         auto parsed_children = parsed_body->children;
         for (auto* child : parsed_children) {
@@ -1965,154 +2407,32 @@
             "WebScene frame " + std::to_string(frame.id));
 #endif
         if (!execute_document_start_scripts(local_frame_context, true)) {
-            return false;
+            activate_css_cascade(context.Get(isolate));
+            return frame_hydration_result::failed;
         }
-
-        const auto execute_group = [&](bool defer) {
-            for (const auto& script : scripts) {
-                if (script.defer != defer) continue;
-                std::string source = script.code;
-                std::shared_ptr<const immutable_text_source> immutable_source;
-                auto name = "webscene-frame-inline-" + std::to_string(script.index) + ".js";
-                if (!script.source.empty()) {
-                    if (!load_text_resource(
-                            script.source,
-                            frame_base_address,
-                            WEBSCENE_RESOURCE_SCRIPT,
-                            source,
-                            name,
-                            &immutable_source)) {
-                        frame_last_error_value = "Unable to load iframe script: " + script.source;
-                        ++frame_script_error_count;
-                        return false;
-                    }
-                }
-                {
-                    v8::Context::Scope context_scope(local_frame_context);
-                    auto document_value = local_frame_context->Global()->Get(
-                        local_frame_context,
-                        js_string(isolate, "document")).ToLocalChecked().As<v8::Object>();
-                    set_current_script(local_frame_context, document_value, name);
-                }
-                std::string error;
-                const auto script_source = immutable_source != nullptr
-                    ? immutable_source->view()
-                    : std::string_view(source);
-                if (!execute_in_context(
-                        local_frame_context,
-                        script_source,
-                        name,
-                        error,
-                        true,
-                        std::move(immutable_source))) {
-                    frame_last_error_value = "Iframe script #" + std::to_string(script.index)
-                        + " failed: " + error;
-                    ++frame_script_error_count;
-                    return false;
-                }
-                ++frame_script_execution_count;
-            }
-            return true;
-        };
-        if (!execute_group(false)) return false;
-        {
-            v8::Context::Scope context_scope(local_frame_context);
-            auto document_value = local_frame_context->Global()->Get(
-                local_frame_context,
-                js_string(isolate, "document")).ToLocalChecked().As<v8::Object>();
-            document_value->Set(
-                local_frame_context,
-                js_string(isolate, "readyState"),
-                js_string(isolate, "interactive")).Check();
+        frame_hydration_state hydration;
+        hydration.body = &frame_body;
+        hydration.scripts = std::move(scripts);
+        hydration.body_opening = std::move(body_opening);
+        hydration.base_address = frame_base_address;
+        hydration.context.Reset(isolate, local_frame_context);
+        auto [state, inserted] = frame_hydration_states.insert_or_assign(
+            frame.id,
+            std::move(hydration));
+        static_cast<void>(inserted);
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+        const auto cooperative = cooperative_iframe_hydration;
+#else
+        constexpr auto cooperative = true;
+#endif
+        const auto result = continue_frame_hydration(
+            frame,
+            state->second,
+            cooperative);
+        if (result != frame_hydration_result::pending) {
+            frame_hydration_states.erase(state);
         }
-        if (!execute_group(true)) return false;
-
-        // Complete the parser lifecycle in the same ordering used by the
-        // working managed iframe host. Deferred scripts observe interactive;
-        // DOMContentLoaded runs before readyState=complete and Window load.
-        // A checkpoint follows each event dispatch, after all listeners for
-        // that event have run.
-        v8::Context::Scope lifecycle_context_scope(local_frame_context);
-        const auto dispatch_lifecycle_event = [&](v8::Local<v8::Object> target, const char* type) {
-            auto event = create_event_instance(local_frame_context);
-            event->Set(
-                local_frame_context,
-                js_string(isolate, "type"),
-                js_string(isolate, type)).Check();
-            event->Set(
-                local_frame_context,
-                js_string(isolate, "bubbles"),
-                v8::Boolean::New(
-                    isolate,
-                    std::string_view(type) == "DOMContentLoaded")).Check();
-            event->Set(
-                local_frame_context,
-                js_string(isolate, "cancelable"),
-                v8::False(isolate)).Check();
-            event->Set(
-                local_frame_context,
-                js_string(isolate, "defaultPrevented"),
-                v8::False(isolate)).Check();
-            v8::Local<v8::Value> dispatcher;
-            if (!target->Get(
-                    local_frame_context,
-                    js_string(isolate, "dispatchEvent")).ToLocal(&dispatcher)
-                || !dispatcher->IsFunction()) {
-                frame_last_error_value =
-                    std::string("Iframe ") + type + " dispatcher is unavailable";
-                ++frame_script_error_count;
-                return false;
-            }
-            v8::TryCatch try_catch(isolate);
-            v8::Local<v8::Value> arguments[] = {event};
-            if (dispatcher.As<v8::Function>()->Call(
-                    local_frame_context,
-                    target,
-                    1,
-                    arguments).IsEmpty()) {
-                frame_last_error_value = std::string("Iframe ") + type
-                    + " dispatch failed: "
-                    + describe_exception(try_catch, local_frame_context);
-                ++frame_script_error_count;
-                return false;
-            }
-            perform_microtask_checkpoint();
-            return true;
-        };
-        auto frame_global = local_frame_context->Global();
-        auto document_value = frame_global->Get(
-            local_frame_context,
-            js_string(isolate, "document")).ToLocalChecked().As<v8::Object>();
-        if (!dispatch_lifecycle_event(document_value, "DOMContentLoaded")) return false;
-        document_value->Set(
-            local_frame_context,
-            js_string(isolate, "readyState"),
-            js_string(isolate, "complete")).Check();
-        auto body_onload = std::string{};
-        for (auto [name, value] : parse_html_attributes(body_opening, 5U)) {
-            if (lower_html_name(name) != "onload") continue;
-            body_onload = std::move(value);
-            break;
-        }
-        if (!body_onload.empty()) {
-            std::string error;
-            const auto handler_source = "(function(event){" + body_onload
-                + "\n}).call(document.body, { type: 'load' });";
-            if (!execute_in_context(
-                    local_frame_context,
-                    handler_source,
-                    frame_base_address + "#body-onload",
-                    error,
-                    true)) {
-                frame_last_error_value = "Iframe body load handler failed: " + error;
-                ++frame_script_error_count;
-                return false;
-            }
-        }
-        if (!dispatch_lifecycle_event(frame_global, "load")) return false;
-        perform_microtask_checkpoint();
-        frame_last_error_value.clear();
-        return true;
+        return result;
     }
 
     bool hydrate_initial_document_start_frames()
@@ -2121,7 +2441,11 @@
             auto* frame = pending_frame_hydrations.front();
             pending_frame_hydrations.erase(pending_frame_hydrations.begin());
             if (frame == nullptr) continue;
-            if (hydrate_frame(*frame)) continue;
+            auto result = hydrate_frame(*frame);
+            while (result == frame_hydration_result::pending) {
+                result = hydrate_frame(*frame);
+            }
+            if (result == frame_hydration_result::complete) continue;
             frame->attributes["data-webscene-frame-error"] =
                 frame_last_error_value;
             last_error = frame_last_error_value;

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_parsing.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_parsing.inc
@@ -177,19 +177,6 @@
         return true;
     }
 
-    enum class hover_invalidation_scope : uint8_t
-    {
-        subject,
-        subtree,
-        siblings
-    };
-
-    struct hover_selector_dependency final
-    {
-        std::string trigger_compound;
-        hover_invalidation_scope scope{hover_invalidation_scope::subject};
-    };
-
     static void strip_hover_state_from_trigger(std::string& trigger)
     {
         // A functional pseudo containing :hover changes truth when hover does,
@@ -1235,22 +1222,28 @@
 
     bool refresh_media_environment()
     {
-        if (!refresh_css_media_matches()) return true;
-
         auto isolate_locker = lock_shared_isolate();
         v8::Isolate::Scope isolate_scope(isolate);
         v8::HandleScope handle_scope(isolate);
-        rebuild_css_rule_indexes_and_root_variables();
-        if (frame_context.IsEmpty()) {
-            auto local_context = context.Get(isolate);
+        auto changed = false;
+        const auto refresh_context = [&](v8::Local<v8::Context> local_context) {
+            if (local_context.IsEmpty()) return;
+            activate_css_cascade(local_context);
             v8::Context::Scope context_scope(local_context);
-            apply_css_rules_subtree(document.body());
-        } else {
-            auto local_frame_context = frame_context.Get(isolate);
-            v8::Context::Scope frame_scope(local_frame_context);
+            if (!refresh_css_media_matches()) return;
+            changed = true;
+            rebuild_css_rule_indexes_and_root_variables();
             apply_css_rules_subtree(active_root());
+        };
+        refresh_context(context.Get(isolate));
+        for (auto& [id, persistent_context] : actual_frame_contexts) {
+            static_cast<void>(id);
+            if (!persistent_context.IsEmpty()) {
+                refresh_context(persistent_context.Get(isolate));
+            }
         }
-        document.mark_dirty();
+        activate_css_cascade(context.Get(isolate));
+        if (changed) document.mark_dirty();
         return true;
     }
 

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_dom_core.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_dom_core.inc
@@ -530,13 +530,89 @@
         }
     }
 
+    css_cascade_state take_active_css_cascade()
+    {
+        css_cascade_state state;
+        state.rules = std::move(css_rules);
+        state.stylesheet_owner_id = active_stylesheet_owner_id;
+        state.stylesheet_shadow_scope_root_id = active_stylesheet_shadow_scope_root_id;
+        state.opacity_keyframes = std::move(opacity_keyframes);
+        state.rules_by_class = std::move(css_rules_by_class);
+        state.rules_by_id = std::move(css_rules_by_id);
+        state.rules_by_tag = std::move(css_rules_by_tag);
+        state.rules_by_attribute = std::move(css_rules_by_attribute);
+        state.rules_by_variable_reference = std::move(css_rules_by_variable_reference);
+        state.focus_rules = std::move(css_focus_rules);
+        state.unindexed_rules = std::move(unindexed_css_rules);
+        state.attribute_dependencies = std::move(css_attribute_dependencies);
+        state.hover_dependencies = std::move(hover_selector_dependencies);
+        state.variables = std::move(css_variables);
+        state.important_variables = std::move(important_css_variables);
+        active_stylesheet_owner_id = 0U;
+        active_stylesheet_shadow_scope_root_id = 0U;
+        return state;
+    }
+
+    void restore_active_css_cascade(css_cascade_state state)
+    {
+        css_rules = std::move(state.rules);
+        active_stylesheet_owner_id = state.stylesheet_owner_id;
+        active_stylesheet_shadow_scope_root_id =
+            state.stylesheet_shadow_scope_root_id;
+        opacity_keyframes = std::move(state.opacity_keyframes);
+        css_rules_by_class = std::move(state.rules_by_class);
+        css_rules_by_id = std::move(state.rules_by_id);
+        css_rules_by_tag = std::move(state.rules_by_tag);
+        css_rules_by_attribute = std::move(state.rules_by_attribute);
+        css_rules_by_variable_reference =
+            std::move(state.rules_by_variable_reference);
+        css_focus_rules = std::move(state.focus_rules);
+        unindexed_css_rules = std::move(state.unindexed_rules);
+        css_attribute_dependencies = std::move(state.attribute_dependencies);
+        hover_selector_dependencies = std::move(state.hover_dependencies);
+        css_variables = std::move(state.variables);
+        important_css_variables = std::move(state.important_variables);
+    }
+
+    void activate_css_cascade(dom_node* root)
+    {
+        if (root == nullptr) root = &document.body();
+        if (active_css_cascade_root == nullptr) {
+            active_css_cascade_root = &document.body();
+        }
+        if (active_css_cascade_root == root) return;
+
+        auto incoming = inactive_css_cascades.extract(root);
+        inactive_css_cascades.insert_or_assign(
+            active_css_cascade_root,
+            take_active_css_cascade());
+        if (!incoming.empty()) {
+            restore_active_css_cascade(std::move(incoming.mapped()));
+        }
+        active_css_cascade_root = root;
+    }
+
+    void activate_css_cascade(v8::Local<v8::Context> local_context)
+    {
+        if (local_context.IsEmpty()) {
+            activate_css_cascade(&document.body());
+            return;
+        }
+        activate_css_cascade(static_cast<dom_node*>(
+            local_context->GetAlignedPointerFromEmbedderData(
+                1,
+                v8::kEmbedderDataTypeTagDefault)));
+    }
+
     dom_node& active_root()
     {
         auto local_context = isolate->GetCurrentContext();
         auto* root = static_cast<dom_node*>(local_context->GetAlignedPointerFromEmbedderData(
             1,
             v8::kEmbedderDataTypeTagDefault));
-        return root == nullptr ? document.body() : *root;
+        if (root == nullptr) root = &document.body();
+        activate_css_cascade(root);
+        return *root;
     }
 
     static dom_node& exposed_body_for_root(dom_node& root)
@@ -695,6 +771,10 @@
                         1,
                         v8::kEmbedderDataTypeTagDefault));
                 frame_base_addresses.erase(frame_root);
+                if (active_css_cascade_root == frame_root) {
+                    activate_css_cascade(&document.body());
+                }
+                inactive_css_cascades.erase(frame_root);
                 detached_contexts.push_back(local_context);
                 cancel_detached_frame_context_tasks(local_context);
                 destroy_inspector_context(local_context);
@@ -705,6 +785,7 @@
                 }
             }
             actual_frame_contexts.erase(id);
+            frame_hydration_states.erase(id);
             actual_frame_windows.erase(id);
             actual_frame_documents.erase(id);
             frame_session_storage.erase(id);
@@ -1011,6 +1092,12 @@
         std::erase_if(frame_base_addresses, [&](const auto& entry) {
             return nodes.contains(const_cast<dom_node*>(entry.first));
         });
+        if (nodes.contains(const_cast<dom_node*>(active_css_cascade_root))) {
+            activate_css_cascade(&document.body());
+        }
+        std::erase_if(inactive_css_cascades, [&](const auto& entry) {
+            return nodes.contains(const_cast<dom_node*>(entry.first));
+        });
         for (auto& observer : resize_observers) {
             std::erase_if(observer->nodes, [&](const auto* node) {
                 return nodes.contains(const_cast<dom_node*>(node));
@@ -1033,6 +1120,7 @@
 #endif
             }
             actual_frame_contexts.erase(id);
+            frame_hydration_states.erase(id);
             actual_frame_documents.erase(id);
             frame_session_storage.erase(id);
             frame_load_listeners.erase(id);
@@ -1463,6 +1551,7 @@
                             resolved,
                             {},
                             WEBSCENE_RESOURCE_DOCUMENT);
+                        start_frame_preparation(node, resolved);
                         node.attributes["data-webscene-remote-result"] = "pending";
                     } else {
                         std::string html;

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_interop.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_interop.inc
@@ -237,6 +237,7 @@
         v8::Isolate::Scope isolate_scope(isolate);
         v8::HandleScope handle_scope(isolate);
         auto local_context = context.Get(isolate);
+        activate_css_cascade(local_context);
         v8::Context::Scope context_scope(local_context);
         v8::TryCatch try_catch(isolate);
         v8::Local<v8::Script> script;
@@ -711,6 +712,7 @@
         v8::Isolate::Scope isolate_scope(isolate);
         v8::HandleScope handle_scope(isolate);
         auto local_context = context.Get(isolate);
+        activate_css_cascade(local_context);
         v8::Context::Scope context_scope(local_context);
         v8::TryCatch try_catch(isolate);
         std::string decoding_error;

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_lifecycle.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_lifecycle.inc
@@ -21,6 +21,12 @@
             std::getenv("WEBSCENE_PROBE_DISABLE_CONNECTED_RESOURCE_STYLE_BATCHING") == nullptr)
         , prefetch_iframe_documents(
             std::getenv("WEBSCENE_PROBE_DISABLE_IFRAME_DOCUMENT_PREFETCH") == nullptr)
+        , prepare_iframe_subresources(
+            std::getenv("WEBSCENE_PROBE_DISABLE_IFRAME_PREPARATION") == nullptr)
+        , defer_compilation_cache_touches(
+            std::getenv("WEBSCENE_PROBE_DISABLE_DEFERRED_COMPILATION_CACHE_TOUCH") == nullptr)
+        , cooperative_iframe_hydration(
+            std::getenv("WEBSCENE_PROBE_DISABLE_COOPERATIVE_IFRAME_HYDRATION") == nullptr)
         , filter_stylesheet_candidates(
             std::getenv("WEBSCENE_PROBE_DISABLE_STYLESHEET_CANDIDATE_FILTER") == nullptr)
         , profile_bindings(std::getenv("WEBSCENE_PROBE_PROFILE_BINDINGS") != nullptr)
@@ -39,18 +45,38 @@
 
     ~implementation()
     {
+        // Preparation workers may still be waiting on a document or adding
+        // newly discovered CSS/script prefetches. Join them before taking the
+        // final snapshot of the resource prefetch table.
+        for (auto& [id, preparation] : pending_frame_preparations) {
+            static_cast<void>(id);
+            if (!preparation.future.valid()) continue;
+            try {
+                static_cast<void>(preparation.future.get());
+            } catch (...) {
+            }
+        }
+        pending_frame_preparations.clear();
         // Resource prefetch tasks capture this runtime and may still be inside
         // the host loader when teardown begins. Join them while the loader and
         // all of its bridge state are still alive.
-        for (auto& [key, future] : prefetched_resources) {
-            static_cast<void>(key);
+        std::vector<std::shared_future<prefetched_resource>> resource_futures;
+        {
+            std::lock_guard lock(resource_prefetch_mutex);
+            resource_futures.reserve(prefetched_resources.size());
+            for (const auto& [key, future] : prefetched_resources) {
+                static_cast<void>(key);
+                resource_futures.push_back(future);
+            }
+            prefetched_resources.clear();
+        }
+        for (auto& future : resource_futures) {
             if (!future.valid()) continue;
             try {
                 static_cast<void>(future.get());
             } catch (...) {
             }
         }
-        prefetched_resources.clear();
         // Stop and join every network worker before releasing persistent V8
         // handles or disposing the isolate. Socket callbacks never touch V8,
         // but they may still be appending to the native delivery queue.
@@ -73,6 +99,7 @@
                 if (generated) write_compilation_cache(entry.key_digest, *generated);
             }
         }
+        flush_compilation_cache_touches();
         resize_listeners.clear();
         timers.clear();
         pending_window_messages.clear();
@@ -88,6 +115,9 @@
 #endif
         connected_resources.clear();
         resize_observers.clear();
+        frame_hydration_states.clear();
+        inactive_css_cascades.clear();
+        active_css_cascade_root = nullptr;
         frame_documents.clear();
         frame_windows.clear();
         frame_window_scroll_offsets.clear();
@@ -171,6 +201,7 @@
                         runtime_context_embedder_slot,
                         v8::kEmbedderDataTypeTagDefault));
                 owner != nullptr) {
+                owner->activate_css_cascade(local_context);
                 return owner;
             }
         }
@@ -818,6 +849,23 @@
             css_focus_rules.shrink_to_fit();
             unindexed_css_rules.shrink_to_fit();
             hover_selector_dependencies.shrink_to_fit();
+            for (auto& [root, cascade] : inactive_css_cascades) {
+                static_cast<void>(root);
+                cascade.rules.shrink_to_fit();
+                for (auto& [name, keyframes] : cascade.opacity_keyframes) {
+                    static_cast<void>(name);
+                    keyframes.opacity_stops.shrink_to_fit();
+                    keyframes.rotation_stops.shrink_to_fit();
+                }
+                compact_index(cascade.rules_by_class);
+                compact_index(cascade.rules_by_id);
+                compact_index(cascade.rules_by_tag);
+                compact_index(cascade.rules_by_attribute);
+                compact_index(cascade.rules_by_variable_reference);
+                cascade.focus_rules.shrink_to_fit();
+                cascade.unindexed_rules.shrink_to_fit();
+                cascade.hover_dependencies.shrink_to_fit();
+            }
         } catch (...) {
             // Capacity compaction is opportunistic. A failed allocator request
             // must not suppress V8's low-memory notification or kill the

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_navigation.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_navigation.inc
@@ -4,6 +4,7 @@
         v8::Isolate::Scope isolate_scope(isolate);
         v8::HandleScope handle_scope(isolate);
         auto local_context = context.Get(isolate);
+        activate_css_cascade(local_context);
         if (!execute_in_context(local_context, source, document_name, last_error)) {
             return false;
         }
@@ -219,6 +220,9 @@
             1,
             &html_element,
             v8::kEmbedderDataTypeTagDefault);
+        frame_hydration_states.clear();
+        inactive_css_cascades.clear();
+        active_css_cascade_root = &html_element;
         css_rules.clear();
         opacity_keyframes.clear();
         css_rules_by_class.clear();

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_resources.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_resources.inc
@@ -236,10 +236,17 @@
         auto has_prefetched = false;
         prefetched_resource prefetched;
         const auto prefetch_key = resource_prefetch_key(kind, resolved_name);
-        if (auto known = prefetched_resources.find(prefetch_key);
-            known != prefetched_resources.end()) {
-            prefetched = known->second.get();
-            prefetched_resources.erase(known);
+        std::shared_future<prefetched_resource> prefetch_future;
+        {
+            std::lock_guard lock(resource_prefetch_mutex);
+            if (auto known = prefetched_resources.find(prefetch_key);
+                known != prefetched_resources.end()) {
+                prefetch_future = known->second;
+                prefetched_resources.erase(known);
+            }
+        }
+        if (prefetch_future.valid()) {
+            prefetched = prefetch_future.get();
             cached = std::move(prefetched.cached);
             has_cached = prefetched.has_cached;
             has_prefetched = true;
@@ -387,13 +394,15 @@
         const std::string& base,
         uint32_t kind)
     {
-        if (!load_resource_callback || prefetched_resources.size() >= maximum_resource_prefetches) {
-            return;
-        }
+        if (!load_resource_callback) return;
         const auto resolved_name = resolve_resource_url(value, base);
         if (resolved_name.empty()) return;
         const auto key = resource_prefetch_key(kind, resolved_name);
-        if (prefetched_resources.contains(key)) return;
+        {
+            std::lock_guard lock(resource_prefetch_mutex);
+            if (prefetched_resources.size() >= maximum_resource_prefetches
+                || prefetched_resources.contains(key)) return;
+        }
 
         cached_text_resource cached;
         const auto cache_key = resource_key_digest(kind, resolved_name);
@@ -406,12 +415,19 @@
             result.has_cached = true;
             result.from_fresh_cache = true;
             std::promise<prefetched_resource> promise;
-            auto future = promise.get_future();
+            auto future = promise.get_future().share();
             promise.set_value(std::move(result));
-            prefetched_resources.emplace(key, std::move(future));
+            std::lock_guard lock(resource_prefetch_mutex);
+            if (prefetched_resources.size() < maximum_resource_prefetches
+                && !prefetched_resources.contains(key)) {
+                prefetched_resources.emplace(key, std::move(future));
+            }
             return;
         }
 
+        std::lock_guard lock(resource_prefetch_mutex);
+        if (prefetched_resources.size() >= maximum_resource_prefetches
+            || prefetched_resources.contains(key)) return;
         auto entity_tag = has_cached ? cached.entity_tag : std::string{};
         const auto last_modified = has_cached ? cached.last_modified_unix_seconds : 0;
         prefetched_resources.emplace(
@@ -431,17 +447,21 @@
                         last_modified,
                         result.loaded);
                     return result;
-                }));
+                }).share());
     }
 
     void prefetch_connected_resources()
     {
         if (!load_resource_callback || connected_resources.empty()) return;
         for (auto& task : connected_resources) {
-            if (prefetched_resources.size() >= maximum_resource_prefetches) return;
+            {
+                std::lock_guard lock(resource_prefetch_mutex);
+                if (prefetched_resources.size() >= maximum_resource_prefetches) return;
+            }
             if (task.node == nullptr) continue;
             auto task_context = task.context.Get(isolate);
             if (task_context.IsEmpty()) continue;
+            activate_css_cascade(task_context);
             v8::Context::Scope task_context_scope(task_context);
             const auto& base = current_base_address();
             if (task.node->tag == "link") {

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state.inc
@@ -2,7 +2,12 @@
     std::function<v8_dom_runtime::viewport_metrics()> viewport_provider;
     resource_loader load_resource_callback;
     static constexpr size_t maximum_resource_prefetches = 16U;
-    std::unordered_map<std::string, std::future<prefetched_resource>> prefetched_resources;
+    std::mutex resource_prefetch_mutex;
+    std::unordered_map<std::string, std::shared_future<prefetched_resource>>
+        prefetched_resources;
+    static constexpr size_t maximum_frame_preparations = 16U;
+    std::unordered_map<uint32_t, pending_frame_preparation>
+        pending_frame_preparations;
     std::shared_ptr<shared_isolate_state> shared_isolate;
     v8::ArrayBuffer::Allocator* allocator{nullptr};
     v8::Isolate* isolate{nullptr};
@@ -139,6 +144,8 @@
     uint32_t next_object_url_id{1};
     std::unordered_map<std::string, std::string> object_urls;
     std::vector<dom_node*> pending_frame_hydrations;
+    std::unordered_map<uint32_t, frame_hydration_state> frame_hydration_states;
+    bool prefer_frame_hydration_task{true};
     static constexpr size_t detached_dom_gc_threshold = 512U;
     std::vector<uint32_t> detached_dom_roots;
     size_t detached_nodes_since_gc{0U};
@@ -168,6 +175,8 @@
     std::vector<hover_selector_dependency> hover_selector_dependencies;
     std::unordered_map<std::string, std::string> css_variables;
     std::unordered_set<std::string> important_css_variables;
+    const dom_node* active_css_cascade_root{nullptr};
+    std::unordered_map<const dom_node*, css_cascade_state> inactive_css_cascades;
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
     mutable std::mutex feature_observation_mutex;
     std::unordered_map<std::string, feature_observation> feature_observations;
@@ -231,6 +240,7 @@
     std::string compilation_cache_directory;
     std::unordered_map<std::string, compilation_cache_entry> compilation_cache;
     std::deque<std::string> compilation_cache_order;
+    std::unordered_set<std::string> pending_compilation_cache_touches;
     size_t compilation_cache_bytes{0};
     uint64_t compilation_request_count{0};
     uint64_t compilation_memory_hit_count{0};
@@ -254,13 +264,13 @@
     uint64_t process_compilation_leader_count{0};
     uint64_t process_compilation_waiter_count{0};
     uint64_t process_compilation_shared_byte_count{0};
-    uint64_t resource_cache_request_count{0};
-    uint64_t resource_cache_hit_count{0};
-    uint64_t resource_cache_miss_count{0};
-    uint64_t resource_cache_rejection_count{0};
-    uint64_t resource_cache_bytes_read_count{0};
-    uint64_t resource_cache_bytes_written_count{0};
-    uint64_t resource_cache_memory_hit_count{0};
+    std::atomic<uint64_t> resource_cache_request_count{0};
+    std::atomic<uint64_t> resource_cache_hit_count{0};
+    std::atomic<uint64_t> resource_cache_miss_count{0};
+    std::atomic<uint64_t> resource_cache_rejection_count{0};
+    std::atomic<uint64_t> resource_cache_bytes_read_count{0};
+    std::atomic<uint64_t> resource_cache_bytes_written_count{0};
+    std::atomic<uint64_t> resource_cache_memory_hit_count{0};
     std::atomic<uint64_t> process_resource_memory_hit_count{0};
     std::atomic<uint64_t> process_resource_load_leader_count{0};
     std::atomic<uint64_t> process_resource_load_waiter_count{0};
@@ -309,6 +319,9 @@
     bool batch_style_recascades{true};
     bool batch_connected_resource_style_recascades{true};
     bool prefetch_iframe_documents{true};
+    bool prepare_iframe_subresources{true};
+    bool defer_compilation_cache_touches{true};
+    bool cooperative_iframe_hydration{true};
     bool filter_stylesheet_candidates{true};
     uint32_t style_recascade_batch_depth{0};
     std::vector<pending_style_recascade> pending_style_recascades;
@@ -371,8 +384,16 @@
     binding_callback_stats startup_subtree_recascade{};
     binding_callback_stats startup_stylesheet_recascade{};
     binding_callback_stats startup_script_execute{};
+    binding_callback_stats startup_script_compile{};
+    binding_callback_stats startup_script_run{};
     binding_callback_stats startup_layout{};
     binding_callback_stats startup_frame_hydrate{};
+    binding_callback_stats startup_frame_prepare{};
+    binding_callback_stats startup_frame_prepare_wait{};
+    uint64_t startup_frame_prepare_lead_nanoseconds{0};
+    uint64_t startup_frame_hydration_slices{0};
+    uint64_t startup_frame_hydration_yields{0};
+    uint64_t startup_frame_hydration_max_slice_nanoseconds{0};
     uint64_t startup_stylesheet_recascade_nodes{0};
     uint64_t startup_stylesheet_candidate_nodes{0};
     uint64_t startup_stylesheet_variable_nodes{0};

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state_types.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state_types.inc
@@ -124,6 +124,63 @@
         std::vector<node_style::rotation_keyframe> rotation_stops;
     };
 
+    enum class hover_invalidation_scope : uint8_t
+    {
+        subject,
+        subtree,
+        siblings
+    };
+
+    struct hover_selector_dependency final
+    {
+        std::string trigger_compound;
+        hover_invalidation_scope scope{hover_invalidation_scope::subject};
+    };
+
+    // A browser document owns an independent cascade. Keeping this movable
+    // makes switching realms an O(1) exchange of vector/map storage, while the
+    // active realm retains the existing direct-field hot path.
+    struct css_cascade_state final {
+        std::vector<css_rule> rules;
+        uint32_t stylesheet_owner_id{0};
+        uint32_t stylesheet_shadow_scope_root_id{0};
+        std::unordered_map<std::string, css_opacity_keyframes> opacity_keyframes;
+        std::unordered_map<std::string, std::vector<size_t>> rules_by_class;
+        std::unordered_map<std::string, std::vector<size_t>> rules_by_id;
+        std::unordered_map<std::string, std::vector<size_t>> rules_by_tag;
+        std::unordered_map<std::string, std::vector<size_t>> rules_by_attribute;
+        std::unordered_map<std::string, std::vector<size_t>>
+            rules_by_variable_reference;
+        std::vector<size_t> focus_rules;
+        std::vector<size_t> unindexed_rules;
+        std::unordered_set<std::string> attribute_dependencies;
+        std::vector<hover_selector_dependency> hover_dependencies;
+        std::unordered_map<std::string, std::string> variables;
+        std::unordered_set<std::string> important_variables;
+    };
+
+    enum class frame_hydration_phase : uint8_t {
+        blocking_scripts,
+        deferred_scripts,
+        lifecycle
+    };
+
+    struct frame_hydration_state final {
+        dom_node* body{nullptr};
+        std::vector<frame_script> scripts;
+        std::string body_opening;
+        std::string base_address;
+        v8::Global<v8::Context> context;
+        size_t next_script{0U};
+        frame_hydration_phase phase{frame_hydration_phase::blocking_scripts};
+    };
+
+    enum class frame_hydration_result : uint8_t {
+        complete,
+        pending,
+        failed
+    };
+
     struct connected_resource_task final {
         dom_node* node;
         v8::Global<v8::Context> context;
@@ -381,6 +438,23 @@
         bool loaded{false};
         bool has_cached{false};
         bool from_fresh_cache{false};
+    };
+
+    struct prepared_frame final {
+        std::string source;
+        std::string html;
+        std::string base_address;
+        std::string html_opening;
+        std::string body_opening;
+        std::vector<std::string> stylesheets;
+        std::vector<frame_script> scripts;
+        std::chrono::steady_clock::time_point started{};
+        std::chrono::steady_clock::time_point completed{};
+    };
+
+    struct pending_frame_preparation final {
+        std::string source;
+        std::shared_future<std::shared_ptr<const prepared_frame>> future;
     };
 
     struct shared_isolate_state final {

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_tasks.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_tasks.inc
@@ -47,6 +47,7 @@
 #endif
             return true;
         }
+        activate_css_cascade(task_context);
         v8::Context::Scope task_context_scope(task_context);
         auto callback = task.callback.Get(isolate);
         if (callback.IsEmpty()) {
@@ -281,6 +282,7 @@
             || wrapper.IsEmpty()) {
             return true;
         }
+        activate_css_cascade(resource_context);
         v8::Context::Scope resource_scope(resource_context);
         // A dynamically loaded script, its load event, and the resulting
         // microtasks form one browser task. Keep style invalidations pending
@@ -346,6 +348,7 @@
             return true;
         }
 
+        activate_css_cascade(target_context);
         v8::Context::Scope target_scope(target_context);
         auto target_global = target_context->Global();
         v8::Local<v8::Value> location_value;
@@ -453,6 +456,7 @@
         auto task_context = task.context.Get(isolate);
         auto* target = document.find_by_native_id(task.target_id);
         if (target == nullptr || task_context.IsEmpty()) return true;
+        activate_css_cascade(task_context);
         v8::Context::Scope task_context_scope(task_context);
         webscene_input_event input{};
         input.sequence = task.input_sequence;
@@ -460,6 +464,41 @@
         if (dispatch_input_event_type(input, "scroll", *target)) return true;
         last_error = "Programmatic scroll dispatch failed: "
             + describe_exception(try_catch, task_context);
+        return false;
+    }
+
+    bool drain_frame_hydration_task()
+    {
+        if (pending_frame_hydrations.empty()) return true;
+        auto* frame = pending_frame_hydrations.front();
+        pending_frame_hydrations.erase(pending_frame_hydrations.begin());
+        if (frame == nullptr) return true;
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+        const auto started = std::chrono::steady_clock::now();
+        if (profile_startup) ++startup_frame_hydration_slices;
+#endif
+        const auto result = hydrate_frame(*frame);
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+        if (profile_startup) {
+            const auto elapsed = static_cast<uint64_t>(
+                std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::steady_clock::now() - started).count());
+            startup_frame_hydration_max_slice_nanoseconds = std::max(
+                startup_frame_hydration_max_slice_nanoseconds,
+                elapsed);
+            if (result == frame_hydration_result::pending) {
+                ++startup_frame_hydration_yields;
+            }
+        }
+#endif
+        if (result == frame_hydration_result::pending) {
+            pending_frame_hydrations.push_back(frame);
+            return true;
+        }
+        if (result == frame_hydration_result::complete) return true;
+        frame->attributes["data-webscene-frame-error"] =
+            frame_last_error_value;
+        last_error = frame_last_error_value;
         return false;
     }
 
@@ -479,18 +518,22 @@
         if (!pending_programmatic_scroll_events.empty()) {
             return drain_programmatic_scroll_event_task();
         }
-        if (!pending_frame_hydrations.empty()) {
-            auto* frame = pending_frame_hydrations.front();
-            pending_frame_hydrations.erase(pending_frame_hydrations.begin());
-            if (frame != nullptr && !hydrate_frame(*frame)) {
-                frame->attributes["data-webscene-frame-error"] =
-                    frame_last_error_value;
-                last_error = frame_last_error_value;
-                return false;
-            }
-            return true;
-        }
         const auto timer_due = has_due_timer();
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+        const auto cooperative_frames = cooperative_iframe_hydration;
+#else
+        constexpr auto cooperative_frames = true;
+#endif
+        const auto competing_task_ready = timer_due
+            || !connected_resources.empty()
+            || resize_observers_pending;
+        if (!pending_frame_hydrations.empty()
+            && (!cooperative_frames
+                || !competing_task_ready
+                || prefer_frame_hydration_task)) {
+            prefer_frame_hydration_task = false;
+            return drain_frame_hydration_task();
+        }
         // Dynamically connected resources and zero-delay timers are separate
         // browser task sources. Do not starve React/datafeed timers behind an
         // entire Webpack resource wave; alternate when both are ready.
@@ -499,10 +542,12 @@
             // Preparing a large warm-cache resource wave can itself take a few
             // milliseconds. Only do that work once this task source has won
             // the fairness decision, so an already-due timer runs promptly.
+            prefer_frame_hydration_task = true;
             return drain_connected_resource_task();
         }
         if (resize_observers_pending) {
             resize_observers_pending = false;
+            prefer_frame_hydration_task = true;
             ensure_layout();
             return dispatch_resize_observers();
         }
@@ -515,6 +560,7 @@
         auto task = std::move(*next);
         timers.erase(next);
         prefer_timer_task = false;
+        prefer_frame_hydration_task = true;
         return execute_timer_task(std::move(task), now_time);
     }
 
@@ -692,6 +738,7 @@
         auto isolate_locker = lock_shared_isolate();
         v8::Isolate::Scope isolate_scope(isolate);
         v8::HandleScope handle_scope(isolate);
+        activate_css_cascade(context.Get(isolate));
         {
             auto local_context = context.Get(isolate);
             v8::Context::Scope context_scope(local_context);
@@ -757,32 +804,30 @@
                 outer_listeners_finished - resize_started).count());
 #endif
 
-        // Responsive stylesheet rules depend on the current host viewport.
-        // The compact runtime retains the active browsing context's stylesheet
-        // index. Once an iframe is hydrated, applying that index to the outer
-        // document erases its already-cascaded percentage sizing (including a
-        // host chart_container and the iframe itself). Re-cascade only the root
-        // that owns the active rules; layout below still recomputes the unified
-        // native tree against the new host viewport.
-        if (refresh_css_media_matches()) {
-            // Only a media-query truth transition changes the cascade. Relative
-            // lengths (percent, vw/vh, calc) are retained as computed terms and
-            // resolve against the new viewport during layout; recascading the
-            // entire component tree on every intermediate resize frame turns a
-            // 60 Hz drag into a 30 Hz one.
+        // Media matches and selector indexes belong to each browsing context.
+        // Recompute only contexts whose query truth changed, retaining relative
+        // lengths for layout to resolve against the new host viewport.
+        const auto refresh_context_styles = [&](v8::Local<v8::Context> css_context) {
+            if (css_context.IsEmpty()) return;
+            activate_css_cascade(css_context);
+            v8::Context::Scope css_context_scope(css_context);
+            if (!refresh_css_media_matches()) return;
             rebuild_css_rule_indexes_and_root_variables();
-            if (frame_context.IsEmpty()) {
-                apply_css_rules_subtree(document.body());
-            } else {
-                auto resize_frame_context = frame_context.Get(isolate);
-                v8::Context::Scope resize_frame_scope(resize_frame_context);
-                apply_css_rules_subtree(active_root());
+            apply_css_rules_subtree(active_root());
+        };
+        refresh_context_styles(context.Get(isolate));
+        for (auto& [id, persistent_context] : actual_frame_contexts) {
+            static_cast<void>(id);
+            if (!persistent_context.IsEmpty()) {
+                refresh_context_styles(persistent_context.Get(isolate));
             }
         }
+        activate_css_cascade(context.Get(isolate));
 
         if (frame_context.IsEmpty()) return true;
         {
             auto local_frame_context = frame_context.Get(isolate);
+            activate_css_cascade(local_frame_context);
             v8::Context::Scope frame_scope(local_frame_context);
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
             v8::Local<v8::String> cpu_profile_title;
@@ -2186,6 +2231,7 @@
         auto local_context = frame_context.IsEmpty()
             ? context.Get(isolate)
             : frame_context.Get(isolate);
+        activate_css_cascade(local_context);
         v8::Context::Scope context_scope(local_context);
         ensure_layout();
         v8::TryCatch try_catch(isolate);

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_frame_scheduling_tests.inc
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_frame_scheduling_tests.inc
@@ -261,6 +261,94 @@ void test_frame_script_dom_presence(webscene_engine* engine)
         "contentDocument queries escaped the frame document boundary: " + boundary);
 }
 
+std::string measure_cooperative_iframe_task_order(bool disable_cooperation)
+{
+#if defined(_WIN32)
+    _putenv_s(
+        "WEBSCENE_PROBE_DISABLE_COOPERATIVE_IFRAME_HYDRATION",
+        disable_cooperation ? "1" : "");
+#else
+    if (disable_cooperation) {
+        setenv("WEBSCENE_PROBE_DISABLE_COOPERATIVE_IFRAME_HYDRATION", "1", 1);
+    } else {
+        unsetenv("WEBSCENE_PROBE_DISABLE_COOPERATIVE_IFRAME_HYDRATION");
+    }
+#endif
+    auto* engine = webscene_engine_create(0);
+    require(engine != nullptr, "cooperative iframe engine creation failed");
+    execute(engine, R"JS(
+        (() => {
+          document.body.innerHTML = '';
+          const outerStyle = document.createElement('style');
+          outerStyle.textContent = '.cascade-target { color: rgb(170, 0, 0); }';
+          document.body.appendChild(outerStyle);
+          const outer = document.createElement('div');
+          outer.className = 'cascade-target';
+          document.body.appendChild(outer);
+          globalThis.__iframeTaskOrder = [];
+          globalThis.__outerCascadeTarget = outer;
+          setTimeout(() => __iframeTaskOrder.push('timer'), 0);
+          const frame = document.createElement('iframe');
+          document.body.appendChild(frame);
+          const frameDocument = frame.contentDocument;
+          frameDocument.open();
+          frameDocument.write(
+            '<html><style>.cascade-target { color: rgb(0, 0, 187); }</style><body>'
+            + '<div class="cascade-target" id="inner"></div>'
+            + '<script>'
+            + 'parent.__iframeTaskOrder.push("blocking");'
+            + 'parent.__innerCascadeColor = getComputedStyle('
+            + 'document.getElementById("inner")).color;'
+            + 'addEventListener("DOMContentLoaded", () => '
+            + 'parent.__iframeTaskOrder.push("dom"));'
+            + 'addEventListener("load", () => parent.__iframeTaskOrder.push("load"));'
+            + 'const deadline = Date.now() + 20; while (Date.now() < deadline) {}'
+            + '<\/script>'
+            + '<script defer>parent.__iframeTaskOrder.push("deferred");<\/script>'
+            + '</body></html>');
+          frameDocument.close();
+        })()
+    )JS", "cooperative-iframe-order.js");
+    auto result = std::string{};
+    for (auto attempt = 0; attempt < 250; ++attempt) {
+        if (evaluate(
+                engine,
+                "globalThis.__iframeTaskOrder.length",
+                "cooperative-iframe-progress.js") == "5") {
+            result = evaluate(engine, R"JS((() => ({
+              order: globalThis.__iframeTaskOrder,
+              outer: getComputedStyle(globalThis.__outerCascadeTarget).color,
+              inner: globalThis.__innerCascadeColor
+            }))())JS", "cooperative-iframe-result.js");
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    webscene_engine_destroy(engine);
+#if defined(_WIN32)
+    _putenv_s("WEBSCENE_PROBE_DISABLE_COOPERATIVE_IFRAME_HYDRATION", "");
+#else
+    unsetenv("WEBSCENE_PROBE_DISABLE_COOPERATIVE_IFRAME_HYDRATION");
+#endif
+    return result;
+}
+
+void test_cooperative_iframe_hydration_yields_and_isolates_cascade()
+{
+    const auto optimized = measure_cooperative_iframe_task_order(false);
+    require(
+        optimized == R"JSON({"order":["blocking","timer","deferred","dom","load"],"outer":"rgb(170, 0, 0)","inner":"rgb(0, 0, 187)"})JSON",
+        "cooperative iframe hydration did not yield or isolate cascade state: "
+            + optimized);
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+    const auto control = measure_cooperative_iframe_task_order(true);
+    require(
+        control == R"JSON({"order":["blocking","deferred","dom","load","timer"],"outer":"rgb(170, 0, 0)","inner":"rgb(0, 0, 187)"})JSON",
+        "cooperative iframe A/B control did not restore monolithic ordering: "
+            + control);
+#endif
+}
+
 #if defined(WEBSCENE_NATIVE_ENGINE_HTML5EVER)
 void test_html5ever_frame_does_not_duplicate_authored_loading_indicator(
     webscene_engine* engine)

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_resource_tests.inc
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_resource_tests.inc
@@ -5,6 +5,9 @@ struct resource_server final {
     std::atomic<int> active_documents{0};
     std::atomic<int> peak_documents{0};
     std::atomic<int> requests{0};
+    std::chrono::steady_clock::time_point observation_start{};
+    std::atomic<int64_t> first_subresource_start_ms{
+        std::numeric_limits<int64_t>::max()};
 };
 
 size_t load_test_resource(
@@ -30,6 +33,19 @@ size_t load_test_resource(
     const auto first_transfer = destination == nullptr
         || destination_capacity != required;
     if (first_transfer && !address.ends_with("index.html")) {
+        if (kind != WEBSCENE_RESOURCE_DOCUMENT
+            && server.observation_start != std::chrono::steady_clock::time_point{}) {
+            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - server.observation_start).count();
+            auto earliest = server.first_subresource_start_ms.load(
+                std::memory_order_relaxed);
+            while (elapsed < earliest
+                && !server.first_subresource_start_ms.compare_exchange_weak(
+                    earliest,
+                    elapsed,
+                    std::memory_order_relaxed)) {
+            }
+        }
         server.requests.fetch_add(1, std::memory_order_relaxed);
         const auto active = server.active.fetch_add(1, std::memory_order_relaxed) + 1;
         auto peak = server.peak.load(std::memory_order_relaxed);
@@ -1719,6 +1735,113 @@ void test_dynamic_frame_resources_use_each_document_base_url()
         "cross-origin frame messages did not expose the sender origin: "
             + message_origins);
     webscene_engine_destroy(engine);
+}
+
+int64_t measure_iframe_subresource_discovery(bool disable_preparation)
+{
+#if defined(_WIN32)
+    _putenv_s(
+        "WEBSCENE_PROBE_DISABLE_IFRAME_PREPARATION",
+        disable_preparation ? "1" : "");
+#else
+    if (disable_preparation) {
+        setenv("WEBSCENE_PROBE_DISABLE_IFRAME_PREPARATION", "1", 1);
+    } else {
+        unsetenv("WEBSCENE_PROBE_DISABLE_IFRAME_PREPARATION");
+    }
+#endif
+    const auto host = disable_preparation
+        ? std::string("https://frame-preparation-control.test")
+        : std::string("https://frame-preparation-enabled.test");
+    resource_server server{
+        .content = {
+            {host + "/index.html", R"HTML(
+                <html><body>
+                  <script>
+                    const frame = document.createElement('iframe');
+                    frame.src = 'frame.html';
+                    document.body.appendChild(frame);
+                    const stop = performance.now() + 180;
+                    while (performance.now() < stop) {}
+                  </script>
+                </body></html>)HTML"},
+            {host + "/frame.html", R"HTML(
+                <html><head><link rel="stylesheet" href="frame.css"></head>
+                <body><script src="frame.js"></script></body></html>)HTML"},
+            {host + "/frame.css", "body { color: rgb(1, 2, 3); }"},
+            {host + "/frame.js", "parent.__framePreparationLoaded = true;"}
+        }};
+    const webscene_engine_options options{
+        sizeof(webscene_engine_options),
+        64U,
+        nullptr,
+        0U,
+        load_test_resource,
+        &server};
+    auto* engine = webscene_engine_create_with_options(&options);
+    require(engine != nullptr, "iframe-preparation engine creation failed");
+    constexpr std::string_view start_source{"globalThis.__documentStartRan = true;"};
+    constexpr std::string_view start_name{"iframe-preparation-start.js"};
+    const webscene_document_script script{
+        sizeof(webscene_document_script),
+        WEBSCENE_DOCUMENT_SCRIPT_ALL_FRAMES,
+        start_source.data(), start_source.size(),
+        start_name.data(), start_name.size()};
+    const webscene_navigation_options navigation{
+        sizeof(webscene_navigation_options),
+        1U,
+        &script};
+    const auto url = host + "/index.html";
+    server.observation_start = std::chrono::steady_clock::now();
+    require(
+        webscene_engine_load_url_with_options(
+            engine,
+            url.data(),
+            url.size(),
+            &navigation) != 0U,
+        "iframe-preparation navigation failed");
+    const auto frame_result = evaluate(
+        engine,
+        "(() => { const frame = document.querySelector('iframe'); return {"
+        "count: document.querySelectorAll('iframe').length,"
+        "window: frame ? typeof frame.contentWindow : 'missing',"
+        "loaded: globalThis.__framePreparationLoaded,"
+        "error: frame && frame.getAttribute('data-webscene-frame-error')"
+        "}; })()",
+        "iframe-preparation-result.js");
+    require(
+        frame_result == R"({"count":1,"window":"object","loaded":true,"error":null})",
+        "prepared iframe resources did not preserve script execution: "
+            + frame_result + " diagnostics=" + diagnostics(engine));
+    const auto result = server.first_subresource_start_ms.load(
+        std::memory_order_relaxed);
+    webscene_engine_destroy(engine);
+    return result;
+}
+
+void test_iframe_preparation_discovers_subresources_during_outer_script()
+{
+    const auto prepared_start = measure_iframe_subresource_discovery(false);
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+    const auto control_start = measure_iframe_subresource_discovery(true);
+#if defined(_WIN32)
+    _putenv_s("WEBSCENE_PROBE_DISABLE_IFRAME_PREPARATION", "");
+#else
+    unsetenv("WEBSCENE_PROBE_DISABLE_IFRAME_PREPARATION");
+#endif
+    require(
+        prepared_start != std::numeric_limits<int64_t>::max()
+            && control_start != std::numeric_limits<int64_t>::max(),
+        "iframe subresource discovery was not observed");
+    require(
+        prepared_start + 70 < control_start,
+        "iframe preparation did not overlap discovery with outer script work");
+#else
+    require(
+        prepared_start != std::numeric_limits<int64_t>::max()
+            && prepared_start < 140,
+        "iframe preparation did not discover subresources during outer script work");
+#endif
 }
 
 void test_deferred_frame_script_observes_window_dom_content_loaded()

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_tests.cpp
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_tests.cpp
@@ -150,8 +150,16 @@ int main()
             test_dynamic_frame_resources_use_each_document_base_url();
             return 0;
         }
+        if (selected == "iframe-preparation") {
+            test_iframe_preparation_discovers_subresources_during_outer_script();
+            return 0;
+        }
         if (selected == "frame-lifecycle") {
             test_deferred_frame_script_observes_window_dom_content_loaded();
+            return 0;
+        }
+        if (selected == "iframe-cooperative") {
+            test_cooperative_iframe_hydration_yields_and_isolates_cascade();
             return 0;
         }
         if (selected == "scrollspy-primitives") {
@@ -249,7 +257,9 @@ int main()
     test_resource_cache_policy_matrix();
     test_due_timer_precedes_dynamic_resource_wave();
     test_dynamic_frame_resources_use_each_document_base_url();
+    test_iframe_preparation_discovers_subresources_during_outer_script();
     test_deferred_frame_script_observes_window_dom_content_loaded();
+    test_cooperative_iframe_hydration_yields_and_isolates_cascade();
     test_animation_frame_demand_emits_idle_to_active_edges();
     test_dynamic_stylesheet_custom_properties_preserve_cascade_order();
     test_persistent_compilation_cache_reuse();

--- a/samples/NativeTradingViewTerminal/README.md
+++ b/samples/NativeTradingViewTerminal/README.md
@@ -144,6 +144,26 @@ dynamic-resource boundary, which flushed after script evaluation and then ran it
 Use `WEBSCENE_PROBE_DISABLE_IFRAME_DOCUMENT_PREFETCH=1` to restore synchronous
 remote iframe-document acquisition at `appendChild`; CSS/script execution order is
 unchanged by this control.
+Use `WEBSCENE_PROBE_DISABLE_IFRAME_PREPARATION=1` to retain concurrent iframe
+document fetches but restore owner-thread HTML scanning and CSS/script discovery.
+The optimized path scans a completed remote frame document off the isolate and starts
+its subresource prefetches while the outer document is still executing; DOM creation,
+V8 context installation, script execution, and lifecycle dispatch remain ordered on
+the owner thread. Startup telemetry reports `frame-prepare`, `frame-prepare-wait`,
+and `frame-prepare-lead`.
+
+Use `WEBSCENE_PROBE_DISABLE_COOPERATIVE_IFRAME_HYDRATION=1` to restore the former
+single-task iframe hydration and strict frame-before-timer/resource task ordering.
+The optimized path retains an independent cascade/index per browsing context,
+executes blocking and deferred script groups as resumable owner-thread work, and
+alternates yielded frame work with already-ready timer, resource, and resize-observer
+tasks. Startup telemetry reports `frame-slices`, `frame-yields`, and
+`frame-max-slice`. Individual JavaScript calls remain atomic inside V8.
+
+Use `WEBSCENE_PROBE_DISABLE_DEFERRED_COMPILATION_CACHE_TOUCH=1` to restore an
+immediate filesystem timestamp update on every persistent V8 code-cache hit. The
+optimized path records cache use in memory and flushes deduplicated timestamps during
+runtime teardown, while cache pruning treats pending touches as recent.
 
 Use `WEBSCENE_PROBE_DISABLE_STYLESHEET_CANDIDATE_FILTER=1` to restore the legacy
 connected-stylesheet path that finalizes and dirties every existing element, even
@@ -211,6 +231,37 @@ preserving ordered single-isolate hydration improved all five interleaved strict
 pairs: median navigation fell from 953.4 ms to 934.4 ms (-19.0 ms, -2.0%), and cold
 host-to-ready from 1,038.5 ms to 1,016.2 ms (-22.3 ms, -2.1%). A delayed native host
 loader regression also requires two remote iframe document requests to overlap.
+
+The follow-up frame-preparation path moves subresource discovery ahead of owner-thread
+hydration. A delayed-loader A/B regression observes discovery at least 70 ms earlier
+while an outer script is busy and verifies that the prepared external frame script still
+executes. Across five interleaved strict-replay pairs with warm code cache and cold
+resource cache, median iframe hydration fell from 104.6 ms to 97.5 ms (-7.1 ms,
+-6.8%). Median preparation CPU was 0.5 ms, owner-thread preparation wait was 0.002 ms,
+and preparation-to-consumption lead was 7.4 ms. Navigation medians were effectively
+flat at 929.3 ms control and 931.7 ms optimized, so this result supports earlier I/O
+overlap rather than a chart-ready wall-time claim.
+
+Separating script compilation from execution showed that persistent-cache bookkeeping,
+not V8 parsing, was the next cache-path cost. With all 129 persistent entries accepted,
+V8 compilation itself took about 4.5 ms, while `compile_script` included dozens of
+milliseconds of cache reads, validation, and per-hit timestamp writes. Deferring and
+deduplicating those timestamp writes reduced the five-run median compile phase from
+59.7 ms to 53.5 ms (-6.2 ms, -10.4%). Navigation medians favored the optimized path
+in four of five interleaved pairs, but live market-data variance remains too large for a
+wall-time claim.
+
+Cooperative iframe hydration was then measured in five interleaved warm-code-cache
+strict-replay pairs. It split the two frame hydrations from two monolithic tasks into
+six slices with four scheduler yields. Median maximum frame-task duration fell from
+65.6 ms to 59.7 ms (-5.9 ms, -9.0%), while navigation-to-ready remained flat at
+872.9 ms control versus 874.3 ms optimized. A deterministic A/B regression also
+verifies that a due outer timer runs after a long blocking frame script but before the
+frame's deferred script and lifecycle; the control runs that timer only after `load`.
+The same regression proves outer and frame stylesheets retain independent cascade
+results. The residual roughly 55 ms TradingView library script is one atomic V8 call,
+so further scheduler slicing cannot remove that long task without application-level
+code splitting or a separate isolate/worker architecture.
 
 Run the Sandwich Trading Platform multi-chart geometry proof with a
 deterministic in-process market-data bridge:


### PR DESCRIPTION
## Summary

- prepare remote iframe documents and discover CSS/script subresources ahead of owner-thread hydration
- defer persistent V8 cache timestamp writes and deduplicate them at teardown
- isolate CSS cascade/index state per browsing context
- split iframe hydration into resumable blocking-script, deferred-script, and lifecycle stages
- alternate yielded iframe work with due timer, resource, and resize-observer task sources
- add deterministic A/B regressions and document strict-replay TradingView results

## Performance

Five interleaved warm-code-cache strict-replay pairs:

- maximum iframe task slice: **65.6 ms → 59.7 ms** (**-9.0%**)
- navigation-to-ready: **872.9 ms control vs 874.3 ms optimized** (effectively flat)
- two monolithic frame hydrations become six slices with four scheduler yields

The remaining roughly 55 ms long task is a single atomic TradingView V8 invocation, so no total chart-ready improvement is claimed.

## Validation

- certification html5ever/cssparser runtime: 4/4 tests passed
- production html5ever/cssparser/Servo/generated-bindings/bootstrap/PartitionAlloc runtime: 4/4 tests passed
- legacy CSS certification configuration: builds successfully
- `git diff --check origin/main..HEAD`
