### PR TITLE
Optimize resize-driven CSSOM layout invalidation

### DIFF
--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime.cpp
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime.cpp
@@ -4070,6 +4070,8 @@ std::string v8_dom_runtime::event_diagnostics() const
         append_counts(
             "resize-geometry",
             impl_->last_resize_geometry_counts);
+        result << ", resize-redundant-style-writes="
+            << impl_->last_resize_redundant_style_writes;
     }
     if (!impl_->last_resize_cpu_profile.empty()) {
         result << ", resize-cpu=" << impl_->last_resize_cpu_profile;

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_dom_core.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_dom_core.inc
@@ -509,9 +509,6 @@
             document.mark_scene_changed();
             return;
         }
-        const auto isolated_out_of_flow_geometry =
-            node.style.position == position_mode::absolute
-            || node.style.position == position_mode::fixed;
         const auto changes_only_positioned_subtree =
             canonical_property_name == "width"
             || canonical_property_name == "height"
@@ -523,8 +520,23 @@
             || canonical_property_name == "top"
             || canonical_property_name == "right"
             || canonical_property_name == "bottom";
-        if (isolated_out_of_flow_geometry && changes_only_positioned_subtree) {
-            document.mark_out_of_flow_geometry_dirty(node);
+        dom_node* isolated_geometry_root = nullptr;
+        if (changes_only_positioned_subtree) {
+            for (auto* current = &node; current != nullptr;
+                 current = current->parent) {
+                if (current->style.position != position_mode::absolute
+                    && current->style.position != position_mode::fixed) {
+                    continue;
+                }
+                isolated_geometry_root = current;
+                break;
+            }
+        }
+        if (isolated_geometry_root != nullptr) {
+            // A descendant can resize an auto-sized positioned ancestor, but
+            // that subtree remains outside normal flow. Keep its pending work
+            // scoped so geometry reads elsewhere do not traverse the document.
+            document.mark_out_of_flow_geometry_dirty(*isolated_geometry_root);
         } else {
             document.mark_dirty();
         }

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state.inc
@@ -363,6 +363,7 @@
     std::unordered_map<std::string, uint64_t> last_resize_style_target_counts;
     std::unordered_map<std::string, uint64_t> last_resize_attribute_counts;
     std::unordered_map<std::string, uint64_t> last_resize_geometry_counts;
+    uint64_t last_resize_redundant_style_writes{0};
     std::string last_resize_cpu_profile;
     binding_callback_stats startup_resource_read{};
     binding_callback_stats startup_css_parse{};

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_style.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_style.inc
@@ -510,9 +510,23 @@
         if (!valid_cssom_declaration_value(name, value)) return;
         const auto canonical_name = canonical_css_property_name(name);
         auto& authored = node->mutable_authored_style();
-        authored.declarations[canonical_name] = serialize_cssom_specified_value(
+        const auto specified_value = serialize_cssom_specified_value(
             canonical_name,
             value);
+        const auto existing = authored.declarations.find(canonical_name);
+        if (existing != authored.declarations.end()
+            && existing->second == specified_value
+            && !authored.important_declarations.contains(canonical_name)) {
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+            if (self->resize_profile_active) {
+                ++self->last_resize_redundant_style_writes;
+            }
+#endif
+            self->notify_custom_element_attribute(
+                *node, "style", old_value, node->attributes.at("style"));
+            return;
+        }
+        authored.declarations[canonical_name] = specified_value;
         authored.important_declarations.erase(canonical_name);
         if (apply_grid_placement_declaration(node->style, name, value)) {
             // Placement CSSOM is stored as computed tokens; layout consumes the
@@ -1815,9 +1829,23 @@
         if (!valid_cssom_declaration_value(name, value)) return;
         const auto canonical_name = canonical_css_property_name(name);
         auto& authored = node->mutable_authored_style();
-        authored.declarations[canonical_name] = serialize_cssom_specified_value(
+        const auto specified_value = serialize_cssom_specified_value(
             canonical_name,
             value);
+        const auto existing = authored.declarations.find(canonical_name);
+        if (existing != authored.declarations.end()
+            && existing->second == specified_value
+            && !authored.important_declarations.contains(canonical_name)) {
+#if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
+            if (self->resize_profile_active) {
+                ++self->last_resize_redundant_style_writes;
+            }
+#endif
+            self->notify_custom_element_attribute(
+                *node, "style", old_value, node->attributes.at("style"));
+            return;
+        }
+        authored.declarations[canonical_name] = specified_value;
         authored.important_declarations.erase(canonical_name);
         if (apply_grid_placement_declaration(node->style, name, value)) {
             // Placement CSSOM is stored as computed tokens; layout consumes the

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_tasks.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_tasks.inc
@@ -677,6 +677,7 @@
                     owner.last_resize_style_target_counts.clear();
                     owner.last_resize_attribute_counts.clear();
                     owner.last_resize_geometry_counts.clear();
+                    owner.last_resize_redundant_style_writes = 0;
                 }
             }
 

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_animation_cssom_tests.inc
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_animation_cssom_tests.inc
@@ -429,6 +429,95 @@ void test_cssom_paint_invalidation_does_not_force_layout(
         changed_height == "41",
         "a changed CSSOM layout declaration did not update synchronous geometry: "
             + changed_height);
+    webscene_engine_metrics after_changed_height{};
+    webscene_engine_get_metrics(engine, &after_changed_height);
+
+    execute_and_wait(engine, R"JS(
+        (() => {
+          const target = document.getElementById('invalidation');
+          target.style.height = '41px';
+          target.style.setProperty('height', '41px');
+        })()
+    )JS", "cssom-unchanged-layout-value.js");
+    const auto unchanged_height = evaluate(
+        engine,
+        "document.getElementById('invalidation').offsetHeight",
+        "cssom-unchanged-layout-geometry-barrier.js");
+    webscene_engine_metrics after_unchanged_height{};
+    webscene_engine_get_metrics(engine, &after_unchanged_height);
+    require(
+        unchanged_height == "41"
+            && after_unchanged_height.layout_passes
+                == after_changed_height.layout_passes,
+        "an unchanged CSSOM layout declaration repeated document layout");
+
+    const auto custom_element_reactions = evaluate(engine, R"JS(
+        (() => {
+          const reactions = [];
+          class CssomIdempotenceObserver extends HTMLElement {
+            static observedAttributes = ['style'];
+            attributeChangedCallback(name, oldValue, newValue) {
+              reactions.push(`${name}:${oldValue}->${newValue}`);
+            }
+          }
+          customElements.define(
+            'cssom-idempotence-observer',
+            CssomIdempotenceObserver);
+          const target = document.createElement('cssom-idempotence-observer');
+          target.style.height = '41px';
+          reactions.length = 0;
+          target.style.height = '41px';
+          target.style.setProperty('height', '41px');
+          return reactions;
+        })()
+    )JS", "cssom-unchanged-custom-element-reactions.js");
+    require(
+        custom_element_reactions
+            == R"(["style:height: 41px;->height: 41px;","style:height: 41px;->height: 41px;"])",
+        "unchanged CSSOM declarations suppressed observable custom-element reactions: "
+            + custom_element_reactions);
+
+    execute_and_wait(engine, R"JS(
+        (() => {
+          document.body.innerHTML = `
+            <div id="toolbar" style="width: 300px; height: 32px"></div>
+            <div id="overlay" style="position: absolute; width: 200px">
+              <div id="overlay-child" style="width: 100px; height: 20px"></div>
+            </div>`;
+          void document.getElementById('overlay-child').offsetWidth;
+        })()
+    )JS", "cssom-positioned-subtree-invalidation-setup.js");
+    webscene_engine_metrics positioned_baseline{};
+    webscene_engine_get_metrics(engine, &positioned_baseline);
+    const auto unrelated_height = evaluate(engine, R"JS(
+        (() => {
+          document.getElementById('overlay-child').style.width = '120px';
+          return document.getElementById('toolbar').clientHeight;
+        })()
+    )JS", "cssom-positioned-subtree-unrelated-geometry.js");
+    webscene_engine_metrics after_unrelated_geometry{};
+    webscene_engine_get_metrics(engine, &after_unrelated_geometry);
+    require(
+        unrelated_height == "32"
+            && after_unrelated_geometry.layout_passes
+                == positioned_baseline.layout_passes,
+        "a positioned-subtree CSSOM mutation invalidated unrelated client geometry");
+
+    const auto changed_child_width = evaluate(
+        engine,
+        "document.getElementById('overlay-child').clientWidth",
+        "cssom-positioned-subtree-changed-geometry.js");
+    webscene_engine_metrics after_changed_child_geometry{};
+    webscene_engine_get_metrics(engine, &after_changed_child_geometry);
+    require(
+        changed_child_width == "120"
+            && after_changed_child_geometry.layout_passes
+                <= positioned_baseline.layout_passes + 1,
+        "positioned-subtree geometry exposed stale or excessive layout state: width="
+            + changed_child_width + ", baseline-passes="
+            + std::to_string(positioned_baseline.layout_passes)
+            + ", after-passes="
+            + std::to_string(after_changed_child_geometry.layout_passes));
 }
 
 void test_client_rect_reads_reuse_unrelated_out_of_flow_layout(


### PR DESCRIPTION
## Summary

- skip redundant normal-priority CSSOM writes without repeating style/layout invalidation
- preserve Chrome-compatible custom-element attribute reactions for identical style assignments
- scope size and inset invalidation to the nearest positioned subtree so unrelated geometry reads can reuse current layout
- add certification attribution for redundant resize-time style writes and regression coverage for layout and observable behavior

## Resize evidence

Load-instrumented TradingView A/B pairs reduced layouts per applied resize from about 18.0 to 15.0 (about 16.5%). The two completed gated pairs also improved presentation p95 by about 1% and 7%, and maximum frame interval by about 7.5% and 14%. Earlier high-variance samples were discarded after host load reached 45 on 10 logical CPUs with concurrent compiler activity.

The changes are product-neutral and contain no TradingView-specific selectors, URLs, or branches.

## Validation

- native certification suite: 4/4 passed
- Avalonia backend net8.0: 122/122 passed
- Avalonia backend net10.0: 122/122 passed
- rebased onto current origin/main before validation
