### PR TITLE
Optimize CSS variables used by positional offsets

### DIFF
--- a/benchmarks/css-variable-resize.py
+++ b/benchmarks/css-variable-resize.py
@@ -2,7 +2,7 @@
 
 Usage: python benchmarks/css-variable-resize.py /absolute/path/to/native/library
 The library directory must contain its matching ICU data and bootstrap snapshot.
-Each sample changes a grid track and reads its resulting width. Setup and 20
+Each sample changes a grid track and a fixed toast offset, then verifies both. Setup and 20
 warm-up updates are excluded; the remaining 60 samples include style and layout.
 """
 import argparse
@@ -13,7 +13,7 @@ import statistics
 import time
 
 SOURCE = r"""
-document.body.innerHTML='<style>:root{--size:252px;--color:#123456}.shell{display:grid;grid-template-columns:200px minmax(250px,1fr) var(--size)}.item{color:var(--color);font-size:12px;padding:2px;border:1px solid #333}.item:nth-child(2n){background:#eee}.item span{font-weight:bold}.right{width:100%}</style><div class="shell"><div id="left"></div><div id="center"></div><div class="right" id="right"></div></div>';
+document.body.innerHTML='<style>:root{--size:252px;--color:#123456}.shell{display:grid;grid-template-columns:200px minmax(250px,1fr) var(--size)}.item{color:var(--color);font-size:12px;padding:2px;border:1px solid #333}.item:nth-child(2n){background:#eee}.item span{font-weight:bold}.right{width:100%}.toast{position:fixed;right:calc(var(--size) + 16px);width:20px;height:20px}</style><div class="shell"><div id="left"></div><div id="center"></div><div class="right" id="right"></div></div><div class="toast" id="toast"></div>';
 document.getElementById('center').innerHTML=Array.from({length:1000},(_,i)=>'<div class="item"><span>Item '+i+'</span></div>').join('');
 const root=document.documentElement, right=document.getElementById('right');
 const samples=[];
@@ -22,6 +22,8 @@ for(let i=0;i<80;i++){
   root.style.setProperty('--size',(252+i%60)+'px');
   const width=right.offsetWidth;
   if(width!==252+i%60)throw Error('Incorrect width '+width);
+  const inset=innerWidth-document.getElementById('toast').getBoundingClientRect().right;
+  if(Math.abs(inset-(252+i%60+16))>.1)throw Error('Incorrect toast inset '+inset);
   if(i>=20)samples.push(performance.now()-start);
 }
 console.log('RESIZE_BENCHMARK:'+JSON.stringify(samples));

--- a/docs/validation/css-positional-variables.md
+++ b/docs/validation/css-positional-variables.md
@@ -1,0 +1,27 @@
+# Positional CSS variable optimization
+
+Kestrel uses --right-width both for grid-template-columns and for the toast stack's
+right: calc(var(--right-width) + 16px). The dimension-only fast path introduced in
+PR #51 therefore fell back to a full subtree recalculation on right-divider drags.
+
+Accept physical left/right/top/bottom offsets in the same conservative geometry
+property set. Apply the existing inheritance, alias, shadow-DOM and selector
+fallbacks to these properties too. No Kestrel or graphics backend changes are
+included.
+
+The new native test combines a grid track with all four calc-based offsets and
+checks setProperty, removeProperty and the empty setter. The benchmark now also
+checks the fixed toast offset on every update, covering the dependency missed by
+the earlier dimension-only benchmark.
+
+Validation was performed with this implementation integrated into the Windows
+Kestrel worktree, before extracting this main-based draft:
+- Native build and all 15 focused compatibility checks passed, including the
+  previous explicit-inheritance regressions.
+- Three alternating expanded benchmark runs measured median-of-medians 22.69 ms
+  before versus 3.49 ms after (approximately 85% less synchronous style/layout time).
+- The attempted live drag verification was invalid because the display changed
+  to an 822px CSS viewport, hiding the properties sidebar; vsync was unavailable.
+  No post-fix application FPS or physical-presentation claim is made.
+
+This extracted main-based branch has not yet had a separate native build.

--- a/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_cascade.inc
+++ b/experiments/WebScene.NativeEngine.Probe/native/webscene_v8_runtime_css_cascade.inc
@@ -3884,11 +3884,13 @@
             if (rule.selector().find(static_cast<char>(92)) != std::string::npos
                 || copy_ascii_lower(rule.selector()).find("style") != std::string::npos) return false;
         }
-        const auto is_dimension = [](std::string_view property) {
+        const auto is_geometry_property = [](std::string_view property) {
             return property == "width" || property == "height"
                 || property == "min-width" || property == "max-width"
                 || property == "min-height" || property == "max-height"
-                || property == "grid-template-columns" || property == "grid-template-rows";
+                || property == "grid-template-columns" || property == "grid-template-rows"
+                || property == "left" || property == "right"
+                || property == "top" || property == "bottom";
         };
         // Non-inherited-by-default dimensions can still explicitly inherit.
         // Include variable-resolved inheritance, not just literal tokens. If
@@ -3897,7 +3899,7 @@
         for (const auto& rule : css_rules) {
             bool potential = false;
             for (const auto& declaration : rule.declarations()) {
-                if (!is_dimension(declaration.name)) continue;
+                if (!is_geometry_property(declaration.name)) continue;
                 if (trim_css_view(declaration.value) == "inherit") return false;
                 potential = potential || declaration.value.find("var(") != std::string::npos;
             }
@@ -3913,7 +3915,7 @@
         // An inherited inline alias may be authored above the mutation root.
         for (auto* parent = root.parent; parent != nullptr; parent = parent->parent) {
             for (const auto& [property, value] : parent->authored_style().declarations) {
-                if (references(value) && !is_dimension(property)) return false;
+                if (references(value) && !is_geometry_property(property)) return false;
             }
         }
         std::vector<const css_rule*> rules;
@@ -3926,7 +3928,7 @@
                     || split_pseudo_element_selector(rule.selector(), origin) != 0)
                     return false;
                 for (const auto& declaration : rule.declarations()) {
-                    if (references(declaration.value) && !is_dimension(declaration.name))
+                    if (references(declaration.value) && !is_geometry_property(declaration.name))
                         return false;
                 }
                 rules.push_back(&rule);
@@ -3945,17 +3947,17 @@
             }
             bool affected = &node == &root;
             for (const auto& [property, value] : node.authored_style().declarations) {
-                if (is_dimension(property)
+                if (is_geometry_property(property)
                     && trim_css_view(resolve_css_value(node, value)) == "inherit") return false;
                 if (!references(value)) continue;
-                if (!is_dimension(property)) return false;
+                if (!is_geometry_property(property)) return false;
                 affected = true;
             }
             if (node.kind == dom_node_kind::element) {
                 for (const auto* rule : inheritance_rules) {
                     if (!rule->media_matches || !css_rule_matches(node, *rule)) continue;
                     for (const auto& declaration : rule->declarations()) {
-                        if (is_dimension(declaration.name)
+                        if (is_geometry_property(declaration.name)
                             && trim_css_view(resolve_css_value(node, declaration.value)) == "inherit")
                             return false;
                     }

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_dimension_variables_tests.inc
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_dimension_variables_tests.inc
@@ -106,3 +106,29 @@ void test_dimension_custom_property_inheritance(webscene_engine* engine)
     )JS", "dimension-custom-property-inheritance.js");
     require(result == "[]", "dimension inheritance regression: " + result);
 }
+
+void test_geometry_variable_positions(webscene_engine* engine)
+{
+    resize(engine, 1280, 720, 1);
+    const auto result = evaluate(engine, R"JS(
+        (() => {
+          const root=document.documentElement;
+          root.style.removeProperty('--geometry-size');
+          document.body.innerHTML='<style>:root{--geometry-size:100px}#stage{position:relative;width:800px;height:600px}#grid{display:grid;grid-template-columns:100px 1fr var(--geometry-size)}.position{position:absolute;width:20px;height:20px}#left{left:calc(var(--geometry-size) + 16px);top:0}#right{right:calc(var(--geometry-size) + 16px);top:0}#top{top:calc(var(--geometry-size) + 16px);left:0}#bottom{bottom:calc(var(--geometry-size) + 16px);left:0}</style><div id="stage"><div id="grid"><div></div><div></div><div id="panel"></div></div><div class="position" id="left"></div><div class="position" id="right"></div><div class="position" id="top"></div><div class="position" id="bottom"></div></div>';
+          const rect=id=>document.getElementById(id).getBoundingClientRect();
+          const check=size=>{
+            const stage=rect('stage');
+            const actual=[rect('panel').width,rect('left').x-stage.x,stage.right-rect('right').right,rect('top').y-stage.y,stage.bottom-rect('bottom').bottom];
+            const expected=[size,size+16,size+16,size+16,size+16];
+            if(actual.some((v,i)=>Math.abs(v-expected[i])>.1))throw Error(JSON.stringify({size,actual,expected}));
+          };
+          check(100);
+          root.style.setProperty('--geometry-size','200px');check(200);
+          root.style.removeProperty('--geometry-size');check(100);
+          root.style.setProperty('--geometry-size','300px');check(300);
+          root.style.setProperty('--geometry-size','');check(100);
+          return true;
+        })()
+    )JS", "geometry-variable-positions.js");
+    require(result == "true", "geometry variable positions failed: " + result);
+}

--- a/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_tests.cpp
+++ b/experiments/WebScene.NativeEngine.Probe/tests/native_v8_runtime_tests.cpp
@@ -314,6 +314,7 @@ int main()
             const std::array tests{
                 test_dimension_custom_property_recascade,
                 test_dimension_custom_property_inheritance,
+                test_geometry_variable_positions,
                 test_tradingview_settings_subgrid_keeps_controls_on_their_rows,
                 test_responsive_positioned_sizing,
                 test_attribute_selector_invalidation,
@@ -607,6 +608,7 @@ int main()
         "intersection-observer-bootstrap.js");
     test_dimension_custom_property_recascade(engine);
     test_dimension_custom_property_inheritance(engine);
+    test_geometry_variable_positions(engine);
     test_responsive_positioned_sizing(engine);
     test_compact_go_to_fixed_grid_tracks_preserve_trailing_space(engine);
     test_go_to_tab_lines_and_calendar_scroll_ranges(engine);


### PR DESCRIPTION
Kestrel’s right-divider variable also controls `#toast-stack { right: calc(var(--right-width) + 16px) }`. That extra positional consumer makes the dimension-only optimization from #51 fall back to a full subtree recalculation, while the left divider uses the fast path.

Include physical left/right/top/bottom offsets in the safe geometry-property set, retaining the existing inheritance and other conservative fallbacks. Add a grid-plus-offset regression test covering all four offsets and setProperty/removeProperty/empty setter. Expand the benchmark to verify the toast offset as well as the grid width.

Validation in the Windows integration worktree: native build and all 15 focused compatibility checks passed; the expanded benchmark improved from 22.69 ms to 3.49 ms median-of-medians across three alternating pairs. These are synchronous style/layout measurements. Live post-fix FPS remains unverified because the display changed and hid the right sidebar. This extracted main-based branch has not yet had a separate native build.

Five files, based on current main, with no Windows GPU, pacing, or Kestrel fixture changes. Details: `docs/validation/css-positional-variables.md`.