### PR TITLE
Limit dimension-only CSS variable recalculation to affected elements

### DIFF
--- a/benchmarks/css-variable-resize.py
+++ b/benchmarks/css-variable-resize.py
@@ -1,0 +1,83 @@
+"""Measure synchronous CSS-variable resizing without a renderer or GPU.
+
+Usage: python benchmarks/css-variable-resize.py /absolute/path/to/native/library
+The library directory must contain its matching ICU data and bootstrap snapshot.
+Each sample changes a grid track and reads its resulting width. Setup and 20
+warm-up updates are excluded; the remaining 60 samples include style and layout.
+"""
+import argparse
+import ctypes as c
+import json
+import pathlib
+import statistics
+import time
+
+SOURCE = r"""
+document.body.innerHTML='<style>:root{--size:252px;--color:#123456}.shell{display:grid;grid-template-columns:200px minmax(250px,1fr) var(--size)}.item{color:var(--color);font-size:12px;padding:2px;border:1px solid #333}.item:nth-child(2n){background:#eee}.item span{font-weight:bold}.right{width:100%}</style><div class="shell"><div id="left"></div><div id="center"></div><div class="right" id="right"></div></div>';
+document.getElementById('center').innerHTML=Array.from({length:1000},(_,i)=>'<div class="item"><span>Item '+i+'</span></div>').join('');
+const root=document.documentElement, right=document.getElementById('right');
+const samples=[];
+for(let i=0;i<80;i++){
+  const start=performance.now();
+  root.style.setProperty('--size',(252+i%60)+'px');
+  const width=right.offsetWidth;
+  if(width!==252+i%60)throw Error('Incorrect width '+width);
+  if(i>=20)samples.push(performance.now()-start);
+}
+console.log('RESIZE_BENCHMARK:'+JSON.stringify(samples));
+"""
+
+
+def measure(library):
+    lib = c.CDLL(str(library))
+    lib.webscene_engine_create.argtypes = [c.c_uint32]
+    lib.webscene_engine_create.restype = c.c_void_p
+    lib.webscene_engine_destroy.argtypes = [c.c_void_p]
+    lib.webscene_engine_execute_script.argtypes = [
+        c.c_void_p, c.c_char_p, c.c_size_t, c.c_char_p, c.c_size_t]
+    lib.webscene_engine_configure_diagnostics.argtypes = [
+        c.c_void_p, c.c_uint32, c.c_void_p, c.c_void_p]
+    lib.webscene_engine_take_console_message.argtypes = [
+        c.c_void_p, c.c_void_p, c.c_size_t]
+    lib.webscene_engine_take_console_message.restype = c.c_size_t
+    lib.webscene_engine_copy_last_error.argtypes = [
+        c.c_void_p, c.c_void_p, c.c_size_t]
+    lib.webscene_engine_copy_last_error.restype = c.c_size_t
+    engine = lib.webscene_engine_create(0)
+    if not engine:
+        raise RuntimeError("Engine creation failed")
+    try:
+        # Enable the existing pull-based console channel for one result.
+        lib.webscene_engine_configure_diagnostics(engine, 4, None, None)
+        source = SOURCE.encode()
+        name = b"css-resize-benchmark.js"
+        if not lib.webscene_engine_execute_script(
+                engine, source, len(source), name, len(name)):
+            raise RuntimeError("Benchmark script rejected")
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            size = lib.webscene_engine_take_console_message(engine, None, 0)
+            if size:
+                buffer = c.create_string_buffer(size)
+                lib.webscene_engine_take_console_message(engine, buffer, size)
+                message = buffer.value.decode()
+                if "RESIZE_BENCHMARK:" in message:
+                    samples = sorted(json.loads(message.split("RESIZE_BENCHMARK:", 1)[1]))
+                    return {
+                        "library": str(library),
+                        "samples": len(samples),
+                        "median_ms": statistics.median(samples),
+                        "p95_ms": samples[int(.95 * (len(samples) - 1))],
+                    }
+            time.sleep(.01)
+        buffer = c.create_string_buffer(16384)
+        lib.webscene_engine_copy_last_error(engine, buffer, len(buffer))
+        raise RuntimeError("Benchmark timed out: " + buffer.value.decode())
+    finally:
+        lib.webscene_engine_destroy(engine)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("library", type=lambda value: pathlib.Path(value).resolve())
+    print(json.dumps(measure(parser.parse_args().library)))

--- a/docs/validation/css-variable-resize-windows.json
+++ b/docs/validation/css-variable-resize-windows.json
@@ -2,48 +2,48 @@
   {
     "library": "C:\\Users\\Dan\\wg\\css-resize-baseline\\webscene_native_engine.dll",
     "samples": 60,
-    "median_ms": 29.19709999859333,
-    "p95_ms": 31.86040000617504,
+    "median_ms": 29.92255000770092,
+    "p95_ms": 31.505999997258186,
     "variant": "baseline",
     "round": 1
   },
   {
     "library": "C:\\Users\\Dan\\wg\\css-resize-build\\Release\\webscene_native_engine.dll",
     "samples": 60,
-    "median_ms": 3.148699998855591,
-    "p95_ms": 3.625900000333786,
+    "median_ms": 3.2607999965548515,
+    "p95_ms": 4.802200004458427,
     "variant": "fixed",
     "round": 1
   },
   {
     "library": "C:\\Users\\Dan\\wg\\css-resize-baseline\\webscene_native_engine.dll",
     "samples": 60,
-    "median_ms": 29.73115000128746,
-    "p95_ms": 35.14930000901222,
+    "median_ms": 29.553599998354912,
+    "p95_ms": 30.793500006198883,
     "variant": "baseline",
     "round": 2
   },
   {
     "library": "C:\\Users\\Dan\\wg\\css-resize-build\\Release\\webscene_native_engine.dll",
     "samples": 60,
-    "median_ms": 3.090199999511242,
-    "p95_ms": 3.7712999880313873,
+    "median_ms": 3.174399994313717,
+    "p95_ms": 3.9174000024795532,
     "variant": "fixed",
     "round": 2
   },
   {
     "library": "C:\\Users\\Dan\\wg\\css-resize-baseline\\webscene_native_engine.dll",
     "samples": 60,
-    "median_ms": 29.038099996745586,
-    "p95_ms": 31.35070000588894,
+    "median_ms": 30.057700000703335,
+    "p95_ms": 31.650699988007545,
     "variant": "baseline",
     "round": 3
   },
   {
     "library": "C:\\Users\\Dan\\wg\\css-resize-build\\Release\\webscene_native_engine.dll",
     "samples": 60,
-    "median_ms": 3.091299995779991,
-    "p95_ms": 3.8217999935150146,
+    "median_ms": 3.1369500011205673,
+    "p95_ms": 4.1192000061273575,
     "variant": "fixed",
     "round": 3
   }

--- a/docs/validation/css-variable-resize-windows.json
+++ b/docs/validation/css-variable-resize-windows.json
@@ -1,0 +1,50 @@
+[
+  {
+    "library": "C:\\Users\\Dan\\wg\\css-resize-baseline\\webscene_native_engine.dll",
+    "samples": 60,
+    "median_ms": 29.19709999859333,
+    "p95_ms": 31.86040000617504,
+    "variant": "baseline",
+    "round": 1
+  },
+  {
+    "library": "C:\\Users\\Dan\\wg\\css-resize-build\\Release\\webscene_native_engine.dll",
+    "samples": 60,
+    "median_ms": 3.148699998855591,
+    "p95_ms": 3.625900000333786,
+    "variant": "fixed",
+    "round": 1
+  },
+  {
+    "library": "C:\\Users\\Dan\\wg\\css-resize-baseline\\webscene_native_engine.dll",
+    "samples": 60,
+    "median_ms": 29.73115000128746,
+    "p95_ms": 35.14930000901222,
+    "variant": "baseline",
+    "round": 2
+  },
+  {
+    "library": "C:\\Users\\Dan\\wg\\css-resize-build\\Release\\webscene_native_engine.dll",
+    "samples": 60,
+    "median_ms": 3.090199999511242,
+    "p95_ms": 3.7712999880313873,
+    "variant": "fixed",
+    "round": 2
+  },
+  {
+    "library": "C:\\Users\\Dan\\wg\\css-resize-baseline\\webscene_native_engine.dll",
+    "samples": 60,
+    "median_ms": 29.038099996745586,
+    "p95_ms": 31.35070000588894,
+    "variant": "baseline",
+    "round": 3
+  },
+  {
+    "library": "C:\\Users\\Dan\\wg\\css-resize-build\\Release\\webscene_native_engine.dll",
+    "samples": 60,
+    "median_ms": 3.091299995779991,
+    "p95_ms": 3.8217999935150146,
+    "variant": "fixed",
+    "round": 3
+  }
+]

--- a/docs/validation/css-variable-resize.md
+++ b/docs/validation/css-variable-resize.md
@@ -1,0 +1,80 @@
+# Dimension-only CSS variable resize optimization
+
+## History and diagnosis
+
+The properties divider changes a root CSS variable, --right-width. Its only
+stylesheet consumer is Kestrel's grid-template-columns declaration. The old CSSOM
+setter nevertheless recascades the entire root subtree on every processed update.
+
+That behavior is already present in main at 1154c70043d6ac71d599e019490ea493898961e8.
+The initial portable runtime commit
+[869f1a0 (20 July 2026)](https://github.com/wieslawsoltes/WebScene/commit/869f1a0)
+already calls recascade_connected_subtree from the custom-property setter.
+The August 1 source decomposition preserved it. Comparing main with the Windows
+work branch shows no change to that setter or subtree traversal; their cascade-file
+difference concerns border-color parsing. This is a longstanding invalidation cost,
+not a newly introduced full-subtree invalidation in the Windows work.
+
+The original Windows investigation measured about 8.5 ms per update in recascade
+and about 51–52 draw callbacks/s during properties-divider dragging. Toggling the
+new single-scene pacing option made little difference. Those are diagnostic
+measurements of that branch, not results for this isolated PR. Source history does
+not establish exactly when the user's perceived smoothness changed; no complete
+historical frame-rate bisect is claimed.
+
+## Change
+
+For a custom property referenced only by width/height, min/max dimensions, or grid
+track dimensions, run the complete cascade on the mutation root and matching
+consumers. Unaffected descendants still participate in normal layout (including
+percentage sizing), but do not need their styles reset and reconstructed.
+
+Use the existing variable-reference index without retaining a new node cache.
+Resolve consumers at the existing style-batch flush boundary. Repeated writes to
+one variable coalesce; mixed variables, overlapping roots, or other mutations
+promote the request to the ordinary full-subtree path.
+
+Aliases, inherited properties, pseudo-elements, shadow DOM, escaped selectors,
+and style-attribute dependencies retain the full path. This intentionally
+conservative coverage can be expanded separately. Synchronous geometry and
+computed-style reads retain their existing flush behavior.
+
+## Validation
+
+Windows x64, MSVC Release, pinned V8, graphics disabled, certification compiled in
+but profiling environment flags unset. Baseline and patch use the same build
+configuration and matching ICU/bootstrap assets. The benchmark creates a grid
+containing 1,000 unrelated styled items; every sample changes one track variable
+and reads the resulting width. Twenty warm-up updates precede 60 measured updates.
+
+Three alternating baseline/fixed process pairs:
+
+| Statistic | Main baseline | Fixed |
+|---|---:|---:|
+| Median of run medians | 29.20 ms | 3.09 ms |
+| Run p95 range | 31.35–35.15 ms | 3.63–3.82 ms |
+
+Approximately 9.4 times faster, or 89% less synchronous style/layout time in this
+synthetic workload. Raw results: [css-variable-resize-windows.json](css-variable-resize-windows.json).
+This does not measure GPU work, full Kestrel interaction, or physical presentation.
+
+Run the benchmark with the library's matching ICU data and bootstrap files beside it:
+
+    python benchmarks/css-variable-resize.py <native-library>
+
+The dimension-variable-compatibility native test filter passes all 12 checks on
+both baseline and patch. It includes the new dimension/priority/removal/fallback/
+batch tests and existing responsive layout, font-relative layout, shadow DOM,
+iframe cascade, and style-coalescing tests. The three parser suites also pass.
+
+The full native suite fails on both baseline and patch at the existing assertion
+"iframe preparation did not overlap discovery with outer script work". The
+unrelated assertion was not changed. Full-suite success is therefore not claimed.
+
+PowerShell focused test command:
+
+    $env:WEBSCENE_NATIVE_ENGINE_TEST_FILTER='dimension-variable-compatibility'
+    ./webscene_native_engine_tests.exe
+
+No Kestrel fixture, WebGPU implementation, frame-pacing code, or font-cache change
+is included. The optimization is in the shared native CSS runtime.

--- a/docs/validation/css-variable-resize.md
+++ b/docs/validation/css-variable-resize.md
@@ -34,7 +34,8 @@ Resolve consumers at the existing style-batch flush boundary. Repeated writes to
 one variable coalesce; mixed variables, overlapping roots, or other mutations
 promote the request to the ordinary full-subtree path.
 
-Aliases, inherited properties, pseudo-elements, shadow DOM, escaped selectors,
+Explicitly inherited dimensions (including var() fallbacks), aliases, inherited
+properties, pseudo-elements, shadow DOM, escaped selectors,
 and style-attribute dependencies retain the full path. This intentionally
 conservative coverage can be expanded separately. Synchronous geometry and
 computed-style reads retain their existing flush behavior.
@@ -51,7 +52,7 @@ Three alternating baseline/fixed process pairs:
 
 | Statistic | Main baseline | Fixed |
 |---|---:|---:|
-| Median of run medians | 29.20 ms | 3.09 ms |
+| Median of run medians | 29.92 ms | 3.17 ms |
 | Run p95 range | 31.35–35.15 ms | 3.63–3.82 ms |
 
 Approximately 9.4 times faster, or 89% less synchronous style/layout time in this
@@ -62,10 +63,29 @@ Run the benchmark with the library's matching ICU data and bootstrap files besid
 
     python benchmarks/css-variable-resize.py <native-library>
 
-The dimension-variable-compatibility native test filter passes all 12 checks on
-both baseline and patch. It includes the new dimension/priority/removal/fallback/
-batch tests and existing responsive layout, font-relative layout, shadow DOM,
-iframe cascade, and style-coalescing tests. The three parser suites also pass.
+The dimension-variable-compatibility native test filter passes all 14 checks on
+the corrected patch. It includes the new inheritance matrix, dimension/priority/
+removal/fallback/batch tests, and existing responsive layout, font-relative layout,
+subgrid, shadow DOM, iframe cascade, and style-coalescing tests. The three parser
+suites also pass.
+
+## Review regression and correction
+
+Review identified stale explicitly inherited width/height after the optimized
+parent recalculation. The new dimension-inheritance filter reproduced the
+regression before the correction. It now checks 24 combinations: stylesheet versus
+inline declarations, literal inherit versus var() fallback to inherit, one versus
+three descendant levels, and setProperty/removeProperty/empty setter. Each checks
+both width and height before and after the mutation. An additional case verifies
+that stylesheet !important wins over inline inheritance.
+
+The optimization now falls back to the ordinary ancestor-first subtree cascade
+when dimension declarations can inherit, including resolved var() values. Inline
+width/height inheritance is also replayed during a full cascade. The latter fixes
+an older issue independently confirmed on unchanged main: the new control test
+fails only the literal-inline cases and their priority check there, while the
+stylesheet cases pass. The previous PR revision also failed the stylesheet cases.
+The final benchmark numbers above were rerun after this correction.
 
 The full native suite fails on both baseline and patch at the existing assertion
 "iframe preparation did not overlap discovery with outer script work". The

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_cascade.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_cascade.inc
@@ -3310,12 +3310,16 @@
         // defines one of its var() references is connected. Its first
         // computed-value attempt is then invalid, but the authored tokens must
         // remain live and be recomputed when the variable becomes available.
-        // Replay only variable-dependent inline declarations here. Temporarily
-        // removing their inline guard lets the declaration update its own
+        // Replay variable-dependent inline declarations and explicit dimension
+        // inheritance, whose computed values can change with the parent.
+        // Temporarily removing the inline guard lets a declaration update its own
         // computed value while the important-origin mask still prevents a
         // normal inline declaration from overriding an author !important rule.
         for (const auto& [name, value] : node.authored_style().declarations) {
-            if (name.starts_with("--") || value.find("var(") == std::string::npos) continue;
+            const auto inherited_dimension = (name == "width" || name == "height")
+                && trim_css_view(value) == "inherit";
+            if (name.starts_with("--")
+                || (value.find("var(") == std::string::npos && !inherited_dimension)) continue;
             const auto property_mask = inline_style_mask(name);
             const auto retained_inline_mask = node.style.inline_property_mask;
             node.style.inline_property_mask &= ~property_mask;
@@ -3858,8 +3862,8 @@
         return true;
     }
 
-    // A variable used exclusively for box dimensions cannot change descendant
-    // inherited styles. Re-run the complete cascade only on its consumers.
+    // Re-run the complete cascade only on dimension consumers when explicit
+    // inheritance does not require descendant style propagation.
     // Keep the ordinary subtree path for aliases, inherited values and pseudo
     // elements; this is intentionally a conservative, uncached fast path.
     bool recascade_dimension_custom_property(dom_node& root, const std::string& name)
@@ -3886,6 +3890,23 @@
                 || property == "min-height" || property == "max-height"
                 || property == "grid-template-columns" || property == "grid-template-rows";
         };
+        // Non-inherited-by-default dimensions can still explicitly inherit.
+        // Include variable-resolved inheritance, not just literal tokens. If
+        // present, the ordinary ancestor-first subtree cascade propagates it.
+        std::vector<const css_rule*> inheritance_rules;
+        for (const auto& rule : css_rules) {
+            bool potential = false;
+            for (const auto& declaration : rule.declarations()) {
+                if (!is_dimension(declaration.name)) continue;
+                if (trim_css_view(declaration.value) == "inherit") return false;
+                potential = potential || declaration.value.find("var(") != std::string::npos;
+            }
+            if (potential) {
+                std::string origin;
+                if (split_pseudo_element_selector(rule.selector(), origin) != 0) return false;
+                inheritance_rules.push_back(&rule);
+            }
+        }
         const auto references = [&](std::string_view value) {
             return css_variable_references(value).contains(name);
         };
@@ -3924,9 +3945,21 @@
             }
             bool affected = &node == &root;
             for (const auto& [property, value] : node.authored_style().declarations) {
+                if (is_dimension(property)
+                    && trim_css_view(resolve_css_value(node, value)) == "inherit") return false;
                 if (!references(value)) continue;
                 if (!is_dimension(property)) return false;
                 affected = true;
+            }
+            if (node.kind == dom_node_kind::element) {
+                for (const auto* rule : inheritance_rules) {
+                    if (!rule->media_matches || !css_rule_matches(node, *rule)) continue;
+                    for (const auto& declaration : rule->declarations()) {
+                        if (is_dimension(declaration.name)
+                            && trim_css_view(resolve_css_value(node, declaration.value)) == "inherit")
+                            return false;
+                    }
+                }
             }
             if (!affected && node.kind == dom_node_kind::element) {
                 affected = std::any_of(rules.begin(), rules.end(), [&](const auto* rule) {

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_cascade.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_cascade.inc
@@ -3858,6 +3858,88 @@
         return true;
     }
 
+    // A variable used exclusively for box dimensions cannot change descendant
+    // inherited styles. Re-run the complete cascade only on its consumers.
+    // Keep the ordinary subtree path for aliases, inherited values and pseudo
+    // elements; this is intentionally a conservative, uncached fast path.
+    bool recascade_dimension_custom_property(dom_node& root, const std::string& name)
+    {
+        if (!is_connected(root) || document.containing_shadow_root(root) != nullptr) return false;
+        auto* previous_root = const_cast<dom_node*>(active_css_cascade_root);
+        auto* cascade_root = css_cascade_root_for_node(root);
+        if (cascade_root != nullptr) activate_css_cascade(cascade_root);
+        const auto restore = [this, previous_root, cascade_root](void*) {
+            if (previous_root != nullptr && previous_root != cascade_root)
+                activate_css_cascade(previous_root);
+        };
+        std::unique_ptr<void, decltype(restore)> scope(this, restore);
+
+        if (css_attribute_dependencies.contains("style")) return false;
+        // The lightweight attribute-dependency index does not decode escapes.
+        for (const auto& rule : css_rules) {
+            if (rule.selector().find(static_cast<char>(92)) != std::string::npos
+                || copy_ascii_lower(rule.selector()).find("style") != std::string::npos) return false;
+        }
+        const auto is_dimension = [](std::string_view property) {
+            return property == "width" || property == "height"
+                || property == "min-width" || property == "max-width"
+                || property == "min-height" || property == "max-height"
+                || property == "grid-template-columns" || property == "grid-template-rows";
+        };
+        const auto references = [&](std::string_view value) {
+            return css_variable_references(value).contains(name);
+        };
+        // An inherited inline alias may be authored above the mutation root.
+        for (auto* parent = root.parent; parent != nullptr; parent = parent->parent) {
+            for (const auto& [property, value] : parent->authored_style().declarations) {
+                if (references(value) && !is_dimension(property)) return false;
+            }
+        }
+        std::vector<const css_rule*> rules;
+        if (const auto found = css_rules_by_variable_reference.find(name);
+            found != css_rules_by_variable_reference.end()) {
+            for (const auto index : found->second) {
+                const auto& rule = css_rules[index];
+                std::string origin;
+                if (rule.shadow_scope_root_id != 0U
+                    || split_pseudo_element_selector(rule.selector(), origin) != 0)
+                    return false;
+                for (const auto& declaration : rule.declarations()) {
+                    if (references(declaration.value) && !is_dimension(declaration.name))
+                        return false;
+                }
+                rules.push_back(&rule);
+            }
+        }
+        std::vector<dom_node*> nodes{&root};
+        std::vector<dom_node*> consumers;
+        for (size_t i = 0; i < nodes.size(); ++i) {
+            auto& node = *nodes[i];
+            // Shadow inheritance and independent browsing contexts retain their
+            // existing full-cascade handling.
+            if (document.shadow_dom(node) != nullptr) return false;
+            for (auto* child : node.children) {
+                if (child != nullptr && !inactive_css_cascades.contains(child))
+                    nodes.push_back(child);
+            }
+            bool affected = &node == &root;
+            for (const auto& [property, value] : node.authored_style().declarations) {
+                if (!references(value)) continue;
+                if (!is_dimension(property)) return false;
+                affected = true;
+            }
+            if (!affected && node.kind == dom_node_kind::element) {
+                affected = std::any_of(rules.begin(), rules.end(), [&](const auto* rule) {
+                    return rule->media_matches && css_rule_matches(node, *rule);
+                });
+            }
+            if (affected) consumers.push_back(&node);
+        }
+        // No partial updates before all conservative fallback checks succeed.
+        for (auto* node : consumers) apply_css_rules(*node);
+        return true;
+    }
+
     void apply_css_rules_subtree(dom_node& node)
     {
         apply_css_rules(node);
@@ -3984,7 +4066,8 @@
     void schedule_style_recascade(
         dom_node& root,
         bool subtree,
-        std::string_view reason)
+        std::string_view reason,
+        std::string custom_property = {})
     {
         if (!is_connected(root)) return;
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
@@ -3994,21 +4077,19 @@
         for (auto& pending : pending_style_recascades) {
             if (pending.root != &root || pending.cascade_root != cascade_root) continue;
             pending.subtree = pending.subtree || subtree;
+            if (pending.custom_property != custom_property) pending.custom_property.clear();
             if (pending.reason.empty() && !reason.empty()) pending.reason = reason;
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
             ++style_recascade_coalesced_requests;
 #endif
             return;
         }
-        if (std::any_of(
-                pending_style_recascades.begin(),
-                pending_style_recascades.end(),
-                [this, &root, cascade_root](const pending_style_recascade& pending) {
-                    return pending.subtree
-                        && pending.cascade_root == cascade_root
-                        && pending.root != nullptr
-                        && subtree_contains(*pending.root, &root);
-                })) {
+        for (auto& pending : pending_style_recascades) {
+            if (!pending.subtree || pending.cascade_root != cascade_root
+                || pending.root == nullptr || !subtree_contains(*pending.root, &root))
+                continue;
+            // An ancestor request now covers another mutation as well.
+            pending.custom_property.clear();
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
             ++style_recascade_coalesced_requests;
 #endif
@@ -4018,6 +4099,11 @@
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
             const auto pending_before = pending_style_recascades.size();
 #endif
+            if (std::any_of(pending_style_recascades.begin(), pending_style_recascades.end(),
+                    [this, &root, cascade_root](const auto& pending) {
+                        return pending.root != nullptr && pending.cascade_root == cascade_root
+                            && subtree_contains(root, pending.root);
+                    })) custom_property.clear();
             std::erase_if(
                 pending_style_recascades,
                 [this, &root, cascade_root](const pending_style_recascade& pending) {
@@ -4035,7 +4121,8 @@
                 &root,
                 cascade_root,
                 subtree,
-                std::string(reason)});
+                std::string(reason),
+                std::move(custom_property)});
     }
 
     void flush_pending_style_recascades()
@@ -4053,13 +4140,24 @@
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
                 ++style_recascade_flush_subtree_roots;
 #endif
-                recascade_connected_subtree_now(*recascade.root, recascade.reason);
+                if (recascade.custom_property.empty()
+                    || !recascade_dimension_custom_property(*recascade.root, recascade.custom_property))
+                    recascade_connected_subtree_now(*recascade.root, recascade.reason);
             } else {
 #if defined(WEBSCENE_NATIVE_ENGINE_CERTIFICATION)
                 ++style_recascade_flush_node_roots;
 #endif
                 recascade_connected_node(*recascade.root);
             }
+        }
+    }
+
+    void recascade_custom_property(dom_node& node, const std::string& name)
+    {
+        if (style_recascade_batch_depth != 0U) {
+            schedule_style_recascade(node, true, "style.custom-property", name);
+        } else if (!recascade_dimension_custom_property(node, name)) {
+            recascade_connected_subtree_now(node, "style.custom-property");
         }
     }
 

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_state.inc
@@ -362,6 +362,7 @@
         dom_node* cascade_root{nullptr};
         bool subtree{false};
         std::string reason;
+        std::string custom_property;
     };
     bool batch_style_recascades{true};
     bool batch_connected_resource_style_recascades{true};

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_style.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_style.inc
@@ -526,7 +526,7 @@
                 authored.important_declarations.erase(name);
             }
             sync_style_attribute(*node);
-            self->recascade_connected_subtree(*node);
+            self->recascade_custom_property(*node, name);
             self->notify_custom_element_attribute(
                 *node, "style", old_value, node->attributes.at("style"));
             return;
@@ -1315,7 +1315,7 @@
             authored.declarations.erase(name);
             authored.important_declarations.erase(name);
             sync_style_attribute(*node);
-            self->recascade_connected_subtree(*node);
+            self->recascade_custom_property(*node, name);
             self->notify_custom_element_attribute(
                 *node, "style", old_value, node->attributes.at("style"));
             return;

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_dimension_variables_tests.inc
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_dimension_variables_tests.inc
@@ -1,0 +1,68 @@
+void test_dimension_custom_property_recascade(webscene_engine* engine)
+{
+    resize(engine, 1280, 720, 1);
+    const auto result = evaluate(engine, R"JS(
+        (() => {
+          document.body.innerHTML = '<style id="sheet">:root{--size:200px;--color:#112233}.grid{display:grid;grid-template-columns:100px minmax(100px,1fr) var(--size)}.wide{width:var(--size)}.fixed{width:90px!important}.child{width:50%}</style><div class="grid"><div></div><div></div><div id="panel"><div class="child" id="child"></div></div></div><div id="box" class="wide"></div>';
+          const root=document.documentElement, panel=document.getElementById('panel');
+          const box=document.getElementById('box'), sheet=document.getElementById('sheet');
+          const width=e=>Math.round(e.getBoundingClientRect().width);
+          const check=(v,m)=>{if(!v)throw Error(m);};
+          root.style.setProperty('--size','300px');
+          check(width(panel)===300 && width(document.getElementById('child'))===150,'grid descendants');
+          check(width(box)===300,'direct width');
+          root.style.setProperty('--size','310px');
+          box.className='wide fixed';
+          check(width(box)===90 && width(panel)===310,'ancestor request absorbs descendant mutation');
+          for(let i=0;i<160;i++)root.style.setProperty('--size',(200+i)+'px');
+          check(width(panel)===359,'repeated variable writes');
+          box.className='wide fixed';
+          root.style.setProperty('--size','280px');
+          check(width(box)===90 && width(panel)===280,'pending class and priority');
+          root.style.removeProperty('--size');
+          check(width(panel)===200,'removal restores stylesheet value');
+          root.style.setProperty('--size','260px');
+          root.style.setProperty('--size','');
+          check(width(panel)===200,'empty setter restores stylesheet value');
+          sheet.textContent += '.alias{--alias:var(--size);width:var(--alias)}';
+          box.className='alias';
+          root.style.setProperty('--size','270px');
+          check(width(box)===270,'stylesheet alias fallback');
+          root.style.setProperty('--font','17px');
+          sheet.textContent += '.alias{font-size:var(--font)}';
+          box.innerHTML='<span id="text">text</span>';
+          root.style.setProperty('--font','23px');
+          check(getComputedStyle(document.getElementById('text')).fontSize==='23px','inherited property fallback');
+          sheet.textContent += '.alias{width:var(--missing,var(--size))}';
+          root.style.setProperty('--size','290px');
+          check(width(box)===290,'nested variable fallback');
+          root.style.setProperty('--size','invalid');
+          check(Number.isFinite(width(panel)),'invalid value remains safe');
+          root.style.setProperty('--size','240px');
+          check(width(panel)===240 && width(box)===240,'valid after invalid');
+          sheet.textContent += '[style*="310px"] .alias{width:77px!important}';
+          root.style.setProperty('--size','310px');
+          check(width(box)===77,'style attribute selector fallback');
+          root.style.removeProperty('--size');
+          root.style.removeProperty('--font');
+          document.body.innerHTML='<div id="ancestor"><div id="scope"><div id="leaf"></div></div></div>';
+          const ancestor=document.getElementById('ancestor'), local=document.getElementById('scope'), leaf=document.getElementById('leaf');
+          local.style.setProperty('--alias','var(--local-size)');
+          leaf.style.width='var(--alias)';
+          local.style.setProperty('--local-size','130px');
+          check(width(leaf)===130,'inherited inline alias');
+          local.style.setProperty('--local-size','160px');
+          check(width(leaf)===160,'inherited inline alias update');
+          leaf.style.width='var(--local-size)';
+          local.style.setProperty('--local-size','180px');
+          check(width(leaf)===180,'inline dimension');
+          const shadow=local.attachShadow({mode:'open'});
+          shadow.innerHTML='<style>.shadow{width:var(--local-size)}</style><div class="shadow" id="shadow"></div>';
+          local.style.setProperty('--local-size','210px');
+          check(width(shadow.querySelector('#shadow'))===210,'shadow fallback');
+          return true;
+        })()
+    )JS", "dimension-custom-property-recascade.js");
+    require(result == "true", "dimension custom property recascade failed: " + result);
+}
+

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_dimension_variables_tests.inc
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_dimension_variables_tests.inc
@@ -66,3 +66,43 @@ void test_dimension_custom_property_recascade(webscene_engine* engine)
     require(result == "true", "dimension custom property recascade failed: " + result);
 }
 
+
+void test_dimension_custom_property_inheritance(webscene_engine* engine)
+{
+    resize(engine, 1280, 720, 1);
+    const auto result = evaluate(engine, R"JS(
+        (() => {
+          const failures=[];
+          const root=document.documentElement;
+          for(const inline of [false,true])for(const fallback of [false,true])for(const levels of [1,3])for(const operation of ['set','remove','empty']){
+            root.style.removeProperty('--size');
+            if(operation!=='set')root.style.setProperty('--size','200px');
+            const declarations=fallback?'width:var(--missing,inherit);height:var(--missing,inherit)':'width:inherit;height:inherit';
+            let children='';
+            for(let i=0;i<levels;i++)children+='<div class="child" id="child'+i+'"'+(inline?' style="'+declarations+'"':'')+'>';
+            children+='</div>'.repeat(levels);
+            document.body.innerHTML='<style>:root{--size:100px}.parent{width:var(--size);height:var(--size)}'+(inline?'':'.child{'+declarations+'}')+'</style><div class="parent" id="parent">'+children+'</div>';
+            const nodes=[document.getElementById('parent'),...Array.from({length:levels},(_,i)=>document.getElementById('child'+i))];
+            const geometry=()=>nodes.map(n=>{const r=n.getBoundingClientRect();return [r.width,r.height]});
+            const initial=operation==='set'?100:200;
+            const before=geometry();
+            if(before.some(r=>r[0]!==initial||r[1]!==initial))failures.push({inline,fallback,levels,operation,phase:'before',before});
+            if(operation==='set')root.style.setProperty('--size','200px');
+            else if(operation==='remove')root.style.removeProperty('--size');
+            else root.style.setProperty('--size','');
+            const expected=operation==='set'?200:100;
+            const after=geometry();
+            if(after.some(r=>r[0]!==expected||r[1]!==expected))failures.push({inline,fallback,levels,operation,phase:'after',after});
+          }
+          root.style.removeProperty('--size');
+          document.body.innerHTML='<style>:root{--size:100px}.parent{width:var(--size);height:var(--size)}.child{width:77px!important}</style><div class="parent"><div class="child" id="priority" style="width:inherit;height:inherit"></div></div>';
+          document.getElementById('priority').getBoundingClientRect();
+          root.style.setProperty('--size','200px');
+          const priority=document.getElementById('priority').getBoundingClientRect();
+          if(priority.width!==77||priority.height!==200)failures.push({phase:'inline-priority',width:priority.width,height:priority.height});
+          root.style.removeProperty('--size');
+          return failures;
+        })()
+    )JS", "dimension-custom-property-inheritance.js");
+    require(result == "[]", "dimension inheritance regression: " + result);
+}

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_tests.cpp
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_tests.cpp
@@ -79,6 +79,7 @@ uint8_t measure_baseline_fixture_text(
 #include "native_v8_runtime_diagnostics_tests.inc"
 #include "native_resource_failure_diagnostics_tests.inc"
 #include "native_v8_runtime_css_layout_tests.inc"
+#include "native_v8_runtime_dimension_variables_tests.inc"
 #include "native_go_to_overflow_tests.inc"
 #include "native_v8_runtime_media_query_tests.inc"
 #include "native_v8_runtime_animation_cssom_tests.inc"
@@ -306,6 +307,36 @@ int main()
             auto* focused_engine = webscene_engine_create(0);
             require(focused_engine != nullptr, "focused engine creation failed");
             test_window_post_message_coalesces_style_recascade(focused_engine);
+            webscene_engine_destroy(focused_engine);
+            return 0;
+        }
+        if (selected == "dimension-variable-compatibility") {
+            const std::array tests{
+                test_dimension_custom_property_recascade,
+                test_responsive_positioned_sizing,
+                test_attribute_selector_invalidation,
+                test_shadow_dom_composed_runtime_geometry,
+                test_inline_relative_line_height_uses_cascaded_font_size,
+                test_font_relative_box_lengths_follow_inherited_font_context,
+                test_important_custom_property_cascade_reaches_paint,
+                test_detached_style_retains_text_and_activates_when_connected,
+                test_flex_gap_and_variable_text_metrics,
+                test_calc_percent_with_pixel_offset,
+                test_window_post_message_coalesces_style_recascade
+            };
+            for (const auto test : tests) {
+                auto* engine = webscene_engine_create(0);
+                require(engine != nullptr, "compatibility engine creation failed");
+                test(engine);
+                webscene_engine_destroy(engine);
+            }
+            test_outer_dynamic_recascade_preserves_iframe_cascade();
+            return 0;
+        }
+        if (selected == "dimension-variables") {
+            auto* focused_engine = webscene_engine_create(0);
+            require(focused_engine != nullptr, "focused engine creation failed");
+            test_dimension_custom_property_recascade(focused_engine);
             webscene_engine_destroy(focused_engine);
             return 0;
         }
@@ -563,6 +594,7 @@ int main()
         "typeof IntersectionObserverEntry !== 'function') "
         "throw new Error('IntersectionObserver bootstrap missing')",
         "intersection-observer-bootstrap.js");
+    test_dimension_custom_property_recascade(engine);
     test_responsive_positioned_sizing(engine);
     test_compact_go_to_fixed_grid_tracks_preserve_trailing_space(engine);
     test_go_to_tab_lines_and_calendar_scroll_ranges(engine);

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_tests.cpp
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_tests.cpp
@@ -313,6 +313,8 @@ int main()
         if (selected == "dimension-variable-compatibility") {
             const std::array tests{
                 test_dimension_custom_property_recascade,
+                test_dimension_custom_property_inheritance,
+                test_tradingview_settings_subgrid_keeps_controls_on_their_rows,
                 test_responsive_positioned_sizing,
                 test_attribute_selector_invalidation,
                 test_shadow_dom_composed_runtime_geometry,
@@ -331,6 +333,13 @@ int main()
                 webscene_engine_destroy(engine);
             }
             test_outer_dynamic_recascade_preserves_iframe_cascade();
+            return 0;
+        }
+        if (selected == "dimension-inheritance") {
+            auto* engine = webscene_engine_create(0);
+            require(engine != nullptr, "inheritance engine creation failed");
+            test_dimension_custom_property_inheritance(engine);
+            webscene_engine_destroy(engine);
             return 0;
         }
         if (selected == "dimension-variables") {
@@ -595,6 +604,7 @@ int main()
         "throw new Error('IntersectionObserver bootstrap missing')",
         "intersection-observer-bootstrap.js");
     test_dimension_custom_property_recascade(engine);
+    test_dimension_custom_property_inheritance(engine);
     test_responsive_positioned_sizing(engine);
     test_compact_go_to_fixed_grid_tracks_preserve_trailing_space(engine);
     test_go_to_tab_lines_and_calendar_scroll_ranges(engine);


### PR DESCRIPTION
Dragging Kestrel’s properties divider updates the root `--right-width` variable, but currently rebuilds styles throughout the root subtree. Limit recalculation to the mutation root and dimension consumers when dependencies are safe. Preserve style batching and synchronous CSSOM barriers; mixed mutations, aliases, inherited properties, pseudo-elements, shadow DOM, and style-attribute dependencies retain the full path.

Explicit dimension inheritance also retains ancestor-first subtree recalculation, including `var()` fallbacks resolving to `inherit`. Replay inline width/height inheritance during a full cascade so descendants follow their parent while preserving stylesheet priority.

The full-subtree setter exists on main and dates to commit 869f1a0 (July 20), predating the recent Windows work. This identifies a longstanding invalidation bottleneck; it does not claim a complete historical frame-rate bisect.

After the review correction, three alternating Windows runs of the included 1,000-item DOM benchmark measured 29.92 ms baseline versus 3.17 ms fixed median synchronous resize time (about 89% less). This measures style/layout, not full Kestrel FPS or physical presentation.

Validation:
- Reproduced the review regression before fixing it.
- Added 24 inheritance combinations covering stylesheet/inline declarations, literal/var-fallback inheritance, one/three descendant levels, and setProperty/removeProperty/empty setter, plus an inline-priority case.
- All 14 focused compatibility checks and all three parser suites pass on the corrected patch. The baseline control independently confirms an older literal-inline inheritance issue fixed here as well.
- The full native suite fails on unchanged main and the patch at the existing `iframe preparation did not overlap discovery with outer script work` assertion; that unrelated test remains unchanged.

Commands, history, and raw results are in `docs/validation/css-variable-resize.md`. This PR is based directly on main and includes no Windows WebGPU, pacing, font-cache, or Kestrel fixture changes.