### PR TITLE
Cache system font probes independently of GPU rendering

### DIFF
--- a/src/WebScene.Backend.Avalonia/NativeTextShaping.cs
+++ b/src/WebScene.Backend.Avalonia/NativeTextShaping.cs
@@ -1511,6 +1511,30 @@ public static class NativeTextShaping
             ? 1.014f
             : 1f;
 
+    // Match the process-lifetime system font resolution policy used by Typefaces,
+    // but bound negative family probes so arbitrary CSS cannot grow this cache.
+    private static readonly ConcurrentDictionary<string, bool> InstalledFontFamilies =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly object InstalledFontFamilyGate = new();
+
+    private static bool IsInstalledFontFamily(string family)
+    {
+        if (InstalledFontFamilies.TryGetValue(family, out var installed)) return installed;
+        using var typeface = SKTypeface.FromFamilyName(family);
+        installed = typeface is not null && string.Equals(typeface.FamilyName, family,
+            StringComparison.OrdinalIgnoreCase);
+        lock (InstalledFontFamilyGate)
+        {
+            if (!InstalledFontFamilies.ContainsKey(family))
+            {
+                if (InstalledFontFamilies.Count >= 256) InstalledFontFamilies.Clear();
+                InstalledFontFamilies.TryAdd(family, installed);
+            }
+        }
+        return installed;
+    }
+
     internal static bool UsesMacSystemUiMetrics(
         string familyList,
         WebTypefaceRegistry? registry)
@@ -1537,9 +1561,7 @@ public static class NativeTextShaping
                 return false;
             }
 
-            using var installed = SKTypeface.FromFamilyName(family);
-            if (installed is not null
-                && string.Equals(installed.FamilyName, family, StringComparison.OrdinalIgnoreCase))
+            if (IsInstalledFontFamily(family))
             {
                 return false;
             }

--- a/tests/WebScene.Backend.Avalonia.Tests/NativeTextShapingTests.cs
+++ b/tests/WebScene.Backend.Avalonia.Tests/NativeTextShapingTests.cs
@@ -944,6 +944,22 @@ public sealed class NativeTextShapingTests
     }
 
     [Fact]
+    public void CachedMissingSystemFamilyDoesNotHideNewDocumentWebFont()
+    {
+        var family = "WebScene Missing Family " + Guid.NewGuid().ToString("N");
+        var list = family + ", system-ui";
+        using var document = NativeTextShaping.CreateWebTypefaceRegistry();
+        using var otherDocument = NativeTextShaping.CreateWebTypefaceRegistry();
+        Assert.True(NativeTextShaping.UsesMacSystemUiMetrics(list, document));
+        Assert.True(NativeTextShaping.UsesMacSystemUiMetrics(list.ToUpperInvariant(), document));
+        var (data, _) = FindDistinctPlatformFonts();
+        Assert.True(document.Register(family, data));
+        Assert.False(NativeTextShaping.UsesMacSystemUiMetrics(list, document));
+        Assert.False(NativeTextShaping.UsesMacSystemUiMetrics(list.ToUpperInvariant(), document));
+        Assert.True(NativeTextShaping.UsesMacSystemUiMetrics(list, otherDocument));
+    }
+
+    [Fact]
     public void WebTypefacesAreSharedByContentButIsolatedByDocumentFamilyMap()
     {
         var (firstData, secondData) = FindDistinctPlatformFonts();


### PR DESCRIPTION
Repeated font-family checks currently call Skia's font lookup for each text preparation. Cache those positive and negative system-font probes using case-insensitive keys and a bounded 256-entry cache. Document and global web-font registrations are still checked first, so a cached missing system family cannot hide a newly registered web font.

Extracted from PR #43, commit 554739783d7e401fe938b0c2ca0c77e9ad9001c3. This PR contains only NativeTextShaping and its regression test. The cache targets the macOS system-UI metrics lookup; no separate Windows-specific optimization is introduced. The GPU-segment shaper reuse remains in #43 because its rendering path is not on main.

Validation on macOS: all 63 NativeTextShapingTests pass on .NET 8 and all 63 pass on .NET 10; git diff --check passes. The regression verifies case-insensitive cached misses, later document web-font registration, and isolation between documents. No independent performance percentage or Windows runtime qualification is claimed.
