### PR TITLE
Cache shared text shaping and glyph blobs independently of WebGPU

### DIFF
--- a/benchmarks/WebScene.NativeEngine.Benchmarks/Program.cs
+++ b/benchmarks/WebScene.NativeEngine.Benchmarks/Program.cs
@@ -8,6 +8,8 @@ if (args.Length > 0 && string.Equals(args[0], "probe", StringComparison.OrdinalI
     {
         switch (args[1].ToLowerInvariant())
         {
+            case "text-cache":
+                return TextCacheProbe.Run(probeArgs);
             case "variable-font":
                 return VariableFontProbe.Run(probeArgs);
             case "generated-realtime-chart":
@@ -36,7 +38,7 @@ if (args.Length > 0 && string.Equals(args[0], "probe", StringComparison.OrdinalI
     }
 
     Console.Error.WriteLine(
-        "Unknown probe. Use one of: variable-font, generated-realtime-chart, native-interop-race, " +
+        "Unknown probe. Use one of: text-cache, variable-font, generated-realtime-chart, native-interop-race, " +
         "native-runtime-work, native-dom-lookup, native-context-memory, native-lifecycle, " +
         "native-resize-cadence, native-inspector-disabled-performance, " +
         "native-retained-render, " +

--- a/benchmarks/WebScene.NativeEngine.Benchmarks/TextCacheProbe.cs
+++ b/benchmarks/WebScene.NativeEngine.Benchmarks/TextCacheProbe.cs
@@ -1,0 +1,69 @@
+using System.Diagnostics;
+using System.Text.Json;
+using SkiaSharp;
+using SkiaSharp.HarfBuzz;
+using WebScene.Backends.Avalonia.Native;
+
+namespace WebScene.NativeEngine.Benchmarks;
+
+// Warm repeated-label microbenchmark. Uses a CPU bitmap, not a GPU context.
+internal static class TextCacheProbe
+{
+    internal static int Run(string[] args)
+    {
+        if (args.Length != 0) throw new ArgumentException("text-cache takes no arguments");
+        const int iterations = 10000;
+        const string text = "Courtyard House 123 office a\u0301";
+        using var face = SKTypeface.FromFamilyName("sans-serif");
+        using var shaper = new SKShaper(face);
+        using var paint = new SKPaint { Typeface = face, TextSize = 18, Color = SKColors.Black };
+        using var bitmap = new SKBitmap(400, 64);
+        using var canvas = new SKCanvas(bitmap);
+        canvas.Clear(SKColors.White);
+        var cache = new NativeTextShaping.ShapedRunCache(2048, 4 * 1024 * 1024);
+        void DrawUncached()
+        {
+            var shaped = shaper.Shape(text, 0, 32, paint);
+            using var font = paint.ToFont();
+            NativeTextShaping.ApplyFontRasterizationProfile(font, 1,
+                NativeTextShaping.NativeFontRasterizationMode.Current);
+            using var builder = new SKTextBlobBuilder();
+            var run = builder.AllocatePositionedRun(font, shaped.Codepoints.Length);
+            for (var i = 0; i < shaped.Codepoints.Length; i++)
+            {
+                run.GetGlyphSpan()[i] = (ushort)shaped.Codepoints[i];
+                run.GetPositionSpan()[i] = shaped.Points[i];
+            }
+            using var blob = builder.Build();
+            canvas.DrawText(blob, 0, 0, paint);
+        }
+        void DrawCached() => NativeTextShaping.DrawShapedText(canvas, shaper, text, 0, 32,
+            paint, 0, rasterizationMode: NativeTextShaping.NativeFontRasterizationMode.Current);
+        Action[] operations = [() => shaper.Shape(text, 0, 0, paint),
+            () => cache.Shape(shaper, text, paint), DrawUncached, DrawCached];
+        string[] names = ["shape_uncached", "shape_cached", "draw_uncached", "draw_cached"];
+        foreach (var operation in operations)
+            for (var i = 0; i < 1000; i++) operation();
+        // Reverse each alternate round to reduce simple ordering bias.
+        for (var round = 0; round < 6; round++)
+        {
+            for (var step = 0; step < operations.Length; step++)
+            {
+                var index = round % 2 == 0 ? step : operations.Length - step - 1;
+                var allocated = GC.GetAllocatedBytesForCurrentThread();
+                var start = Stopwatch.GetTimestamp();
+                for (var i = 0; i < iterations; i++) operations[index]();
+                var elapsed = Stopwatch.GetTimestamp() - start;
+                var bytes = GC.GetAllocatedBytesForCurrentThread() - allocated;
+                Console.WriteLine(JsonSerializer.Serialize(new
+                {
+                    round, operation = names[index], iterations, family = face.FamilyName,
+                    microsecondsPerOperation = elapsed * 1_000_000.0 / Stopwatch.Frequency / iterations,
+                    managedBytesPerOperation = (double)bytes / iterations,
+                    cpuBitmap = true
+                }));
+            }
+        }
+        return 0;
+    }
+}

--- a/docs/validation/text-cache-macos.json
+++ b/docs/validation/text-cache-macos.json
@@ -1,0 +1,218 @@
+[
+  {
+    "round": 0,
+    "operation": "shape_uncached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 5.0962290999999995,
+    "managedBytesPerOperation": 1784.0128,
+    "cpuBitmap": true
+  },
+  {
+    "round": 0,
+    "operation": "shape_cached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 0.2909292,
+    "managedBytesPerOperation": 0,
+    "cpuBitmap": true
+  },
+  {
+    "round": 0,
+    "operation": "draw_uncached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 7.3138584,
+    "managedBytesPerOperation": 2104,
+    "cpuBitmap": true
+  },
+  {
+    "round": 0,
+    "operation": "draw_cached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 2.7095791,
+    "managedBytesPerOperation": 0,
+    "cpuBitmap": true
+  },
+  {
+    "round": 1,
+    "operation": "draw_cached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 2.753475,
+    "managedBytesPerOperation": 0,
+    "cpuBitmap": true
+  },
+  {
+    "round": 1,
+    "operation": "draw_uncached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 7.1130832999999996,
+    "managedBytesPerOperation": 2104,
+    "cpuBitmap": true
+  },
+  {
+    "round": 1,
+    "operation": "shape_cached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 0.28925,
+    "managedBytesPerOperation": 0,
+    "cpuBitmap": true
+  },
+  {
+    "round": 1,
+    "operation": "shape_uncached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 4.9029958,
+    "managedBytesPerOperation": 1784.0056,
+    "cpuBitmap": true
+  },
+  {
+    "round": 2,
+    "operation": "shape_uncached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 4.0875667,
+    "managedBytesPerOperation": 1784,
+    "cpuBitmap": true
+  },
+  {
+    "round": 2,
+    "operation": "shape_cached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 0.2092417,
+    "managedBytesPerOperation": 0,
+    "cpuBitmap": true
+  },
+  {
+    "round": 2,
+    "operation": "draw_uncached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 7.0206375,
+    "managedBytesPerOperation": 2104,
+    "cpuBitmap": true
+  },
+  {
+    "round": 2,
+    "operation": "draw_cached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 2.1541709,
+    "managedBytesPerOperation": 0,
+    "cpuBitmap": true
+  },
+  {
+    "round": 3,
+    "operation": "draw_cached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 2.1295,
+    "managedBytesPerOperation": 0,
+    "cpuBitmap": true
+  },
+  {
+    "round": 3,
+    "operation": "draw_uncached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 6.9091583,
+    "managedBytesPerOperation": 2104,
+    "cpuBitmap": true
+  },
+  {
+    "round": 3,
+    "operation": "shape_cached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 0.08505,
+    "managedBytesPerOperation": 0,
+    "cpuBitmap": true
+  },
+  {
+    "round": 3,
+    "operation": "shape_uncached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 3.3211833,
+    "managedBytesPerOperation": 1784,
+    "cpuBitmap": true
+  },
+  {
+    "round": 4,
+    "operation": "shape_uncached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 3.3064625,
+    "managedBytesPerOperation": 1784,
+    "cpuBitmap": true
+  },
+  {
+    "round": 4,
+    "operation": "shape_cached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 0.0806625,
+    "managedBytesPerOperation": 0,
+    "cpuBitmap": true
+  },
+  {
+    "round": 4,
+    "operation": "draw_uncached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 6.7598,
+    "managedBytesPerOperation": 2104,
+    "cpuBitmap": true
+  },
+  {
+    "round": 4,
+    "operation": "draw_cached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 2.109125,
+    "managedBytesPerOperation": 0,
+    "cpuBitmap": true
+  },
+  {
+    "round": 5,
+    "operation": "draw_cached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 2.1088958,
+    "managedBytesPerOperation": 0,
+    "cpuBitmap": true
+  },
+  {
+    "round": 5,
+    "operation": "draw_uncached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 5.9011292,
+    "managedBytesPerOperation": 2104,
+    "cpuBitmap": true
+  },
+  {
+    "round": 5,
+    "operation": "shape_cached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 0.0755667,
+    "managedBytesPerOperation": 0,
+    "cpuBitmap": true
+  },
+  {
+    "round": 5,
+    "operation": "shape_uncached",
+    "iterations": 10000,
+    "family": "Helvetica",
+    "microsecondsPerOperation": 3.260175,
+    "managedBytesPerOperation": 1784,
+    "cpuBitmap": true
+  }
+]

--- a/docs/validation/text-cache-windows.json
+++ b/docs/validation/text-cache-windows.json
@@ -1,0 +1,225 @@
+{
+  "date": "2026-09-09",
+  "platform": "Windows x64",
+  "runtime": ".NET 10",
+  "command": "dotnet run --project benchmarks/WebScene.NativeEngine.Benchmarks -c Release -- probe text-cache",
+  "notes": "Warm repeated-label CPU microbenchmark; no GPU context. Managed allocations exclude native Skia memory. Not an end-to-end or cross-platform performance claim.",
+  "samples": [
+    {
+      "round": 0,
+      "operation": "shape_uncached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 5.1399,
+      "managedBytesPerOperation": 1824.0128,
+      "cpuBitmap": true
+    },
+    {
+      "round": 0,
+      "operation": "shape_cached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 0.22379000000000002,
+      "managedBytesPerOperation": 0,
+      "cpuBitmap": true
+    },
+    {
+      "round": 0,
+      "operation": "draw_uncached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 7.56773,
+      "managedBytesPerOperation": 2144,
+      "cpuBitmap": true
+    },
+    {
+      "round": 0,
+      "operation": "draw_cached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 3.42009,
+      "managedBytesPerOperation": 0,
+      "cpuBitmap": true
+    },
+    {
+      "round": 1,
+      "operation": "draw_cached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 3.3927099999999997,
+      "managedBytesPerOperation": 0,
+      "cpuBitmap": true
+    },
+    {
+      "round": 1,
+      "operation": "draw_uncached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 8.98882,
+      "managedBytesPerOperation": 2144,
+      "cpuBitmap": true
+    },
+    {
+      "round": 1,
+      "operation": "shape_cached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 0.33883,
+      "managedBytesPerOperation": 0,
+      "cpuBitmap": true
+    },
+    {
+      "round": 1,
+      "operation": "shape_uncached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 4.08424,
+      "managedBytesPerOperation": 1824,
+      "cpuBitmap": true
+    },
+    {
+      "round": 2,
+      "operation": "shape_uncached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 3.45819,
+      "managedBytesPerOperation": 1824,
+      "cpuBitmap": true
+    },
+    {
+      "round": 2,
+      "operation": "shape_cached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 0.26668000000000003,
+      "managedBytesPerOperation": 0,
+      "cpuBitmap": true
+    },
+    {
+      "round": 2,
+      "operation": "draw_uncached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 9.11837,
+      "managedBytesPerOperation": 2144,
+      "cpuBitmap": true
+    },
+    {
+      "round": 2,
+      "operation": "draw_cached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 4.1037300000000005,
+      "managedBytesPerOperation": 0,
+      "cpuBitmap": true
+    },
+    {
+      "round": 3,
+      "operation": "draw_cached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 3.13337,
+      "managedBytesPerOperation": 0,
+      "cpuBitmap": true
+    },
+    {
+      "round": 3,
+      "operation": "draw_uncached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 6.56867,
+      "managedBytesPerOperation": 2111.3208,
+      "cpuBitmap": true
+    },
+    {
+      "round": 3,
+      "operation": "shape_cached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 0.06602000000000001,
+      "managedBytesPerOperation": 0,
+      "cpuBitmap": true
+    },
+    {
+      "round": 3,
+      "operation": "shape_uncached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 2.41988,
+      "managedBytesPerOperation": 1824,
+      "cpuBitmap": true
+    },
+    {
+      "round": 4,
+      "operation": "shape_uncached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 2.53397,
+      "managedBytesPerOperation": 1824,
+      "cpuBitmap": true
+    },
+    {
+      "round": 4,
+      "operation": "shape_cached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 0.08357,
+      "managedBytesPerOperation": 0,
+      "cpuBitmap": true
+    },
+    {
+      "round": 4,
+      "operation": "draw_uncached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 5.87389,
+      "managedBytesPerOperation": 2088,
+      "cpuBitmap": true
+    },
+    {
+      "round": 4,
+      "operation": "draw_cached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 2.24661,
+      "managedBytesPerOperation": 0,
+      "cpuBitmap": true
+    },
+    {
+      "round": 5,
+      "operation": "draw_cached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 2.13576,
+      "managedBytesPerOperation": 0,
+      "cpuBitmap": true
+    },
+    {
+      "round": 5,
+      "operation": "draw_uncached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 5.4349099999999995,
+      "managedBytesPerOperation": 2088,
+      "cpuBitmap": true
+    },
+    {
+      "round": 5,
+      "operation": "shape_cached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 0.06967999999999999,
+      "managedBytesPerOperation": 0,
+      "cpuBitmap": true
+    },
+    {
+      "round": 5,
+      "operation": "shape_uncached",
+      "iterations": 10000,
+      "family": "Segoe UI",
+      "microsecondsPerOperation": 2.41932,
+      "managedBytesPerOperation": 1824,
+      "cpuBitmap": true
+    }
+  ]
+}

--- a/docs/validation/text-cache.md
+++ b/docs/validation/text-cache.md
@@ -10,9 +10,10 @@ Shaped runs are cached by typeface object identity, text, size, horizontal scale
 and encoding, with a 2,048-entry / estimated 4 MiB bound. Identity is checked after
 hash lookup, and weak typeface references avoid retaining document fonts in this
 cache. Short unspaced, unscaled draws additionally reuse up to 512 native text
-blobs, keyed by font styling and rasterization profile. Eviction disposes blobs;
-native fonts owned by these blobs remain retained until eviction. Draw location
-and color are applied during replay. Spacing and horizontal-advance adjustments
+blobs, keyed by font styling and rasterization profile. Eviction retires blobs;
+disposal waits for active draw readers to return. Drawing runs outside the cache
+lock. Native fonts owned by these blobs remain retained until eviction and the
+final active reader returns. Draw location and color are applied during replay. Spacing and horizontal-advance adjustments
 retain the existing per-draw positioning path.
 
 ## Windows validation
@@ -30,7 +31,7 @@ dotnet run --project benchmarks/WebScene.NativeEngine.Benchmarks -c Release -- p
 ```
 
 It warms a repeated label, runs six rounds of 10,000 operations, and reverses
-operation order on alternate rounds. Recorded Windows .NET 10 medians:
+operation order on alternate rounds. Recorded Windows .NET 10 medians at `0d32a5cf`, before the reader-lifetime change:
 
 | Operation | Uncached | Cached |
 | --- | ---: | ---: |
@@ -41,3 +42,23 @@ Cached operations reported zero managed allocations in this probe. This does
 not measure native Skia allocations, cold/miss-heavy workloads, concurrent
 contention, application frame rates or other operating systems. JIT/CPU variation
 is visible across rounds. Raw samples are in [text-cache-windows.json](text-cache-windows.json).
+
+## Follow-up validation on macOS
+
+The expanded focused suite passes 75 tests on each of .NET 8 and .NET 10.
+New tests check LRU eviction, native handle disposal, multiple active readers
+across cache disposal, oversize bypass, rasterization-profile separation, color
+reuse, and pixel equivalence during concurrent draws with frequent eviction.
+The cache pins blobs during drawing and releases the global lock before calling
+Skia, while retaining zero managed allocations on warm hits.
+
+The same CPU probe on macOS arm64 (.NET 10, Helvetica), after this change:
+
+| Operation | Uncached | Cached |
+| --- | ---: | ---: |
+| Shape repeated label | 3.70 µs | 0.15 µs |
+| Shape and draw onto CPU bitmap | 6.96 µs | 2.14 µs |
+
+Both cached operations report zero managed allocations. These are warm-label
+measurements, not an application frame-rate or concurrent-throughput claim.
+Raw samples: [text-cache-macos.json](text-cache-macos.json).

--- a/docs/validation/text-cache.md
+++ b/docs/validation/text-cache.md
@@ -1,0 +1,43 @@
+# Shared text cache validation
+
+This extracts shaped-run and text-blob caching developed during Windows Kestrel
+work. It builds on the system-font probe cache already merged in PR #49; that
+earlier cache handles macOS system-UI family detection. These additional caches
+live in `NativeTextShaping`, shared by Avalonia and Uno, and require no WebGPU,
+native engine, canvas checkpoint or frame scheduling changes.
+
+Shaped runs are cached by typeface object identity, text, size, horizontal scale
+and encoding, with a 2,048-entry / estimated 4 MiB bound. Identity is checked after
+hash lookup, and weak typeface references avoid retaining document fonts in this
+cache. Short unspaced, unscaled draws additionally reuse up to 512 native text
+blobs, keyed by font styling and rasterization profile. Eviction disposes blobs;
+native fonts owned by these blobs remain retained until eviction. Draw location
+and color are applied during replay. Spacing and horizontal-advance adjustments
+retain the existing per-draw positioning path.
+
+## Windows validation
+
+- .NET 8 and .NET 10: all 71 `NativeTextShapingTests` / `ShapedRunCacheTests` pass.
+- Uno Release build passes with zero warnings and errors.
+- Tests compare glyph data with uncached HarfBuzz, compare CPU-rendered pixels at
+  different baselines and font styles, distinguish typefaces, and exercise bounds
+  and eviction. PR #49's web-font registration/isolation regression also passes.
+
+Run the CPU-only probe:
+
+```sh
+dotnet run --project benchmarks/WebScene.NativeEngine.Benchmarks -c Release -- probe text-cache
+```
+
+It warms a repeated label, runs six rounds of 10,000 operations, and reverses
+operation order on alternate rounds. Recorded Windows .NET 10 medians:
+
+| Operation | Uncached | Cached |
+| --- | ---: | ---: |
+| Shape repeated label | 3.00 µs | 0.15 µs |
+| Shape and draw onto CPU bitmap | 7.07 µs | 3.26 µs |
+
+Cached operations reported zero managed allocations in this probe. This does
+not measure native Skia allocations, cold/miss-heavy workloads, concurrent
+contention, application frame rates or other operating systems. JIT/CPU variation
+is visible across rounds. Raw samples are in [text-cache-windows.json](text-cache-windows.json).

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime.cpp
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime.cpp
@@ -4472,6 +4472,14 @@ void v8_dom_runtime::notify_low_memory()
     auto isolate_locker = impl_->lock_shared_isolate();
     v8::Isolate::Scope isolate_scope(impl_->isolate);
     impl_->isolate->LowMemoryNotification();
+    // Idle tasks may previously have declined to collect weak wrappers. Now
+    // that V8 has collected, revisit roots in the normal bounded idle slices,
+    // including workloads smaller than the mutation-triggered GC threshold.
+    if (!impl_->detached_dom_roots.empty()) {
+        impl_->detached_dom_gc_requested = true;
+        impl_->detached_dom_gc_deferred_once = false;
+        impl_->detached_dom_gc_retry_count = 0U;
+    }
 }
 
 void v8_dom_runtime::signal_animation_frame(double timestamp_ms)

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_frame_scheduling_tests.inc
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_frame_scheduling_tests.inc
@@ -693,6 +693,14 @@ void test_low_memory_reclaims_small_detached_dom_batches()
           }
         })()
     )JS", "small-detached-dom-create.js");
+    webscene_engine_memory_metrics created{sizeof(webscene_engine_memory_metrics)};
+    for (auto attempt = 0; attempt < 500; ++attempt) {
+        webscene_engine_get_memory_metrics(engine, &created);
+        if (created.native_dom_node_count >= before.native_dom_node_count + 32U) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    require(created.native_dom_node_count >= before.native_dom_node_count + 32U,
+        "small detached DOM batch was not visible in the worker snapshot");
     require(webscene_engine_request_low_memory(engine) != 0,
         "small detached DOM collection request failed");
     webscene_engine_memory_metrics after{sizeof(webscene_engine_memory_metrics)};

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_frame_scheduling_tests.inc
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_frame_scheduling_tests.inc
@@ -669,26 +669,83 @@ void test_initial_frame_document_write_and_hidden_style(webscene_engine* engine)
         "initial iframe document replacement or hidden computed style regressed: " + result);
 }
 
+void test_low_memory_reclaims_small_detached_dom_batches()
+{
+    auto* engine = webscene_engine_create(0);
+    require(engine != nullptr, "small detached DOM engine creation failed");
+    evaluate(engine, "document.body.textContent = ''", "small-detached-dom-init.js");
+    webscene_engine_memory_metrics before{sizeof(webscene_engine_memory_metrics)};
+    for (auto attempt = 0; attempt < 500; ++attempt) {
+        webscene_engine_get_memory_metrics(engine, &before);
+        if (before.native_dom_node_count != 0U) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    require(before.native_dom_node_count != 0U,
+        "small detached DOM baseline metrics were unavailable");
+    // Stay below the 512-node idle-collection threshold. A low-memory
+    // notification must schedule a native sweep even without an idle request.
+    evaluate(engine, R"JS(
+        (() => {
+          for (let index = 0; index < 32; index++) {
+            const node = document.createElement('div');
+            document.body.appendChild(node);
+            node.remove();
+          }
+        })()
+    )JS", "small-detached-dom-create.js");
+    require(webscene_engine_request_low_memory(engine) != 0,
+        "small detached DOM collection request failed");
+    webscene_engine_memory_metrics after{sizeof(webscene_engine_memory_metrics)};
+    for (auto attempt = 0; attempt < 500; ++attempt) {
+        webscene_engine_get_memory_metrics(engine, &after);
+        if (after.low_memory_notifications > before.low_memory_notifications
+            && after.native_dom_node_count <= before.native_dom_node_count) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    require(after.low_memory_notifications > before.low_memory_notifications
+            && after.native_dom_node_count <= before.native_dom_node_count,
+        "low-memory collection did not reclaim a sub-threshold detached DOM batch (before="
+            + std::to_string(before.native_dom_node_count) + ", after="
+            + std::to_string(after.native_dom_node_count) + ")");
+    webscene_engine_destroy(engine);
+}
+
 void test_detached_dom_wrappers_do_not_permanently_root_nodes(webscene_engine* engine)
 {
-    webscene_engine_metrics before{};
-    webscene_engine_get_metrics(engine, &before);
+    execute_and_wait(engine, "void document.body", "native-detached-dom-init.js");
+    webscene_engine_memory_metrics before{sizeof(webscene_engine_memory_metrics)};
+    for (auto attempt = 0; attempt < 500; ++attempt) {
+        webscene_engine_get_memory_metrics(engine, &before);
+        if (before.native_dom_node_count != 0U) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    require(before.native_dom_node_count != 0U, "detached DOM baseline metrics were unavailable");
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
-    const auto diagnostic_value = [&](std::string_view name) {
-        const auto report = diagnostics(engine);
+    const auto diagnostic_value = [&](std::string_view name, uint64_t minimum = 0U) {
         const auto prefix = std::string{name} + '=';
-        const auto position = report.find(prefix);
-        require(position != std::string::npos,
-            "detached DOM diagnostic was unavailable: " + report);
-        const auto first = position + prefix.size();
-        const auto last = report.find_first_not_of("0123456789", first);
         uint64_t value = 0U;
-        const auto parsed = std::from_chars(
-            report.data() + first,
-            report.data() + (last == std::string::npos ? report.size() : last),
-            value);
-        require(parsed.ec == std::errc{},
-            "detached DOM diagnostic was not numeric: " + report);
+        for (auto attempt = 0; attempt < 500; ++attempt) {
+            // Certification counters are published with scene diagnostics,
+            // throttled to 250 ms. Ask for another publication while waiting
+            // for a post-collection snapshot, without queueing more DOM work.
+            execute_and_wait(engine, "void 0", "native-detached-dom-diagnostics.js");
+            const auto report = diagnostics(engine);
+            const auto position = report.find(prefix);
+            if (position != std::string::npos) {
+                const auto first = position + prefix.size();
+                const auto last = report.find_first_not_of("0123456789", first);
+                const auto parsed = std::from_chars(
+                    report.data() + first,
+                    report.data() + (last == std::string::npos ? report.size() : last),
+                    value);
+                require(parsed.ec == std::errc{},
+                    "detached DOM diagnostic was not numeric: " + report);
+                if (value >= minimum) return value;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(2));
+        }
+        fail("detached DOM diagnostic did not reach the expected value: "
+            + std::string{name} + "=" + std::to_string(value));
         return value;
     };
     const auto release_batches_before = diagnostic_value(
@@ -716,7 +773,7 @@ void test_detached_dom_wrappers_do_not_permanently_root_nodes(webscene_engine* e
     require(
         detached_event == R"({"calls":2,"dispatched":true,"connected":false})",
         "a detached element stopped dispatching custom events: " + detached_event);
-    execute(engine, R"JS(
+    evaluate(engine, R"JS(
         (() => {
           const retained = document.createElement('div');
           retained.id = 'retained-detached-node';
@@ -732,6 +789,21 @@ void test_detached_dom_wrappers_do_not_permanently_root_nodes(webscene_engine* e
           }
         })()
     )JS", "native-detached-dom-gc.js");
+    // RunIdleTasks only offers time to work already scheduled by V8; it does
+    // not guarantee a collection on a small heap. Explicitly request memory
+    // reclamation so this tests weak-wrapper ownership rather than GC policy.
+    webscene_engine_memory_metrics collection_before{sizeof(webscene_engine_memory_metrics)};
+    webscene_engine_get_memory_metrics(engine, &collection_before);
+    require(webscene_engine_request_low_memory(engine) != 0,
+        "detached DOM test could not request V8 collection");
+    webscene_engine_memory_metrics collected{sizeof(webscene_engine_memory_metrics)};
+    for (auto attempt = 0; attempt < 500; ++attempt) {
+        webscene_engine_get_memory_metrics(engine, &collected);
+        if (collected.low_memory_notifications > collection_before.low_memory_notifications) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    require(collected.low_memory_notifications > collection_before.low_memory_notifications,
+        "detached DOM test did not observe V8 collection");
     require(
         evaluate(engine, R"JS(
           (() => {
@@ -746,43 +818,43 @@ void test_detached_dom_wrappers_do_not_permanently_root_nodes(webscene_engine* e
         )JS", "native-detached-dom-retain.js")
             == R"({"expando":42,"identity":true,"connected":true})",
         "a reachable detached wrapper lost identity or expando state across native DOM collection");
-    webscene_engine_metrics after{};
+    webscene_engine_memory_metrics after{sizeof(webscene_engine_memory_metrics)};
     // Collection is deliberately lower priority than observable task sources
     // and releases only a bounded root batch per pump. Leave the worker idle
-    // rather than queueing artificial scripts, then prove that a
-    // TradingView-sized replacement eventually drains.
+    // rather than queueing artificial scripts, then prove that the collected
+    // wrappers from a large replacement drain across bounded release slices.
     for (auto attempt = 0; attempt < 500; ++attempt) {
-        webscene_engine_get_metrics(engine, &after);
-        if (after.dom_nodes <= before.dom_nodes + 8U) break;
+        webscene_engine_get_memory_metrics(engine, &after);
+        if (after.native_dom_node_count <= before.native_dom_node_count + 8U) break;
         std::this_thread::sleep_for(std::chrono::milliseconds(2));
     }
     require(
-        after.dom_nodes <= before.dom_nodes + 8U,
+        after.native_dom_node_count <= before.native_dom_node_count + 8U,
         "unreachable detached DOM nodes remained permanently owned after V8 collection (before="
-            + std::to_string(before.dom_nodes)
-            + ", after=" + std::to_string(after.dom_nodes) + ")");
+            + std::to_string(before.native_dom_node_count)
+            + ", after=" + std::to_string(after.native_dom_node_count) + ")");
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
     require(
-        diagnostic_value("detached-dom-release-batches")
+        diagnostic_value("detached-dom-release-batches", release_batches_before + 2U)
             > release_batches_before + 1U,
         "large detached DOM replacement was not amortized across release batches");
     require(
-        diagnostic_value("detached-dom-release-roots")
+        diagnostic_value("detached-dom-release-roots", release_roots_before + 2048U)
             >= release_roots_before + 2048U,
         "detached DOM release did not coalesce the individual removed roots");
     require(
-        diagnostic_value("detached-dom-release-slices")
+        diagnostic_value("detached-dom-release-slices", release_slices_before + 2U)
             > release_slices_before + 1U,
         "large detached DOM replacement was not drained over multiple idle slices");
     require(
         diagnostic_value("detached-dom-release-max-roots-per-slice") <= 16U,
         "a detached DOM release slice exceeded the input-latency root budget");
     require(
-        diagnostic_value("detached-dom-idle-gc-notifications")
+        diagnostic_value("detached-dom-idle-gc-notifications", idle_gc_notifications_before + 1U)
             > idle_gc_notifications_before,
         "detached DOM cleanup did not use the browser-style V8 idle queue");
 #endif
-    execute(engine, R"JS(
+    evaluate(engine, R"JS(
         (() => {
           globalThis.__webSceneRetainedDetachedNode.remove();
           delete globalThis.__webSceneRetainedDetachedNode;

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_frame_scheduling_tests.inc
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_frame_scheduling_tests.inc
@@ -673,14 +673,15 @@ void test_low_memory_reclaims_small_detached_dom_batches()
 {
     auto* engine = webscene_engine_create(0);
     require(engine != nullptr, "small detached DOM engine creation failed");
-    evaluate(engine, "document.body.textContent = ''", "small-detached-dom-init.js");
-    webscene_engine_memory_metrics before{sizeof(webscene_engine_memory_metrics)};
+    resize(engine, 320, 120, 1U);
+    execute_and_wait(engine, "document.body.textContent = ''", "small-detached-dom-init.js");
+    webscene_engine_metrics before{};
     for (auto attempt = 0; attempt < 500; ++attempt) {
-        webscene_engine_get_memory_metrics(engine, &before);
-        if (before.native_dom_node_count != 0U) break;
+        webscene_engine_get_metrics(engine, &before);
+        if (before.dom_nodes != 0U) break;
         std::this_thread::sleep_for(std::chrono::milliseconds(2));
     }
-    require(before.native_dom_node_count != 0U,
+    require(before.dom_nodes != 0U,
         "small detached DOM baseline metrics were unavailable");
     // Stay below the 512-node idle-collection threshold. A low-memory
     // notification must schedule a native sweep even without an idle request.
@@ -693,41 +694,39 @@ void test_low_memory_reclaims_small_detached_dom_batches()
           }
         })()
     )JS", "small-detached-dom-create.js");
-    webscene_engine_memory_metrics created{sizeof(webscene_engine_memory_metrics)};
+    webscene_engine_metrics created{};
     for (auto attempt = 0; attempt < 500; ++attempt) {
-        webscene_engine_get_memory_metrics(engine, &created);
-        if (created.native_dom_node_count >= before.native_dom_node_count + 32U) break;
+        webscene_engine_get_metrics(engine, &created);
+        if (created.dom_nodes >= before.dom_nodes + 32U) break;
         std::this_thread::sleep_for(std::chrono::milliseconds(2));
     }
-    require(created.native_dom_node_count >= before.native_dom_node_count + 32U,
+    require(created.dom_nodes >= before.dom_nodes + 32U,
         "small detached DOM batch was not visible in the worker snapshot");
     require(webscene_engine_request_low_memory(engine) != 0,
         "small detached DOM collection request failed");
-    webscene_engine_memory_metrics after{sizeof(webscene_engine_memory_metrics)};
+    webscene_engine_metrics after{};
     for (auto attempt = 0; attempt < 500; ++attempt) {
-        webscene_engine_get_memory_metrics(engine, &after);
-        if (after.low_memory_notifications > before.low_memory_notifications
-            && after.native_dom_node_count <= before.native_dom_node_count) break;
+        webscene_engine_get_metrics(engine, &after);
+        if (after.dom_nodes <= before.dom_nodes) break;
         std::this_thread::sleep_for(std::chrono::milliseconds(2));
     }
-    require(after.low_memory_notifications > before.low_memory_notifications
-            && after.native_dom_node_count <= before.native_dom_node_count,
+    require(after.dom_nodes <= before.dom_nodes,
         "low-memory collection did not reclaim a sub-threshold detached DOM batch (before="
-            + std::to_string(before.native_dom_node_count) + ", after="
-            + std::to_string(after.native_dom_node_count) + ")");
+            + std::to_string(before.dom_nodes) + ", after="
+            + std::to_string(after.dom_nodes) + ")");
     webscene_engine_destroy(engine);
 }
 
 void test_detached_dom_wrappers_do_not_permanently_root_nodes(webscene_engine* engine)
 {
     execute_and_wait(engine, "void document.body", "native-detached-dom-init.js");
-    webscene_engine_memory_metrics before{sizeof(webscene_engine_memory_metrics)};
+    webscene_engine_metrics before{};
     for (auto attempt = 0; attempt < 500; ++attempt) {
-        webscene_engine_get_memory_metrics(engine, &before);
-        if (before.native_dom_node_count != 0U) break;
+        webscene_engine_get_metrics(engine, &before);
+        if (before.dom_nodes != 0U) break;
         std::this_thread::sleep_for(std::chrono::milliseconds(2));
     }
-    require(before.native_dom_node_count != 0U, "detached DOM baseline metrics were unavailable");
+    require(before.dom_nodes != 0U, "detached DOM baseline metrics were unavailable");
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
     const auto diagnostic_value = [&](std::string_view name, uint64_t minimum = 0U) {
         const auto prefix = std::string{name} + '=';
@@ -826,21 +825,21 @@ void test_detached_dom_wrappers_do_not_permanently_root_nodes(webscene_engine* e
         )JS", "native-detached-dom-retain.js")
             == R"({"expando":42,"identity":true,"connected":true})",
         "a reachable detached wrapper lost identity or expando state across native DOM collection");
-    webscene_engine_memory_metrics after{sizeof(webscene_engine_memory_metrics)};
+    webscene_engine_metrics after{};
     // Collection is deliberately lower priority than observable task sources
     // and releases only a bounded root batch per pump. Leave the worker idle
     // rather than queueing artificial scripts, then prove that the collected
     // wrappers from a large replacement drain across bounded release slices.
     for (auto attempt = 0; attempt < 500; ++attempt) {
-        webscene_engine_get_memory_metrics(engine, &after);
-        if (after.native_dom_node_count <= before.native_dom_node_count + 8U) break;
+        webscene_engine_get_metrics(engine, &after);
+        if (after.dom_nodes <= before.dom_nodes + 8U) break;
         std::this_thread::sleep_for(std::chrono::milliseconds(2));
     }
     require(
-        after.native_dom_node_count <= before.native_dom_node_count + 8U,
+        after.dom_nodes <= before.dom_nodes + 8U,
         "unreachable detached DOM nodes remained permanently owned after V8 collection (before="
-            + std::to_string(before.native_dom_node_count)
-            + ", after=" + std::to_string(after.native_dom_node_count) + ")");
+            + std::to_string(before.dom_nodes)
+            + ", after=" + std::to_string(after.dom_nodes) + ")");
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
     require(
         diagnostic_value("detached-dom-release-batches", release_batches_before + 2U)

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_tests.cpp
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_tests.cpp
@@ -310,8 +310,10 @@ int main()
             return 0;
         }
         if (selected == "detached-dom-gc") {
+            test_low_memory_reclaims_small_detached_dom_batches();
             auto* focused_engine = webscene_engine_create(0);
             require(focused_engine != nullptr, "focused engine creation failed");
+            resize(focused_engine, 320, 120, 1U);
             test_detached_dom_wrappers_do_not_permanently_root_nodes(
                 focused_engine);
             webscene_engine_destroy(focused_engine);
@@ -742,6 +744,7 @@ int main()
     test_dom_element_constructor_identity(engine);
     test_provisional_frame_focus_and_document_event_identity(engine);
     test_initial_frame_document_write_and_hidden_style(engine);
+    test_low_memory_reclaims_small_detached_dom_batches();
     test_detached_dom_wrappers_do_not_permanently_root_nodes(engine);
     test_connected_style_recascade_skips_detached_wrapper_retention(engine);
     test_resize_updates_device_pixel_ratio(engine);

--- a/src/WebScene.Backend.Avalonia/NativeTextShaping.cs
+++ b/src/WebScene.Backend.Avalonia/NativeTextShaping.cs
@@ -50,6 +50,118 @@ public struct NativeTextMetrics
 
 public static class NativeTextShaping
 {
+    private static readonly ShapedRunCache ShapedRuns = new(2048, 4 * 1024 * 1024);
+    private static readonly TextBlobCache TextBlobs = new();
+    // Cache the immutable native glyph container as well as HarfBuzz output.
+    // Draw coordinates and color are supplied at replay time. The short-run
+    // limit and LRU bound native font/blob ownership to a small working set.
+    private sealed class TextBlobCache
+    {
+        private readonly record struct Key(int Face, string Text, float Size, float Scale,
+            float Skew, bool Bold, bool AutoHint, SKTextEncoding Encoding, FontRasterizationProfile Profile);
+        private sealed record Entry(Key Key, WeakReference<SKTypeface> Face, SKTextBlob Blob);
+        private readonly object _gate = new();
+        private readonly Dictionary<Key, LinkedListNode<Entry>> _entries = [];
+        private readonly LinkedList<Entry> _order = [];
+
+        public bool Draw(SKCanvas canvas, SKShaper shaper, string text, SKShaper.Result shaped,
+            SKPaint paint, float x, float baseline, float deviceScale, NativeFontRasterizationMode? mode)
+        {
+            if (text.Length > 256 || shaped.Codepoints.Length > 512) return false;
+            var face = shaper.Typeface;
+            var key = new Key(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(face), text,
+                paint.TextSize, paint.TextScaleX, paint.TextSkewX, paint.FakeBoldText, paint.IsAutohinted, paint.TextEncoding,
+                ResolveFontRasterizationProfile(deviceScale, mode));
+            lock (_gate)
+            {
+                if (_entries.TryGetValue(key, out var found))
+                {
+                    if (found.Value.Face.TryGetTarget(out var previous) && ReferenceEquals(previous, face))
+                    {
+                        _order.Remove(found); _order.AddLast(found);
+                        canvas.DrawText(found.Value.Blob, x, baseline, paint);
+                        return true;
+                    }
+                    _entries.Remove(key); _order.Remove(found); found.Value.Blob.Dispose();
+                }
+                using var font = paint.ToFont();
+                font.Typeface = face;
+                ApplyFontRasterizationProfile(font, deviceScale, mode);
+                using var builder = new SKTextBlobBuilder();
+                var count = Math.Min(shaped.Codepoints.Length, shaped.Points.Length);
+                var run = builder.AllocatePositionedRun(font, count);
+                for (var index = 0; index < count; index++)
+                {
+                    run.GetGlyphSpan()[index] = (ushort)shaped.Codepoints[index];
+                    run.GetPositionSpan()[index] = shaped.Points[index];
+                }
+                var blob = builder.Build();
+                if (blob is null) return false;
+                if (_entries.Count == 512)
+                {
+                    var oldest = _order.First!;
+                    _entries.Remove(oldest.Value.Key); _order.RemoveFirst(); oldest.Value.Blob.Dispose();
+                }
+                _entries.Add(key, _order.AddLast(new Entry(key, new WeakReference<SKTypeface>(face), blob)));
+                canvas.DrawText(blob, x, baseline, paint);
+                return true;
+            }
+        }
+    }
+
+    // SKShaper's string overload depends on the immutable typeface, text,
+    // encoding, size and horizontal scale. Cache origin-relative glyph data;
+    // alignment, spacing, rasterization and draw position are applied later.
+    // Weak face references avoid extending a document web font's native life.
+    internal sealed class ShapedRunCache(int maximumEntries, long maximumBytes)
+    {
+        private readonly record struct Key(int Face, string Text, float Size, float Scale, SKTextEncoding Encoding);
+        private sealed record Entry(Key Key, WeakReference<SKTypeface> Face, SKShaper.Result Result, long Bytes);
+        private readonly object _gate = new();
+        private readonly Dictionary<Key, LinkedListNode<Entry>> _entries = [];
+        private readonly LinkedList<Entry> _order = [];
+        private long _bytes;
+        internal (int Count, long Bytes) Occupancy { get { lock (_gate) return (_entries.Count, _bytes); } }
+
+        internal SKShaper.Result Shape(SKShaper shaper, string text, SKPaint paint)
+        {
+            if (text.Length > 4096 || maximumEntries <= 0 || maximumBytes <= 0
+                || !float.IsFinite(paint.TextSize) || !float.IsFinite(paint.TextScaleX))
+                return shaper.Shape(text, 0, 0, paint);
+            var face = shaper.Typeface;
+            var key = new Key(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(face),
+                text, paint.TextSize, paint.TextScaleX, paint.TextEncoding);
+            lock (_gate)
+            {
+                if (_entries.TryGetValue(key, out var found)
+                    && found.Value.Face.TryGetTarget(out var cachedFace) && ReferenceEquals(face, cachedFace))
+                {
+                    _order.Remove(found); _order.AddLast(found);
+                    return found.Value.Result;
+                }
+            }
+            var result = shaper.Shape(text, 0, 0, paint);
+            var bytes = 128L + text.Length * 2L + result.Codepoints.Length * 4L
+                + result.Clusters.Length * 4L + result.Points.Length * 8L;
+            if (bytes > maximumBytes) return result;
+            lock (_gate)
+            {
+                if (_entries.Remove(key, out var previous))
+                { _order.Remove(previous); _bytes -= previous.Value.Bytes; }
+                while (_entries.Count >= maximumEntries || _bytes + bytes > maximumBytes)
+                {
+                    var oldest = _order.First!;
+                    _entries.Remove(oldest.Value.Key); _order.RemoveFirst(); _bytes -= oldest.Value.Bytes;
+                }
+                var entry = new Entry(key, new WeakReference<SKTypeface>(face), result, bytes);
+                _entries.Add(key, _order.AddLast(entry)); _bytes += bytes;
+            }
+            return result;
+        }
+    }
+
+    private static SKShaper.Result ShapeAtOrigin(SKShaper shaper, string text, SKPaint paint)
+        => ShapedRuns.Shape(shaper, text, paint);
     internal const string RasterizationModeEnvironmentVariable =
         "WEBSCENE_TEXT_RASTERIZATION";
     internal const uint TabularNumerals = 1u << 0;
@@ -752,10 +864,10 @@ public static class NativeTextShaping
         }
         if ((featureFlags & TabularNumerals) == 0)
         {
-            return shaper.Shape(text, paint).Width;
+            return ShapeAtOrigin(shaper, text, paint).Width;
         }
 
-        var tabularDigitWidth = shaper.Shape("0", paint).Width * tabularDigitScale;
+        var tabularDigitWidth = ShapeAtOrigin(shaper, "0", paint).Width * tabularDigitScale;
         var width = 0f;
         for (var index = 0; index < text.Length;)
         {
@@ -767,7 +879,7 @@ public static class NativeTextShaping
             }
             var start = index++;
             while (index < text.Length && text[index] is not (>= '0' and <= '9')) index++;
-            width += shaper.Shape(text[start..index], paint).Width;
+            width += ShapeAtOrigin(shaper, text[start..index], paint).Width;
         }
         return width;
     }
@@ -797,7 +909,7 @@ public static class NativeTextShaping
             registry,
             shaper.Typeface);
         if (!TextRunPositioner.IsEligible(in request)) return false;
-        var shaped = shaper.Shape(text, 0, 0, paint);
+        var shaped = ShapeAtOrigin(shaper, text, paint);
         if (shaped.Codepoints.Length == 0
             || shaped.Codepoints.Length != shaped.Points.Length)
         {
@@ -828,7 +940,7 @@ public static class NativeTextShaping
 
         var result = SKRect.Empty;
         var hasBounds = false;
-        var tabularDigitWidth = shaper.Shape("0", paint).Width * tabularDigitScale;
+        var tabularDigitWidth = ShapeAtOrigin(shaper, "0", paint).Width * tabularDigitScale;
         var cursor = 0f;
         for (var index = 0; index < text.Length;)
         {
@@ -845,7 +957,7 @@ public static class NativeTextShaping
                 var start = index++;
                 while (index < text.Length && text[index] is not (>= '0' and <= '9')) index++;
                 segment = text[start..index];
-                advance = shaper.Shape(segment, paint).Width;
+                advance = ShapeAtOrigin(shaper, segment, paint).Width;
             }
 
             var bounds = MeasureShapedTextRunBounds(
@@ -896,7 +1008,7 @@ public static class NativeTextShaping
         SKPaint paint,
         float horizontalAdvanceScale)
     {
-        var shaped = shaper.Shape(text, 0, 0, paint);
+        var shaped = ShapeAtOrigin(shaper, text, paint);
         if (shaped.Codepoints.Length == 0 || shaped.Points.Length == 0)
         {
             return SKRect.Empty;
@@ -989,7 +1101,7 @@ public static class NativeTextShaping
             return;
         }
 
-        var tabularDigitWidth = shaper.Shape("0", paint).Width * tabularDigitScale;
+        var tabularDigitWidth = ShapeAtOrigin(shaper, "0", paint).Width * tabularDigitScale;
         for (var index = 0; index < text.Length;)
         {
             if (text[index] is >= '0' and <= '9')
@@ -1022,7 +1134,7 @@ public static class NativeTextShaping
                 horizontalAdvanceScale,
                 deviceScaleFactor,
                 rasterizationMode);
-            cursor += shaper.Shape(segment, paint).Width * horizontalAdvanceScale;
+            cursor += ShapeAtOrigin(shaper, segment, paint).Width * horizontalAdvanceScale;
         }
     }
 
@@ -1306,11 +1418,15 @@ public static class NativeTextShaping
         float letterSpacing = 0,
         float wordSpacing = 0)
     {
-        var result = shaper.Shape(text, 0, baseline, paint);
+        var result = ShapeAtOrigin(shaper, text, paint);
         if (result.Codepoints.Length == 0 || result.Points.Length == 0)
         {
             return;
         }
+
+        if (horizontalAdvanceScale == 1 && letterSpacing == 0 && wordSpacing == 0
+            && TextBlobs.Draw(canvas, shaper, text, result, paint, x, baseline, deviceScaleFactor, rasterizationMode))
+            return;
 
         using var font = paint.ToFont();
         font.Typeface = shaper.Typeface;
@@ -1332,7 +1448,7 @@ public static class NativeTextShaping
             positions[index] = new SKPoint(
                 x + result.Points[index].X * horizontalAdvanceScale
                     + spacingOffsets[index],
-                result.Points[index].Y);
+                baseline + result.Points[index].Y);
         }
 
         using var textBlob = builder.Build();

--- a/src/WebScene.Backend.Avalonia/NativeTextShaping.cs
+++ b/src/WebScene.Backend.Avalonia/NativeTextShaping.cs
@@ -55,34 +55,60 @@ public static class NativeTextShaping
     // Cache the immutable native glyph container as well as HarfBuzz output.
     // Draw coordinates and color are supplied at replay time. The short-run
     // limit and LRU bound native font/blob ownership to a small working set.
-    private sealed class TextBlobCache
+    internal sealed class TextBlobCache(int maximumEntries = 512) : IDisposable
     {
         private readonly record struct Key(int Face, string Text, float Size, float Scale,
             float Skew, bool Bold, bool AutoHint, SKTextEncoding Encoding, FontRasterizationProfile Profile);
-        private sealed record Entry(Key Key, WeakReference<SKTypeface> Face, SKTextBlob Blob);
+        internal sealed class BorrowedBlob(SKTextBlob blob)
+        {
+            internal SKTextBlob Blob { get; } = blob;
+            internal int Readers;
+            internal bool Retired;
+        }
+        private sealed record Entry(Key Key, WeakReference<SKTypeface> Face, BorrowedBlob Value);
         private readonly object _gate = new();
         private readonly Dictionary<Key, LinkedListNode<Entry>> _entries = [];
         private readonly LinkedList<Entry> _order = [];
+        private bool _disposed;
 
         public bool Draw(SKCanvas canvas, SKShaper shaper, string text, SKShaper.Result shaped,
             SKPaint paint, float x, float baseline, float deviceScale, NativeFontRasterizationMode? mode)
         {
-            if (text.Length > 256 || shaped.Codepoints.Length > 512) return false;
+            var borrowed = Acquire(shaper, text, shaped, paint, deviceScale, mode);
+            if (borrowed is null) return false;
+            try
+            {
+                canvas.DrawText(borrowed.Blob, x, baseline, paint);
+                return true;
+            }
+            finally
+            {
+                Release(borrowed);
+            }
+        }
+
+        internal BorrowedBlob? Acquire(SKShaper shaper, string text, SKShaper.Result shaped,
+            SKPaint paint, float deviceScale, NativeFontRasterizationMode? mode)
+        {
+            if (maximumEntries <= 0 || text.Length > 256 || shaped.Codepoints.Length > 512
+                || shaped.Codepoints.Length == 0 || shaped.Codepoints.Length != shaped.Points.Length)
+                return null;
             var face = shaper.Typeface;
             var key = new Key(System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(face), text,
                 paint.TextSize, paint.TextScaleX, paint.TextSkewX, paint.FakeBoldText, paint.IsAutohinted, paint.TextEncoding,
                 ResolveFontRasterizationProfile(deviceScale, mode));
             lock (_gate)
             {
+                ObjectDisposedException.ThrowIf(_disposed, this);
                 if (_entries.TryGetValue(key, out var found))
                 {
                     if (found.Value.Face.TryGetTarget(out var previous) && ReferenceEquals(previous, face))
                     {
                         _order.Remove(found); _order.AddLast(found);
-                        canvas.DrawText(found.Value.Blob, x, baseline, paint);
-                        return true;
+                        found.Value.Value.Readers++;
+                        return found.Value.Value;
                     }
-                    _entries.Remove(key); _order.Remove(found); found.Value.Blob.Dispose();
+                    _entries.Remove(key); _order.Remove(found); Retire(found.Value.Value);
                 }
                 using var font = paint.ToFont();
                 font.Typeface = face;
@@ -96,15 +122,42 @@ public static class NativeTextShaping
                     run.GetPositionSpan()[index] = shaped.Points[index];
                 }
                 var blob = builder.Build();
-                if (blob is null) return false;
-                if (_entries.Count == 512)
+                if (blob is null) return null;
+                if (_entries.Count == maximumEntries)
                 {
                     var oldest = _order.First!;
-                    _entries.Remove(oldest.Value.Key); _order.RemoveFirst(); oldest.Value.Blob.Dispose();
+                    _entries.Remove(oldest.Value.Key); _order.RemoveFirst(); Retire(oldest.Value.Value);
                 }
-                _entries.Add(key, _order.AddLast(new Entry(key, new WeakReference<SKTypeface>(face), blob)));
-                canvas.DrawText(blob, x, baseline, paint);
-                return true;
+                var value = new BorrowedBlob(blob) { Readers = 1 };
+                _entries.Add(key, _order.AddLast(new Entry(key, new WeakReference<SKTypeface>(face), value)));
+                return value;
+            }
+        }
+
+        // Readers pin a blob across native drawing without holding the cache lock.
+        // Eviction releases cache ownership; the final reader disposes it.
+        private static void Retire(BorrowedBlob value)
+        {
+            value.Retired = true;
+            if (value.Readers == 0) value.Blob.Dispose();
+        }
+
+        internal void Release(BorrowedBlob value)
+        {
+            lock (_gate)
+            {
+                if (--value.Readers == 0 && value.Retired) value.Blob.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_gate)
+            {
+                _disposed = true;
+                foreach (var entry in _order) Retire(entry.Value);
+                _entries.Clear();
+                _order.Clear();
             }
         }
     }

--- a/tests/WebScene.Backend.Avalonia.Tests/ShapedRunCacheTests.cs
+++ b/tests/WebScene.Backend.Avalonia.Tests/ShapedRunCacheTests.cs
@@ -107,4 +107,107 @@ public sealed class ShapedRunCacheTests
         Assert.Equal(before, cache.Occupancy);
         Assert.InRange(cache.Occupancy.Bytes, 1, 1024);
     }
+    [Fact]
+    public void BlobEvictionHonorsLruAndPinsActiveReaders()
+    {
+        using var cache = new NativeTextShaping.TextBlobCache(2);
+        using var shaper = new SKShaper(SKTypeface.Default);
+        using var paint = new SKPaint { TextSize = 18 };
+        NativeTextShaping.TextBlobCache.BorrowedBlob Acquire(string text)
+            => cache.Acquire(shaper, text, shaper.Shape(text, paint), paint, 1, null)!;
+        var first = Acquire("one");
+        cache.Release(first);
+        var second = Acquire("two");
+        cache.Release(second);
+        var reader = Acquire("one");
+        Assert.Same(first, reader);
+        var third = Acquire("three");
+        cache.Release(third);
+        Assert.Equal(IntPtr.Zero, second.Blob.Handle);
+        var fourth = Acquire("four");
+        cache.Release(fourth);
+        Assert.NotEqual(IntPtr.Zero, first.Blob.Handle);
+        cache.Release(reader);
+        Assert.Equal(IntPtr.Zero, first.Blob.Handle);
+        cache.Dispose();
+        Assert.Equal(IntPtr.Zero, third.Blob.Handle);
+        Assert.Equal(IntPtr.Zero, fourth.Blob.Handle);
+    }
+
+    [Fact]
+    public void DisposingCacheDefersDisposalUntilLastReaderReturns()
+    {
+        using var cache = new NativeTextShaping.TextBlobCache();
+        using var shaper = new SKShaper(SKTypeface.Default);
+        using var paint = new SKPaint { TextSize = 18 };
+        var shaped = shaper.Shape("same", paint);
+        var first = cache.Acquire(shaper, "same", shaped, paint, 1, null)!;
+        var second = cache.Acquire(shaper, "same", shaped, paint, 1, null)!;
+        Assert.Same(first, second);
+        cache.Dispose();
+        cache.Release(first);
+        Assert.NotEqual(IntPtr.Zero, second.Blob.Handle);
+        cache.Release(second);
+        Assert.Equal(IntPtr.Zero, second.Blob.Handle);
+    }
+
+    [Fact]
+    public void BlobCacheRejectsOversizedRunsAndSeparatesRasterizationProfiles()
+    {
+        using var cache = new NativeTextShaping.TextBlobCache();
+        using var shaper = new SKShaper(SKTypeface.Default);
+        using var paint = new SKPaint { TextSize = 18 };
+        var text = new string('W', 257);
+        Assert.Null(cache.Acquire(shaper, text, shaper.Shape(text, paint), paint, 1, null));
+        var shaped = shaper.Shape("label", paint);
+        var first = cache.Acquire(shaper, "label", shaped, paint, 1,
+            NativeTextShaping.NativeFontRasterizationMode.Current)!;
+        var second = cache.Acquire(shaper, "label", shaped, paint, 2,
+            NativeTextShaping.NativeFontRasterizationMode.Current)!;
+        Assert.NotSame(first, second);
+        paint.Color = SKColors.Red;
+        var colored = cache.Acquire(shaper, "label", shaped, paint, 1,
+            NativeTextShaping.NativeFontRasterizationMode.Current)!;
+        Assert.Same(first, colored);
+        cache.Release(first);
+        cache.Release(second);
+        cache.Release(colored);
+    }
+
+    [Fact]
+    public void ConcurrentDrawingDuringEvictionMatchesUncachedPixels()
+    {
+        using var cache = new NativeTextShaping.TextBlobCache(2);
+        Parallel.For(0, 8, worker =>
+        {
+            using var shaper = new SKShaper(SKTypeface.Default);
+            using var paint = new SKPaint { TextSize = 20, Color = SKColors.Black };
+            using var expected = new SKBitmap(300, 60);
+            using var actual = new SKBitmap(300, 60);
+            using var expectedCanvas = new SKCanvas(expected);
+            using var actualCanvas = new SKCanvas(actual);
+            for (var i = 0; i < 100; i++)
+            {
+                var text = $"office a\u0301 {worker} {i % 4}";
+                var shaped = shaper.Shape(text, paint);
+                expectedCanvas.Clear(SKColors.White);
+                actualCanvas.Clear(SKColors.White);
+                using var font = paint.ToFont();
+                NativeTextShaping.ApplyFontRasterizationProfile(font, 2,
+                    NativeTextShaping.NativeFontRasterizationMode.Current);
+                using var builder = new SKTextBlobBuilder();
+                var run = builder.AllocatePositionedRun(font, shaped.Codepoints.Length);
+                for (var j = 0; j < shaped.Codepoints.Length; j++)
+                {
+                    run.GetGlyphSpan()[j] = (ushort)shaped.Codepoints[j];
+                    run.GetPositionSpan()[j] = shaped.Points[j];
+                }
+                using var blob = builder.Build();
+                expectedCanvas.DrawText(blob, 13.25f, 30.125f, paint);
+                Assert.True(cache.Draw(actualCanvas, shaper, text, shaped, paint, 13.25f, 30.125f, 2,
+                    NativeTextShaping.NativeFontRasterizationMode.Current));
+                Assert.Equal(expected.Pixels, actual.Pixels);
+            }
+        });
+    }
 }

--- a/tests/WebScene.Backend.Avalonia.Tests/ShapedRunCacheTests.cs
+++ b/tests/WebScene.Backend.Avalonia.Tests/ShapedRunCacheTests.cs
@@ -1,0 +1,110 @@
+using SkiaSharp;
+using SkiaSharp.HarfBuzz;
+using WebScene.Backends.Avalonia.Native;
+using Xunit;
+
+namespace WebScene.Backend.Avalonia.Tests;
+
+public sealed class ShapedRunCacheTests
+{
+    [Theory]
+    [InlineData("Courtyard House 123")]
+    [InlineData("office a\u0301 العربية")]
+    public void CachedRunsMatchShaperAndSeparateSizeScaleAndEncoding(string text)
+    {
+        var cache = new NativeTextShaping.ShapedRunCache(8, 32768);
+        using var face = SKTypeface.FromFamilyName("sans-serif");
+        using var shaper = new SKShaper(face);
+        using var paint = new SKPaint { Typeface = face, TextSize = 14 };
+        var first = cache.Shape(shaper, text, paint);
+        using var anotherShaper = new SKShaper(face);
+        paint.Color = SKColors.Red;
+        Assert.Same(first, cache.Shape(anotherShaper, text, paint));
+        foreach (var settings in new[] { (14f, 1f, SKTextEncoding.Utf8), (18f, 1f, SKTextEncoding.Utf8),
+                     (18f, 1.3f, SKTextEncoding.Utf8), (18f, 1.3f, SKTextEncoding.Utf16) })
+        {
+            paint.TextSize = settings.Item1; paint.TextScaleX = settings.Item2; paint.TextEncoding = settings.Item3;
+            var expected = shaper.Shape(text, 0, 0, paint);
+            var actual = cache.Shape(shaper, text, paint);
+            Assert.Equal(expected.Width, actual.Width);
+            Assert.Equal(expected.Codepoints, actual.Codepoints);
+            Assert.Equal(expected.Clusters, actual.Clusters);
+            Assert.Equal(expected.Points, actual.Points);
+        }
+        Assert.Equal(4, cache.Occupancy.Count);
+    }
+
+    [Theory]
+    [InlineData(0, false, 0, false)]
+    [InlineData(13.25f, false, 0, false)]
+    [InlineData(13.25f, true, -0.2f, false)]
+    [InlineData(13.25f, false, 0, true)]
+    public void CachedDrawingMatchesUncachedGlyphPositionsAtDifferentBaselines(float x, bool bold, float skew, bool autoHint)
+    {
+        const string text = "office a\u0301";
+        using var shaper = new SKShaper(SKTypeface.Default);
+        using var paint = new SKPaint { Typeface = shaper.Typeface, TextSize = 22, Color = SKColors.Black,
+            FakeBoldText = bold, TextSkewX = skew, IsAutohinted = autoHint };
+        using var expected = new SKBitmap(300, 100);
+        using var actual = new SKBitmap(300, 100);
+        using var expectedCanvas = new SKCanvas(expected);
+        using var actualCanvas = new SKCanvas(actual);
+        expectedCanvas.Clear(SKColors.White);
+        actualCanvas.Clear(SKColors.White);
+        foreach (var baseline in new[] { 30.125f, 70.125f })
+        {
+            var shaped = shaper.Shape(text, 0, baseline, paint);
+            using var font = paint.ToFont();
+            NativeTextShaping.ApplyFontRasterizationProfile(font, 1,
+                NativeTextShaping.NativeFontRasterizationMode.Current);
+            using var builder = new SKTextBlobBuilder();
+            var run = builder.AllocatePositionedRun(font, shaped.Codepoints.Length);
+            for (var index = 0; index < shaped.Codepoints.Length; index++)
+            {
+                run.GetGlyphSpan()[index] = (ushort)shaped.Codepoints[index];
+                run.GetPositionSpan()[index] = new SKPoint(x + shaped.Points[index].X, shaped.Points[index].Y);
+            }
+            using var blob = builder.Build();
+            expectedCanvas.DrawText(blob, 0, 0, paint);
+            NativeTextShaping.DrawShapedText(actualCanvas, shaper, text, x, baseline, paint, 0,
+                rasterizationMode: NativeTextShaping.NativeFontRasterizationMode.Current);
+        }
+        Assert.Equal(expected.Pixels, actual.Pixels);
+    }
+
+    [Fact]
+    public void ReplacingTypefaceCannotReuseThePreviousFontsGlyphs()
+    {
+        var cache = new NativeTextShaping.ShapedRunCache(8, 32768);
+        var root = new DirectoryInfo(AppContext.BaseDirectory);
+        while (root is not null && !File.Exists(Path.Combine(root.FullName, "tests/Fonts/Roboto/Roboto-400.ttf")))
+            root = root.Parent;
+        Assert.NotNull(root);
+        using var firstFace = SKTypeface.FromFile(Path.Combine(root.FullName, "tests/Fonts/Roboto/Roboto-400.ttf"));
+        using var secondFace = SKTypeface.FromFile(Path.Combine(root.FullName, "tests/Fonts/Roboto/Roboto-700.ttf"));
+        using var firstShaper = new SKShaper(firstFace);
+        using var secondShaper = new SKShaper(secondFace);
+        using var paint = new SKPaint { TextSize = 16 };
+        var first = cache.Shape(firstShaper, "WWiii", paint);
+        var second = cache.Shape(secondShaper, "WWiii", paint);
+        Assert.NotSame(first, second);
+        Assert.Equal(secondShaper.Shape("WWiii", paint).Points, second.Points);
+    }
+
+    [Fact]
+    public void EvictionAndOversizedRunsRespectBothBounds()
+    {
+        var cache = new NativeTextShaping.ShapedRunCache(2, 1024);
+        using var shaper = new SKShaper(SKTypeface.Default);
+        using var paint = new SKPaint { TextSize = 14 };
+        var oldest = cache.Shape(shaper, "one", paint);
+        cache.Shape(shaper, "two", paint);
+        cache.Shape(shaper, "three", paint);
+        Assert.Equal(2, cache.Occupancy.Count);
+        Assert.NotSame(oldest, cache.Shape(shaper, "one", paint));
+        var before = cache.Occupancy;
+        cache.Shape(shaper, new string('W', 1000), paint);
+        Assert.Equal(before, cache.Occupancy);
+        Assert.InRange(cache.Occupancy.Bytes, 1, 1024);
+    }
+}


### PR DESCRIPTION
Repeated text measurement and drawing rerun HarfBuzz shaping and recreate Skia text blobs. Cache origin-relative shaped runs and short-run text blobs so repeated labels reuse glyph data while positioning, color and rasterization remain correct. NativeTextShaping is shared by Avalonia and Uno, including CPU rendering and macOS.

Shaped runs are bounded to 2,048 entries / an estimated 4 MiB, keyed by typeface identity, text, size, scale and encoding. Short text blobs use a 512-entry LRU with styling and rasterization keys. Active readers pin blobs while drawing outside the cache lock; eviction disposes a blob after its final reader returns. Spaced/scaled drawing retains the existing positioning path. This builds on #49 and adds no WebGPU, frame-pacing or canvas-checkpoint changes.

The Linux native-package failure also exposed a GC test assumption: offering V8 idle time does not guarantee collection. Tests now complete script setup before explicitly requesting GC, observe detached nodes in scene counters before requesting collection, and verify that the count falls afterward. They avoid the five-second heap snapshot refresh interval. Low-memory notifications reschedule bounded detached-node cleanup, including batches below the 512-node mutation threshold. Certification checks wait for fresh diagnostic counters while preserving the existing batch limits. This native fix is in a separate commit.

Validation:
- macOS: all 75 NativeTextShapingTests / ShapedRunCacheTests pass on both .NET 8 and .NET 10, including blob disposal, active-reader lifetime, LRU eviction, rasterization separation and concurrent pixel equivalence during eviction.
- macOS: focused native detached-DOM GC tests pass with certification enabled, covering small batches, 2,048 detached nodes, reachable-wrapper identity and bounded release slices.
- macOS CPU warm-label probe: median shaping 3.70 → 0.15 µs; shaping plus bitmap drawing 6.96 → 2.14 µs. Both cached operations report zero managed allocations.
- Original Windows validation at 0d32a5cf: 71 focused tests on each framework, clean Uno Release build, and warm-label medians of 3.00 → 0.15 µs shaping and 7.07 → 3.26 µs drawing.
- git diff --check passes. Updated Linux/Windows/macOS CI is running.

Probe code, methodology and raw samples are in docs/validation/text-cache.md, text-cache-windows.json and text-cache-macos.json. These are warm microbenchmark results; cold workloads, concurrent throughput and application frame rates remain unmeasured.
