### PR TITLE
Release WebScene 1.0.27

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <NoWarn>$(NoWarn);NU1507</NoWarn>
-    <VersionPrefix>1.0.26</VersionPrefix>
+    <VersionPrefix>1.0.27</VersionPrefix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>
     <Copyright>Copyright © Wiesław Šoltés 2025</Copyright>


### PR DESCRIPTION
## Summary

- bump the repository package version from 1.0.26 to 1.0.27
- prepare the merged multi-instance performance milestone for verified NuGet publication

## Release sequence

After this PR merges and the exact main commit passes CI, dispatch the NuGet packages workflow with publish enabled, verify the package on NuGet.org, and tag that release commit as v1.0.27.